### PR TITLE
fix: explicitly pass query_prompts to search Lambda in Step Functions

### DIFF
--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -796,6 +796,7 @@ export class CitationAnalysisStack extends cdk.Stack {
       payload: stepfunctions.TaskInput.fromObject({
         'keyword.$': '$.keyword',
         'timestamp.$': '$.timestamp',
+        'query_prompts.$': '$.query_prompts',
       }),
       outputPath: '$.Payload',
       retryOnServiceExceptions: true,


### PR DESCRIPTION
The SearchAllProviders task payload only passed keyword and timestamp, omitting query_prompts. This caused the search Lambda to fall back to the default template instead of using configured persona prompts.

## Description

Please include a summary of the change and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Deployed to AWS account and verified functionality
- [ ] Tested with sample keywords
- [ ] Verified dashboard displays correctly
- [ ] Checked CloudWatch logs for errors

**Test Configuration**:
* AWS Region:
* CDK Version:
* Node.js Version:
* Python Version:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
