### PR TITLE
Change Gemini model 'gemini-2.0-flash' to 'gemini-2.5-flash'

### DIFF
--- a/lambda/api/keyword-research.py
+++ b/lambda/api/keyword-research.py
@@ -152,7 +152,7 @@ class GeminiClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.base_url = "https://generativelanguage.googleapis.com/v1beta"
-        self.model = "gemini-2.0-flash"
+        self.model = "gemini-2.5-flash"
     
     def search(self, query: str) -> Dict[str, Any]:
         """Execute search with Google Search grounding."""

--- a/lambda/api/manage-providers.py
+++ b/lambda/api/manage-providers.py
@@ -59,7 +59,7 @@ PROVIDERS = {
         'description': 'Gemini Flash with Google Search grounding',
         'secret_name': f'{SECRETS_PREFIX}gemini-key',
         'docs_url': 'https://aistudio.google.com/apikey',
-        'model': 'gemini-2.0-flash',
+        'model': 'gemini-2.5-flash',
         'type': PROVIDER_TYPE_LLM
     },
     'claude': {

--- a/lambda/search/api_clients.py
+++ b/lambda/search/api_clients.py
@@ -171,8 +171,8 @@ class GeminiClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.base_url = "https://generativelanguage.googleapis.com/v1beta"
-        # Use gemini-2.0-flash for reliable grounding with citations
-        self.model = "gemini-2.0-flash"
+        # Use gemini-2.5-flash for reliable grounding with citations
+        self.model = "gemini-2.5-flash"
     
     @retry_with_backoff(provider_name="GEMINI", timeout=60)
     def _make_request(self, payload: Dict, timeout: int = 60) -> requests.Response:

--- a/lambda/search/handler.py
+++ b/lambda/search/handler.py
@@ -190,7 +190,7 @@ def is_provider_enabled(provider_id: str) -> bool:
 DEFAULT_PROVIDER_MODELS = {
     Provider.OPENAI: 'gpt-5-mini',
     Provider.PERPLEXITY: 'sonar',
-    Provider.GEMINI: 'gemini-2.0-flash',
+    Provider.GEMINI: 'gemini-2.5-flash',
     Provider.CLAUDE: 'claude-sonnet-4-5',
 }
 
@@ -429,7 +429,7 @@ def query_gemini(keyword: str, api_key: str, query_template: Optional[str] = Non
             "status": "success",
             "raw_response": raw_response,
             "metadata": {
-                "model": "gemini-2.0-flash",
+                "model": "gemini-2.5-flash",
                 "latency_ms": latency_ms,
                 "usage": raw_response.get('usageMetadata', {})
             }
@@ -443,7 +443,7 @@ def query_gemini(keyword: str, api_key: str, query_template: Optional[str] = Non
             "status": "error",
             "error": str(e),
             "raw_response": None,
-            "metadata": {"model": "gemini-2.0-flash", "latency_ms": int((time.time() - start_time) * 1000)}
+            "metadata": {"model": "gemini-2.5-flash", "latency_ms": int((time.time() - start_time) * 1000)}
         }
 
 

--- a/lambda/search/test_handler_prompts.py
+++ b/lambda/search/test_handler_prompts.py
@@ -109,7 +109,7 @@ class TestGetProviderModel:
             handler._provider_model_cache.clear()
             assert handler.get_provider_model('perplexity') == 'sonar'
             handler._provider_model_cache.clear()
-            assert handler.get_provider_model('gemini') == 'gemini-2.0-flash'
+            assert handler.get_provider_model('gemini') == 'gemini-2.5-flash'
 
 
 class TestQueryOpenAIModel:

--- a/web/src/hooks/useProviderConfig.ts
+++ b/web/src/hooks/useProviderConfig.ts
@@ -101,7 +101,7 @@ function createDefaultProviders(): ProviderConfig[] {
       id: PROVIDER.GEMINI,
       name: PROVIDER_NAMES[PROVIDER.GEMINI],
       description: PROVIDER_DESCRIPTIONS[PROVIDER.GEMINI],
-      model: 'gemini-2.0-flash',
+      model: 'gemini-2.5-flash',
       docs_url: PROVIDER_DOCS_URLS[PROVIDER.GEMINI],
       enabled: true,
       configured: false,


### PR DESCRIPTION
## Description

Gemini model 2.0 is deprecated, so I've changed all references to Gemini 2.5

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ X] Deployed to AWS account and verified functionality
- [X ] Tested with sample keywords
- [ X] Verified dashboard displays correctly
- [ ] Checked CloudWatch logs for errors

**Test Configuration**:
* AWS Region: eu-west-3
* CDK Version: 
* Node.js Version:
* Python Version:

## Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [X ] I have checked my code and corrected any misspellings
