### PR TITLE
fix: pass keyword to crawler in Step Functions Map, fix env var misma…

### DIFF
--- a/lambda/crawler/handler.py
+++ b/lambda/crawler/handler.py
@@ -691,6 +691,12 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     citation = event.get('citation', {})
     url = citation.get('normalized_url')
     
+    # keyword is passed at the top level by the Map itemSelector,
+    # not inside the citation object from deduplication
+    keyword_override = event.get('keyword', '')
+    if keyword_override:
+        citation['keyword'] = keyword_override
+    
     if not url:
         error = ValueError("Missing required parameter: normalized_url")
         log_error(error, "crawler handler", event)

--- a/lambda/shared/config.py
+++ b/lambda/shared/config.py
@@ -71,8 +71,8 @@ class LambdaConfig:
     # AWS Configuration
     region: str = os.environ.get("AWS_REGION", "us-west-2")
     
-    # LLM Model for summarization
-    llm_model_id: str = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    # LLM Model for summarization (configurable via environment variable)
+    llm_model_id: str = os.environ.get('BEDROCK_MODEL_ID', 'global.anthropic.claude-sonnet-4-5-20250929-v1:0')
     
     # Get AWS Account ID automatically
     @property
@@ -100,7 +100,7 @@ class LambdaConfig:
     
     @property
     def crawled_content_table(self) -> str:
-        return os.environ.get('CRAWLED_CONTENT_TABLE', 'CitationAnalysis-CrawledContent')
+        return os.environ.get('DYNAMODB_TABLE_CRAWLED_CONTENT', 'CitationAnalysis-CrawledContent')
     
     # Secrets Manager prefix
     secrets_prefix: str = "citation-analysis/"

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -540,9 +540,6 @@ export class CitationAnalysisStack extends cdk.Stack {
     // Grant Crawler Lambda write access to Screenshots bucket
     screenshotsBucket.grantWrite(crawlerLambdaRole);
 
-    // Grant Crawler Lambda read access to Nova Act secret (for intelligent verification handling)
-    novaActSecret.grantRead(crawlerLambdaRole);
-
     // IAM Role for Step Functions State Machine
     // Permissions: Invoke all Lambda functions
     const stepFunctionsRole = new iam.Role(this, 'StepFunctionsRole', {
@@ -747,11 +744,8 @@ export class CitationAnalysisStack extends cdk.Stack {
       environment: {
         DYNAMODB_TABLE_CRAWLED_CONTENT: crawledContentTable.tableName,
         BEDROCK_MODEL_ID: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
-        BROWSER_TIMEOUT_MS: '30000',
         SCREENSHOTS_BUCKET: screenshotsBucket.bucketName,
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1', // Use AgentCore managed browsers
         BROWSER_ID: crawlerBrowser.attrBrowserId, // Pre-created browser with Web Bot Auth
-        NOVA_ACT_SECRET_NAME: 'citation-analysis/nova-act-key', // Nova Act for verification handling
       },
     });
 
@@ -847,7 +841,10 @@ export class CitationAnalysisStack extends cdk.Stack {
       maxConcurrency: 3,
       itemsPath: '$.deduplicated_citations',
       resultPath: '$.crawled_results',
-      itemSelector: {'citation.$': '$$.Map.Item.Value',},
+      itemSelector: {
+        'citation.$': '$$.Map.Item.Value',
+        'keyword.$': '$.keyword',
+      },
     }).itemProcessor(crawlTask);
 
     // 6. Chain Search -> Deduplication -> Crawl


### PR DESCRIPTION
…tches

- CrawlCitations Map itemSelector now passes keyword from parent scope so crawled content is stored with the correct keyword (was empty before)
- LambdaConfig.crawled_content_table reads DYNAMODB_TABLE_CRAWLED_CONTENT to match the env var name CDK actually sets
- LambdaConfig.llm_model_id reads BEDROCK_MODEL_ID from env so the CDK-configured Haiku 4.5 model is used instead of hardcoded Sonnet 4.5
- Remove dead env vars from crawler: NOVA_ACT_SECRET_NAME, BROWSER_TIMEOUT_MS, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
- Remove unused novaActSecret.grantRead on crawler role

## Description

Please include a summary of the change and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Deployed to AWS account and verified functionality
- [ ] Tested with sample keywords
- [ ] Verified dashboard displays correctly
- [ ] Checked CloudWatch logs for errors

**Test Configuration**:
* AWS Region:
* CDK Version:
* Node.js Version:
* Python Version:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
