### PR TITLE
fix: log provider names instead of secret paths (CodeQL alert)

### DIFF
--- a/lambda/api/keyword-research.py
+++ b/lambda/api/keyword-research.py
@@ -55,6 +55,7 @@ def get_secret(secret_name: str) -> Optional[str]:
     """Retrieve secret from Secrets Manager with caching."""
     current_time = time.time()
     full_name = f"{SECRETS_PREFIX}{secret_name}"
+    provider_label = secret_name.replace('-key', '').title()
     
     # Check cache
     if full_name in _secrets_cache:
@@ -75,7 +76,7 @@ def get_secret(secret_name: str) -> Optional[str]:
         _secrets_cache_time[full_name] = current_time
         return api_key
     except Exception as e:
-        logger.warning(f"Secret {secret_name} not found: {e}")
+        logger.warning(f"No secret found for {provider_label}: {e}")
         return None
 
 

--- a/lambda/api/manage-providers.py
+++ b/lambda/api/manage-providers.py
@@ -134,7 +134,7 @@ def get_secret_status(secret_name: str) -> dict:
     except ClientError as e:
         if e.response['Error']['Code'] == 'ResourceNotFoundException':
             return {'exists': False, 'has_value': False, 'masked_key': None}
-        logger.error(f"Error checking secret {secret_name}: {str(e)}")
+        logger.error(f"Error checking provider status: {str(e)}")
         return {'exists': False, 'has_value': False}
 
 

--- a/lambda/search/handler.py
+++ b/lambda/search/handler.py
@@ -144,6 +144,8 @@ def store_raw_response_to_s3(
 def get_secret(secret_name: str) -> Optional[str]:
     """Retrieve a secret from AWS Secrets Manager with TTL-based caching."""
     current_time = time.time()
+    # Derive provider label from secret path (e.g. "citation-analysis/openai-key" -> "OpenAI")
+    provider_label = secret_name.rsplit('/', 1)[-1].replace('-key', '').title()
     
     # Check if cached and not expired
     if secret_name in _secrets_cache:
@@ -151,8 +153,7 @@ def get_secret(secret_name: str) -> Optional[str]:
         if current_time - cache_time < SECRETS_CACHE_TTL:
             return _secrets_cache[secret_name]
         else:
-            # Cache expired, remove stale entries
-            logger.info(f"Secret cache expired for {secret_name}, refreshing")
+            logger.info(f"Cache expired for {provider_label}, refreshing")
             del _secrets_cache[secret_name]
             del _secrets_cache_time[secret_name]
     
@@ -166,7 +167,7 @@ def get_secret(secret_name: str) -> Optional[str]:
                 _secrets_cache_time[secret_name] = current_time
                 return api_key
     except Exception as e:
-        logger.error(f"Error retrieving secret {secret_name}: {str(e)}")
+        logger.error(f"No secret found for {provider_label}: {str(e)}")
     
     return None
 


### PR DESCRIPTION
Replace secret_name with derived provider label in log messages. e.g. 'No secret found for OpenAI' instead of logging the Secrets Manager path.

## Description

Please include a summary of the change and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Deployed to AWS account and verified functionality
- [ ] Tested with sample keywords
- [ ] Verified dashboard displays correctly
- [ ] Checked CloudWatch logs for errors

**Test Configuration**:
* AWS Region:
* CDK Version:
* Node.js Version:
* Python Version:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
