### PR TITLE
feat: per-persona brand ranking and LLM self-reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Go to **Settings > Query Prompts**. Define persona-based search templates that s
 - Create multiple personas to see how different traveler types get different AI recommendations
 - Enable/disable individual prompts to control which run during analysis
 - Each analysis run executes all enabled prompts × all keywords × all providers
+- After analysis, use the persona filter on the Visibility and Brand Mentions pages to compare how your brand ranks under each persona
 
 ### Step 5: Run Analysis
 
@@ -243,8 +244,8 @@ After analysis completes, explore your data:
 
 **Insights Section:**
 - **Dashboard** – Overview stats: total searches, citations, pages crawled
-- **Visibility** – Your visibility score vs competitors, with 30-day trends. Shows share of voice by provider.
-- **Brand Mentions** – Every mention of your brand and competitors with sentiment (positive/negative/neutral) and ranking context
+- **Visibility** – Your visibility score vs competitors, with 30-day trends. Shows share of voice by provider. Filter by persona to see how rankings change for different audience segments. The persona comparison chart plots your brand's average rank across personas side by side with competitors.
+- **Brand Mentions** – Every mention of your brand and competitors with sentiment (positive/negative/neutral) and ranking context. Filter by persona to see which brands appear under each audience segment.
 - **Citations** – All URLs cited by AI models, ranked by frequency. Click any URL to see breakdown by keyword and provider.
 - **Prompt Insights** – How AI models frame their responses to your keywords
 - **Citation Gaps** – Sources that cite competitors but not you. This is your PR/content target list.
@@ -254,7 +255,8 @@ After analysis completes, explore your data:
 - **Keyword Research** – Expand your keyword list using AI with live web search. Analyze competitor websites to discover keywords they target. Both operations run asynchronously — results appear after 30-60 seconds.
 
 **Content Section:**
-- **Content Studio** – Generate content briefs and outlines based on citation gap analysis, with output language selection (English, Spanish, French, or any language). Helps you create content that AI models are more likely to cite.
+- **Content Studio** – Generate content briefs and outlines based on citation gap analysis, with output language selection (English, Spanish, French, or any language). Helps you create content that AI models are more likely to cite. Self-reflection recommendations from the ranking analysis also appear here as actionable content ideas, labelled with the originating persona.
+- **Ranking Analysis (Self-Reflection)** – For any brand and persona combination, ask the AI to explain why it ranked the brand where it did. Returns a structured breakdown: what the brand's content contributed, what competitors showed, what data points were missing, and prioritised content recommendations to improve ranking. Results are cached for 24 hours. This is industry-agnostic and works with whatever industry you have configured.
 
 **Data Section:**
 - **Recent Searches** – Your analysis history with full AI responses
@@ -270,7 +272,7 @@ The default OpenAI model is `gpt-5-mini` (cost-effective, supports web search). 
 2. The model can be overridden per provider via the ProviderConfig DynamoDB table
 3. Set the `model` field for any provider to change the default (e.g., `gpt-5.2` for higher quality)
 
-Content generation (Content Studio) uses Amazon Bedrock Claude Haiku 4.5 — this runs on your AWS account and doesn't require an external API key.
+Content generation (Content Studio) and ranking self-reflection both use Amazon Bedrock Claude Haiku 4.5. This runs on your AWS account and does not require an external API key. Self-reflection results are cached in a dedicated DynamoDB table with a 24-hour TTL to avoid repeated LLM calls for the same keyword, brand, and persona combination.
 
 ### Retry Logic
 - All API clients implement exponential backoff (5 retries, ~35s max wait)

--- a/lambda/api/content-studio.py
+++ b/lambda/api/content-studio.py
@@ -20,7 +20,7 @@ import logging
 from boto3.dynamodb.conditions import Key
 from typing import Dict, Any, List
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
 # Add shared module to path
@@ -429,7 +429,37 @@ def generate_content_ideas(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     # Add seasonal/trending content ideas based on keywords
     seasonal_keywords = _get_seasonal_suggestions(list(keyword_data.keys()), config)
     ideas.extend(seasonal_keywords)
-    
+
+    # Add self-reflection recommendations as content ideas
+    try:
+        self_reflection_table_name = os.environ.get('DYNAMODB_TABLE_SELF_REFLECTION')
+        if self_reflection_table_name:
+            sr_table = dynamodb.Table(self_reflection_table_name)
+            seven_days_ago = (datetime.utcnow() - timedelta(days=7)).isoformat() + 'Z'
+            sr_response = sr_table.scan(
+                FilterExpression='created_at >= :since',
+                ExpressionAttributeValues={':since': seven_days_ago},
+                Limit=100
+            )
+            for sr_item in sr_response.get('Items', []):
+                for rec in sr_item.get('recommendations', []):
+                    ideas.append({
+                        'id': str(uuid.uuid4()),
+                        'type': 'self_reflection',
+                        'priority': rec.get('priority', 'medium'),
+                        'title': rec.get('title', 'Self-Reflection Recommendation'),
+                        'description': rec.get('description', ''),
+                        'keyword': sr_item.get('keyword', ''),
+                        'source': 'self_reflection',
+                        'persona_name': sr_item.get('query_prompt_name', ''),
+                        'persona_id': sr_item.get('query_prompt_id', ''),
+                        'gap_reference': rec.get('gap_reference', ''),
+                        'content_angle': rec.get('content_type', 'comprehensive_guide'),
+                        'actionable': True,
+                    })
+    except Exception as e:
+        logger.warning(f"Failed to fetch self-reflection recommendations: {e}")
+
     priority_order = {'high': 0, 'medium': 1, 'low': 2}
     ideas.sort(key=lambda x: (priority_order.get(x.get('priority', 'low'), 2), x.get('keyword', '')))
     return ideas[:50]  # Increased from 30 to 50

--- a/lambda/api/get-brand-mentions.py
+++ b/lambda/api/get-brand-mentions.py
@@ -122,10 +122,11 @@ def aggregate_brand_mentions(results: List[Dict[str, Any]], config: Dict[str, An
     'keyword': require_keyword(),
     'timestamp': {'type': str, 'max_length': 50},
     'provider': optional_provider(),
-    'classification': {'type': str, 'choices': ['first_party', 'competitor', 'other']}
+    'classification': {'type': str, 'choices': ['first_party', 'competitor', 'other']},
+    'query_prompt_id': {'type': str, 'max_length': 100},
 })
 def handler(event: Dict[str, Any], context: Any, keyword: str, timestamp: str = None, 
-            provider: str = None, classification: str = None) -> Dict[str, Any]:
+            provider: str = None, classification: str = None, query_prompt_id: str = None) -> Dict[str, Any]:
     """
     API handler to get brand mentions for a keyword.
     
@@ -169,6 +170,10 @@ def handler(event: Dict[str, Any], context: Any, keyword: str, timestamp: str = 
     
     if not items:
         return not_found_response('Results for keyword', event)
+    
+    # Filter by persona if specified
+    if query_prompt_id:
+        items = [item for item in items if item.get('query_prompt_id', 'default') == query_prompt_id]
     
     # Filter by provider if specified
     if provider:

--- a/lambda/api/get-persona-rankings.py
+++ b/lambda/api/get-persona-rankings.py
@@ -1,0 +1,310 @@
+"""
+Persona Rankings API
+
+Returns brand ranking data grouped by persona for a given keyword.
+Queries the SearchResults table, groups results by query_prompt_id,
+and calculates per-persona brand metrics plus a cross-persona summary.
+"""
+
+import os
+import sys
+import logging
+import math
+import boto3
+from boto3.dynamodb.conditions import Key
+from typing import Dict, Any, List
+
+# Add shared module to path
+sys.path.insert(0, '/opt/python')
+
+from shared.decorators import api_handler, validate, require_keyword
+from shared.api_response import success_response, validation_error
+from decimal_utils import to_int
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.resource('dynamodb')
+
+# Fail-fast: Required environment variables
+SEARCH_RESULTS_TABLE = os.environ['DYNAMODB_TABLE_SEARCH_RESULTS']
+QUERY_PROMPTS_TABLE = os.environ['QUERY_PROMPTS_TABLE']
+
+
+def sentiment_to_label(sentiments: List[str]) -> str:
+    """Determine the dominant sentiment from a list of sentiment strings."""
+    if not sentiments:
+        return 'neutral'
+
+    counts = {}
+    for s in sentiments:
+        label = (s or 'neutral').lower()
+        counts[label] = counts.get(label, 0) + 1
+
+    return max(counts, key=counts.get)
+
+
+def sentiment_to_score(sentiment: str) -> float:
+    """Convert sentiment string to numeric score."""
+    sentiment_map = {
+        'positive': 1.0,
+        'neutral': 0.0,
+        'negative': -1.0,
+        'mixed': 0.0,
+    }
+    return sentiment_map.get(sentiment.lower() if sentiment else 'neutral', 0.0)
+
+
+
+def calculate_visibility_score(
+    provider_count: int,
+    total_mentions: int,
+    best_rank: int,
+    avg_sentiment_score: float,
+    total_providers: int,
+) -> float:
+    """
+    Calculate visibility score (0-100) based on multiple factors.
+
+    Factors:
+    - Provider coverage (40%): How many AI engines mention the brand
+    - Ranking position (30%): Best rank across providers (1=best)
+    - Mention frequency (20%): Total number of mentions
+    - Sentiment (10%): Average sentiment score
+
+    This replicates the formula from get-visibility-metrics.py.
+    """
+    # Provider coverage score (0-40)
+    provider_score = (provider_count / total_providers) * 40 if total_providers > 0 else 0
+
+    # Ranking score (0-30) - inverse of rank, capped at rank 10
+    rank_score = max(0, (11 - min(best_rank, 10)) / 10) * 30
+
+    # Mention score (0-20) - logarithmic scale, capped at 50 mentions
+    mention_score = min(math.log(total_mentions + 1) / math.log(51), 1) * 20
+
+    # Sentiment score (0-10) - convert -1 to 1 scale to 0-10
+    sentiment_score = ((avg_sentiment_score + 1) / 2) * 10
+
+    return round(provider_score + rank_score + mention_score + sentiment_score, 1)
+
+
+def fetch_persona_names() -> Dict[str, str]:
+    """
+    Fetch all persona names from the QueryPrompts table.
+
+    Returns a mapping of persona id -> persona name.
+    """
+    table = dynamodb.Table(QUERY_PROMPTS_TABLE)
+    response = table.scan(ProjectionExpression='id, #n', ExpressionAttributeNames={'#n': 'name'})
+    items = response.get('Items', [])
+
+    return {item['id']: item.get('name', 'Unknown Persona') for item in items}
+
+
+def get_valid_persona_ids() -> set:
+    """Return the set of all persona IDs stored in the QueryPrompts table."""
+    table = dynamodb.Table(QUERY_PROMPTS_TABLE)
+    response = table.scan(ProjectionExpression='id')
+    return {item['id'] for item in response.get('Items', [])}
+
+
+
+def build_persona_brands(items: List[Dict[str, Any]], total_providers: int) -> List[Dict[str, Any]]:
+    """
+    Build per-brand metrics from a list of search result items belonging to one persona.
+
+    Returns a list of brand dicts sorted by rank ascending.
+    """
+    brand_data: Dict[str, Dict[str, Any]] = {}
+
+    for item in items:
+        provider = item.get('provider', 'unknown')
+        brands = item.get('brands', [])
+
+        for brand in brands:
+            name = brand.get('name', '')
+            if not name:
+                continue
+
+            key = name.lower()
+            if key not in brand_data:
+                brand_data[key] = {
+                    'original_name': name,
+                    'classification': brand.get('classification', 'other'),
+                    'providers': set(),
+                    'mentions': 0,
+                    'ranks': [],
+                    'sentiments': [],
+                }
+
+            brand_data[key]['providers'].add(provider)
+            brand_data[key]['mentions'] += to_int(brand.get('mention_count'), 1)
+            brand_data[key]['ranks'].append(to_int(brand.get('rank'), 999))
+            if brand.get('sentiment'):
+                brand_data[key]['sentiments'].append(brand.get('sentiment'))
+
+    results = []
+    for data in brand_data.values():
+        best_rank = min(data['ranks']) if data['ranks'] else 999
+        sentiment_scores = [sentiment_to_score(s) for s in data['sentiments']]
+        avg_sentiment = sum(sentiment_scores) / len(sentiment_scores) if sentiment_scores else 0.0
+        mentions = to_int(data['mentions'], 0)
+
+        visibility = calculate_visibility_score(
+            provider_count=len(data['providers']),
+            total_mentions=mentions,
+            best_rank=best_rank,
+            avg_sentiment_score=float(avg_sentiment),
+            total_providers=total_providers,
+        )
+
+        results.append({
+            'name': data['original_name'],
+            'rank': best_rank,
+            'mention_count': mentions,
+            'sentiment': sentiment_to_label(data['sentiments']),
+            'visibility_score': visibility,
+            'classification': data['classification'],
+        })
+
+    results.sort(key=lambda x: x['rank'])
+    return results
+
+
+
+def build_cross_persona_summary(
+    personas: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Build a cross-persona summary with each brand's average rank, best rank,
+    worst rank, and the persona that produced the best rank.
+    """
+    # brand_key -> { ranks: [(rank, persona_name)], classification }
+    brand_agg: Dict[str, Dict[str, Any]] = {}
+
+    for persona in personas:
+        persona_name = persona['persona_name']
+        for brand in persona.get('brands', []):
+            key = brand['name'].lower()
+            if key not in brand_agg:
+                brand_agg[key] = {
+                    'original_name': brand['name'],
+                    'classification': brand.get('classification', 'other'),
+                    'ranks': [],
+                }
+            brand_agg[key]['ranks'].append((brand['rank'], persona_name))
+
+    summary_brands = []
+    for data in brand_agg.values():
+        ranks_only = [r for r, _ in data['ranks']]
+        best_rank = min(ranks_only)
+        worst_rank = max(ranks_only)
+        avg_rank = round(sum(ranks_only) / len(ranks_only), 1)
+
+        # Find the persona that produced the best rank
+        best_persona = next(name for r, name in data['ranks'] if r == best_rank)
+
+        summary_brands.append({
+            'name': data['original_name'],
+            'avg_rank': avg_rank,
+            'best_rank': best_rank,
+            'worst_rank': worst_rank,
+            'best_persona': best_persona,
+            'classification': data['classification'],
+        })
+
+    summary_brands.sort(key=lambda x: x['avg_rank'])
+    return {'brands': summary_brands}
+
+
+def get_persona_rankings(keyword: str, query_prompt_id: str = None) -> Dict[str, Any]:
+    """
+    Calculate persona-grouped brand rankings for a keyword.
+
+    If query_prompt_id is provided, returns only that persona's data.
+    """
+    table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+
+    response = table.query(
+        KeyConditionExpression=Key('keyword').eq(keyword)
+    )
+    items = response.get('Items', [])
+
+    if not items:
+        return {
+            'keyword': keyword,
+            'personas': [],
+            'cross_persona_summary': {'brands': []},
+            'message': 'No search results found for this keyword.',
+        }
+
+    # Use the latest timestamp only
+    latest_timestamp = max(item.get('timestamp', '') for item in items)
+    latest_items = [item for item in items if item.get('timestamp') == latest_timestamp]
+
+    # Determine total provider count from the data
+    all_providers = {item.get('provider', 'unknown') for item in latest_items}
+    total_providers = len(all_providers) if all_providers else 1
+
+    # Group items by query_prompt_id
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for item in latest_items:
+        pid = item.get('query_prompt_id', 'default')
+        grouped.setdefault(pid, []).append(item)
+
+    # Fetch persona names
+    persona_names = fetch_persona_names()
+
+    # Build per-persona brand lists
+    personas = []
+    for pid, group_items in grouped.items():
+        brands = build_persona_brands(group_items, total_providers)
+        personas.append({
+            'persona_id': pid,
+            'persona_name': persona_names.get(pid, pid),
+            'brands': brands,
+        })
+
+    # Sort personas by name for consistent ordering
+    personas.sort(key=lambda p: p['persona_name'])
+
+    # Build cross-persona summary from all personas
+    cross_persona_summary = build_cross_persona_summary(personas)
+
+    # If a specific persona was requested, filter to just that one
+    if query_prompt_id:
+        personas = [p for p in personas if p['persona_id'] == query_prompt_id]
+
+    return {
+        'keyword': keyword,
+        'personas': personas,
+        'cross_persona_summary': cross_persona_summary,
+    }
+
+
+@api_handler
+@validate({
+    'keyword': require_keyword(),
+    'query_prompt_id': {'type': str, 'max_length': 100},
+})
+def handler(event, context, keyword, query_prompt_id=None):
+    """
+    API handler for persona rankings.
+
+    Query params:
+        - keyword: Search keyword (required)
+        - query_prompt_id: Filter to a specific persona (optional)
+    """
+    # If a persona filter was provided, validate it exists in the QueryPrompts table
+    if query_prompt_id:
+        valid_ids = get_valid_persona_ids()
+        if query_prompt_id not in valid_ids:
+            return validation_error(
+                f'Persona not found: {query_prompt_id}',
+                event,
+                'query_prompt_id',
+            )
+
+    result = get_persona_rankings(keyword, query_prompt_id)
+    return success_response(result, event)

--- a/lambda/api/get-visibility-metrics.py
+++ b/lambda/api/get-visibility-metrics.py
@@ -124,8 +124,8 @@ def calculate_share_of_voice(brand_mentions: Dict[str, int], total_mentions: int
     }
 
 
-def get_visibility_metrics(keyword: str, config: Dict[str, Any]) -> Dict[str, Any]:
-    """Calculate visibility metrics for a keyword."""
+def get_visibility_metrics(keyword: str, config: Dict[str, Any], query_prompt_id: str = None) -> Dict[str, Any]:
+    """Calculate visibility metrics for a keyword, optionally filtered by persona."""
     table = dynamodb.Table(SEARCH_RESULTS_TABLE)
     
     # Query all results for this keyword
@@ -149,6 +149,10 @@ def get_visibility_metrics(keyword: str, config: Dict[str, Any]) -> Dict[str, An
     # Get latest timestamp for current metrics
     latest_timestamp = max(item.get('timestamp', '') for item in items)
     latest_items = [item for item in items if item.get('timestamp') == latest_timestamp]
+    
+    # Filter by persona if specified
+    if query_prompt_id:
+        latest_items = [item for item in latest_items if item.get('query_prompt_id', 'default') == query_prompt_id]
     
     for item in latest_items:
         provider = item.get('provider', 'unknown')
@@ -253,18 +257,20 @@ def get_visibility_metrics(keyword: str, config: Dict[str, Any]) -> Dict[str, An
 @api_handler
 @validate({
     'keyword': require_keyword(),
-    'brand': {'type': str, 'max_length': 200}
+    'brand': {'type': str, 'max_length': 200},
+    'query_prompt_id': {'type': str, 'max_length': 100},
 })
-def handler(event, context, keyword, brand=None):
+def handler(event, context, keyword, brand=None, query_prompt_id=None):
     """
     API handler for visibility metrics.
     
     Query params:
         - keyword: Search keyword (required)
         - brand: Filter to specific brand (optional)
+        - query_prompt_id: Filter to specific persona (optional)
     """
     config = get_brand_config()
-    metrics = get_visibility_metrics(keyword, config)
+    metrics = get_visibility_metrics(keyword, config, query_prompt_id=query_prompt_id)
     
     # Filter to specific brand if requested
     if brand and 'brands' in metrics:

--- a/lambda/api/self-reflection.py
+++ b/lambda/api/self-reflection.py
@@ -25,17 +25,17 @@ sys.path.insert(0, '/opt/python')
 from shared.decorators import api_handler, parse_json_body, validate, require_keyword
 from shared.api_response import success_response, validation_error
 from shared.utils import get_brand_config
+from shared.models import ModelRole, invoke_bedrock
+from shared.llm_json import parse_llm_json
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
-bedrock = boto3.client('bedrock-runtime')
 
 SEARCH_RESULTS_TABLE = os.environ['DYNAMODB_TABLE_SEARCH_RESULTS']
 SELF_REFLECTION_TABLE = os.environ['DYNAMODB_TABLE_SELF_REFLECTION']
 QUERY_PROMPTS_TABLE = os.environ['QUERY_PROMPTS_TABLE']
-MODEL_ID = os.environ.get('BEDROCK_MODEL_ID', 'global.anthropic.claude-haiku-4-5-20251001-v1:0')
 CACHE_TTL_HOURS = 24
 
 SELF_REFLECTION_PROMPT = """You are analysing an AI search response to explain brand ranking decisions.
@@ -78,28 +78,6 @@ Please provide a JSON response with this exact structure:
 Rank recommendations by estimated impact on improving the brand's position for this specific persona.
 Be specific about what content changes would help. Reference concrete gaps you identified.
 Return ONLY the JSON object. Do not include any text before or after the JSON."""
-
-
-def invoke_bedrock(prompt: str, max_retries: int = 3) -> str:
-    """Call Bedrock Converse API with retry logic for throttling."""
-    for attempt in range(max_retries):
-        try:
-            response = bedrock.converse(
-                modelId=MODEL_ID,
-                messages=[{'role': 'user', 'content': [{'text': prompt}]}],
-                inferenceConfig={'maxTokens': 4000, 'temperature': 0}
-            )
-            content_blocks = response.get('output', {}).get('message', {}).get('content', [])
-            return content_blocks[0].get('text', '') if content_blocks else ''
-        except Exception as e:
-            error_str = str(e)
-            is_throttle = any(t in error_str for t in [
-                'ThrottlingException', 'TooManyRequestsException', 'ServiceUnavailableException'
-            ])
-            if is_throttle and attempt < max_retries - 1:
-                time.sleep((2 ** attempt) + 1)
-                continue
-            raise
 
 
 def get_persona_info(query_prompt_id: str) -> dict:
@@ -201,58 +179,6 @@ def store_reflection(keyword, brand, query_prompt_id, persona_name,
     }
     table.put_item(Item=item)
     return item
-
-
-def parse_llm_json(raw_text: str) -> dict:
-    """Parse a JSON response from the LLM, handling markdown fences and surrounding text."""
-    text = raw_text.strip()
-
-    # Strip markdown code fences (```json ... ``` or ``` ... ```)
-    if '```' in text:
-        lines = text.split('\n')
-        filtered = []
-        inside_fence = False
-        for line in lines:
-            stripped = line.strip()
-            if stripped.startswith('```'):
-                inside_fence = not inside_fence
-                continue
-            if inside_fence:
-                filtered.append(line)
-        if filtered:
-            text = '\n'.join(filtered).strip()
-
-    # Try parsing the full text as JSON first
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        pass
-
-    # Find the outermost JSON object in the text
-    start = text.find('{')
-    if start >= 0:
-        depth = 0
-        end = start
-        for i in range(start, len(text)):
-            if text[i] == '{':
-                depth += 1
-            elif text[i] == '}':
-                depth -= 1
-                if depth == 0:
-                    end = i + 1
-                    break
-        try:
-            return json.loads(text[start:end])
-        except json.JSONDecodeError:
-            pass
-
-    logger.warning("Failed to parse LLM JSON response")
-    return {
-        'explanation': text, 'content_contributions': '',
-        'competitor_advantages': '', 'missing_data_points': '',
-        'recommendations': [],
-    }
-
 
 
 def strip_internal_keys(item: dict) -> dict:
@@ -359,8 +285,12 @@ def post_self_reflection(event, context, body, keyword, brand, query_prompt_id=N
         first_party_brands=', '.join(first_party),
         competitor_brands=', '.join(competitors),
     )
-    raw_response = invoke_bedrock(prompt)
-    reflection = parse_llm_json(raw_response)
+    raw_response = invoke_bedrock(prompt, ModelRole.ANALYSIS, max_tokens=4000, temperature=0)
+    reflection = parse_llm_json(raw_response, expect="object") or {
+        'explanation': raw_response, 'content_contributions': '',
+        'competitor_advantages': '', 'missing_data_points': '',
+        'recommendations': [],
+    }
 
     # 7. Store and return
     stored = store_reflection(

--- a/lambda/api/self-reflection.py
+++ b/lambda/api/self-reflection.py
@@ -1,0 +1,418 @@
+"""
+Self-Reflection API
+
+Triggers LLM self-reflection analysis for a keyword, brand, and persona.
+The LLM explains why a brand was ranked in its position and provides
+actionable content recommendations.
+
+Endpoints:
+- POST /self-reflection  - Trigger a new analysis (with 24h caching)
+- GET  /self-reflection   - Retrieve stored results
+"""
+
+import json
+import os
+import sys
+import time
+import logging
+from datetime import datetime, timedelta
+
+import boto3
+from boto3.dynamodb.conditions import Key, Attr
+
+sys.path.insert(0, '/opt/python')
+
+from shared.decorators import api_handler, parse_json_body, validate, require_keyword
+from shared.api_response import success_response, validation_error
+from shared.utils import get_brand_config
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.resource('dynamodb')
+bedrock = boto3.client('bedrock-runtime')
+
+SEARCH_RESULTS_TABLE = os.environ['DYNAMODB_TABLE_SEARCH_RESULTS']
+SELF_REFLECTION_TABLE = os.environ['DYNAMODB_TABLE_SELF_REFLECTION']
+QUERY_PROMPTS_TABLE = os.environ['QUERY_PROMPTS_TABLE']
+MODEL_ID = os.environ.get('BEDROCK_MODEL_ID', 'global.anthropic.claude-haiku-4-5-20251001-v1:0')
+CACHE_TTL_HOURS = 24
+
+SELF_REFLECTION_PROMPT = """You are analysing an AI search response to explain brand ranking decisions.
+
+Industry: {industry}
+Keyword: {keyword}
+Persona/Query: {persona_template}
+
+Original AI Response:
+{response_text}
+
+Brand Extraction Data:
+{brand_data_json}
+
+Brand being analysed: {brand_name}
+Current rank: {current_rank}
+Brand classification: {classification}
+
+Tracked brands configuration:
+First-party: {first_party_brands}
+Competitors: {competitor_brands}
+
+Please provide a JSON response with this exact structure:
+{{
+  "explanation": "Why this brand was ranked at position {current_rank}...",
+  "content_contributions": "What the brand's online content contributed to this ranking...",
+  "competitor_advantages": "What competitor content showed that influenced their higher/lower rankings...",
+  "missing_data_points": "What data or content was missing from this brand that would improve its ranking...",
+  "recommendations": [
+    {{
+      "title": "Short action title",
+      "description": "Detailed description of what to create or improve",
+      "priority": "high|medium|low",
+      "content_type": "landing page|blog post|FAQ section|data page|review page",
+      "gap_reference": "The specific gap this addresses"
+    }}
+  ]
+}}
+
+Rank recommendations by estimated impact on improving the brand's position for this specific persona.
+Be specific about what content changes would help. Reference concrete gaps you identified.
+Return ONLY the JSON object. Do not include any text before or after the JSON."""
+
+
+def invoke_bedrock(prompt: str, max_retries: int = 3) -> str:
+    """Call Bedrock Converse API with retry logic for throttling."""
+    for attempt in range(max_retries):
+        try:
+            response = bedrock.converse(
+                modelId=MODEL_ID,
+                messages=[{'role': 'user', 'content': [{'text': prompt}]}],
+                inferenceConfig={'maxTokens': 4000, 'temperature': 0}
+            )
+            content_blocks = response.get('output', {}).get('message', {}).get('content', [])
+            return content_blocks[0].get('text', '') if content_blocks else ''
+        except Exception as e:
+            error_str = str(e)
+            is_throttle = any(t in error_str for t in [
+                'ThrottlingException', 'TooManyRequestsException', 'ServiceUnavailableException'
+            ])
+            if is_throttle and attempt < max_retries - 1:
+                time.sleep((2 ** attempt) + 1)
+                continue
+            raise
+
+
+def get_persona_info(query_prompt_id: str) -> dict:
+    """Look up persona name and template from the QueryPrompts table."""
+    table = dynamodb.Table(QUERY_PROMPTS_TABLE)
+    response = table.get_item(Key={'id': query_prompt_id})
+    item = response.get('Item', {})
+    return {
+        'name': item.get('name', query_prompt_id),
+        'template': item.get('template', ''),
+    }
+
+
+def check_cache(keyword: str, brand: str, query_prompt_id: str):
+    """Return a cached self-reflection result if one exists within the TTL window."""
+    table = dynamodb.Table(SELF_REFLECTION_TABLE)
+    pk = f"{keyword}#{brand.lower()}"
+    response = table.query(
+        KeyConditionExpression=(
+            Key('keyword_brand').eq(pk) &
+            Key('persona_timestamp').begins_with(f"{query_prompt_id}#")
+        ),
+        ScanIndexForward=False, Limit=1
+    )
+    items = response.get('Items', [])
+    if not items:
+        return None
+    item = items[0]
+    created_at = item.get('created_at', '')
+    try:
+        created_dt = datetime.fromisoformat(created_at.replace('Z', '+00:00')).replace(tzinfo=None)
+        if datetime.utcnow() - created_dt < timedelta(hours=CACHE_TTL_HOURS):
+            return item
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
+def fetch_search_data(keyword: str, query_prompt_id: str):
+    """Fetch the latest search response and brand data for a keyword + persona."""
+    table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+    response = table.query(KeyConditionExpression=Key('keyword').eq(keyword))
+    items = response.get('Items', [])
+    if not items:
+        return None, None
+
+    latest_ts = max(item.get('timestamp', '') for item in items)
+    persona_items = [
+        item for item in items
+        if item.get('timestamp') == latest_ts
+        and (query_prompt_id in (None, '', 'all') or item.get('query_prompt_id', 'default') == query_prompt_id)
+    ]
+    if not persona_items:
+        return None, None
+
+    response_texts, all_brands = [], []
+    for item in persona_items[:4]:
+        text = item.get('response', '')
+        if text:
+            response_texts.append(f"[{item.get('provider', 'unknown')}]: {text[:2000]}")
+        all_brands.extend(item.get('brands', []))
+
+    return '\n\n'.join(response_texts), all_brands
+
+
+def find_brand_in_results(brand: str, brands_list: list):
+    """Find a brand in the extracted brands list. Returns (brand_data, rank) or (None, None)."""
+    if not brands_list:
+        return None, None
+    brand_lower = brand.lower()
+    for b in brands_list:
+        name = b.get('name', '')
+        if name.lower() == brand_lower or brand_lower in name.lower():
+            return b, b.get('rank', None)
+    return None, None
+
+
+def store_reflection(keyword, brand, query_prompt_id, persona_name,
+                     reflection, config, current_rank):
+    """Store a self-reflection result in DynamoDB with a 24-hour TTL."""
+    table = dynamodb.Table(SELF_REFLECTION_TABLE)
+    timestamp = datetime.utcnow().isoformat() + 'Z'
+    item = {
+        'keyword_brand': f"{keyword}#{brand.lower()}",
+        'persona_timestamp': f"{query_prompt_id}#{timestamp}",
+        'keyword': keyword,
+        'brand': brand,
+        'query_prompt_id': query_prompt_id,
+        'query_prompt_name': persona_name,
+        'current_rank': current_rank,
+        'explanation': reflection.get('explanation', ''),
+        'content_contributions': reflection.get('content_contributions', ''),
+        'competitor_advantages': reflection.get('competitor_advantages', ''),
+        'missing_data_points': reflection.get('missing_data_points', ''),
+        'recommendations': reflection.get('recommendations', []),
+        'industry': config.get('industry', 'general'),
+        'created_at': timestamp,
+        'ttl': int(time.time()) + (CACHE_TTL_HOURS * 3600),
+    }
+    table.put_item(Item=item)
+    return item
+
+
+def parse_llm_json(raw_text: str) -> dict:
+    """Parse a JSON response from the LLM, handling markdown fences and surrounding text."""
+    text = raw_text.strip()
+
+    # Strip markdown code fences (```json ... ``` or ``` ... ```)
+    if '```' in text:
+        lines = text.split('\n')
+        filtered = []
+        inside_fence = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith('```'):
+                inside_fence = not inside_fence
+                continue
+            if inside_fence:
+                filtered.append(line)
+        if filtered:
+            text = '\n'.join(filtered).strip()
+
+    # Try parsing the full text as JSON first
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Find the outermost JSON object in the text
+    start = text.find('{')
+    if start >= 0:
+        depth = 0
+        end = start
+        for i in range(start, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        try:
+            return json.loads(text[start:end])
+        except json.JSONDecodeError:
+            pass
+
+    logger.warning("Failed to parse LLM JSON response")
+    return {
+        'explanation': text, 'content_contributions': '',
+        'competitor_advantages': '', 'missing_data_points': '',
+        'recommendations': [],
+    }
+
+
+
+def strip_internal_keys(item: dict) -> dict:
+    """Remove DynamoDB composite keys from the API response."""
+    cleaned = dict(item)
+    cleaned.pop('keyword_brand', None)
+    cleaned.pop('persona_timestamp', None)
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# POST /self-reflection
+# ---------------------------------------------------------------------------
+
+@parse_json_body
+@validate({
+    'keyword': {'required': True, 'type': str, 'max_length': 500, 'source': 'body'},
+    'brand': {'required': True, 'type': str, 'max_length': 200, 'source': 'body'},
+    'query_prompt_id': {'required': False, 'type': str, 'max_length': 100, 'source': 'body'},
+    'force_refresh': {'type': bool, 'default': False, 'source': 'body'},
+})
+def post_self_reflection(event, context, body, keyword, brand, query_prompt_id=None, force_refresh=False):
+    """Trigger a self-reflection analysis for a keyword / brand / persona."""
+    query_prompt_id = query_prompt_id or 'all'
+
+    # 1. Check cache (skip if force_refresh)
+    if not force_refresh:
+        cached = check_cache(keyword, brand, query_prompt_id)
+        if cached:
+            logger.info("Returning cached self-reflection result")
+            return success_response(strip_internal_keys(cached), event)
+
+    # 2. Fetch search data
+    response_text, brands_list = fetch_search_data(keyword, query_prompt_id)
+    if not response_text:
+        return success_response({
+            'keyword': keyword, 'brand': brand,
+            'query_prompt_id': query_prompt_id, 'current_rank': None,
+            'explanation': (
+                f'No search results found for keyword "{keyword}" with the specified persona. '
+                'Run an analysis first to generate data for self-reflection.'
+            ),
+            'content_contributions': '', 'competitor_advantages': '',
+            'missing_data_points': '', 'recommendations': [],
+        }, event)
+
+    # 3. Look up brand in results
+    brand_data, current_rank = find_brand_in_results(brand, brands_list)
+    classification = brand_data.get('classification', 'other') if brand_data else 'not_found'
+
+    # 4. If brand is absent, return an absence explanation
+    if brand_data is None:
+        config = get_brand_config()
+        persona_info = get_persona_info(query_prompt_id)
+        absence_result = {
+            'explanation': (
+                f'The brand "{brand}" did not appear in any AI search results for '
+                f'"{keyword}" under this persona. None of the queried AI engines '
+                'mentioned or recommended this brand for the given query.'
+            ),
+            'content_contributions': 'No content from this brand was referenced by any AI engine.',
+            'competitor_advantages': (
+                'Competitor brands that did appear likely have stronger topical authority, '
+                'more relevant content, or better structured data for this query.'
+            ),
+            'missing_data_points': (
+                'The brand needs content that directly addresses this keyword and persona. '
+                'Consider creating authoritative, well-structured pages targeting this topic.'
+            ),
+            'recommendations': [{
+                'title': f'Create targeted content for "{keyword}"',
+                'description': (
+                    f'Create a comprehensive page that directly addresses "{keyword}" '
+                    "from this persona's perspective to gain initial visibility."
+                ),
+                'priority': 'high',
+                'content_type': 'landing page',
+                'gap_reference': 'Brand completely absent from results',
+            }],
+        }
+        stored = store_reflection(
+            keyword, brand, query_prompt_id, persona_info['name'],
+            absence_result, config, current_rank,
+        )
+        return success_response(strip_internal_keys(stored), event)
+
+    # 5. Load brand config for industry context
+    config = get_brand_config()
+    tracked_brands = config.get('tracked_brands', {})
+    first_party = tracked_brands.get('first_party', [])
+    competitors = tracked_brands.get('competitors', [])
+
+    # 6. Build the prompt and call Bedrock
+    persona_info = get_persona_info(query_prompt_id)
+    prompt = SELF_REFLECTION_PROMPT.format(
+        industry=config.get('industry', 'general'),
+        keyword=keyword,
+        persona_template=persona_info['template'] or persona_info['name'],
+        response_text=response_text[:4000],
+        brand_data_json=json.dumps(brands_list, default=str)[:2000],
+        brand_name=brand,
+        current_rank=current_rank if current_rank else 'N/A',
+        classification=classification,
+        first_party_brands=', '.join(first_party),
+        competitor_brands=', '.join(competitors),
+    )
+    raw_response = invoke_bedrock(prompt)
+    reflection = parse_llm_json(raw_response)
+
+    # 7. Store and return
+    stored = store_reflection(
+        keyword, brand, query_prompt_id, persona_info['name'],
+        reflection, config, current_rank,
+    )
+    return success_response(strip_internal_keys(stored), event)
+
+
+# ---------------------------------------------------------------------------
+# GET /self-reflection
+# ---------------------------------------------------------------------------
+
+@validate({
+    'keyword': require_keyword(),
+    'brand': {'type': str, 'max_length': 200},
+    'query_prompt_id': {'type': str, 'max_length': 100},
+})
+def get_self_reflection(event, context, keyword, brand=None, query_prompt_id=None):
+    """Retrieve stored self-reflection results with optional filters."""
+    table = dynamodb.Table(SELF_REFLECTION_TABLE)
+
+    if brand:
+        pk = f"{keyword}#{brand.lower()}"
+        key_cond = Key('keyword_brand').eq(pk)
+        if query_prompt_id:
+            key_cond = key_cond & Key('persona_timestamp').begins_with(f"{query_prompt_id}#")
+        response = table.query(KeyConditionExpression=key_cond, ScanIndexForward=False)
+        items = response.get('Items', [])
+    else:
+        response = table.scan(FilterExpression=Attr('keyword').eq(keyword))
+        items = response.get('Items', [])
+        if query_prompt_id:
+            items = [i for i in items if i.get('query_prompt_id') == query_prompt_id]
+        items.sort(key=lambda x: x.get('created_at', ''), reverse=True)
+
+    return success_response({'keyword': keyword, 'results': items, 'count': len(items)}, event)
+
+
+# ---------------------------------------------------------------------------
+# Lambda handler
+# ---------------------------------------------------------------------------
+
+@api_handler
+def handler(event, context):
+    """
+    POST /self-reflection  - Trigger a new analysis
+    GET  /self-reflection   - Retrieve stored results
+    """
+    method = event.get('httpMethod', 'GET').upper()
+    if method == 'POST':
+        return post_self_reflection(event, context)
+    elif method == 'GET':
+        return get_self_reflection(event, context)
+    return validation_error('Method not allowed', event)

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -1343,7 +1343,7 @@ export class CitationAnalysisStack extends cdk.Stack {
     configMgmtFunction.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['scheduler:CreateSchedule', 'scheduler:GetSchedule', 'scheduler:DeleteSchedule', 'scheduler:UpdateSchedule'],
-      resources: [`arn:aws:scheduler:${this.region}:${this.account}:schedule/default/CitationAnalysis-*`],
+      resources: [`arn:aws:scheduler:${this.region}:${this.account}:schedule/citation-analysis-schedules/*`],
     }));
     configMgmtFunction.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -1353,7 +1353,7 @@ export class CitationAnalysisStack extends cdk.Stack {
     configMgmtFunction.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['scheduler:CreateScheduleGroup', 'scheduler:GetScheduleGroup'],
-      resources: [`arn:aws:scheduler:${this.region}:${this.account}:schedule-group/default`],
+      resources: [`arn:aws:scheduler:${this.region}:${this.account}:schedule-group/citation-analysis-schedules`],
     }));
     configMgmtFunction.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -325,6 +325,25 @@ export class CitationAnalysisStack extends cdk.Stack {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // DynamoDB Table: SelfReflection
+    // Stores LLM self-reflection analysis results with 24-hour TTL caching
+    const selfReflectionTable = new dynamodb.Table(this, 'SelfReflectionTable', {
+      tableName: 'CitationAnalysis-SelfReflection',
+      partitionKey: {
+        name: 'keyword_brand',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'persona_timestamp',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      timeToLiveAttribute: 'ttl',
+    });
+
     // ========================================
     // Secrets Manager - API Keys
     // ========================================
@@ -1363,6 +1382,64 @@ export class CitationAnalysisStack extends cdk.Stack {
 
     searchResultsTable.grantReadData(getBrandMentionsFunction);
     brandConfigTable.grantReadData(getBrandMentionsFunction);
+
+    // ========================================
+    // Persona Rankings API
+    // ========================================
+
+    const getPersonaRankingsFunction = new lambda.Function(this, 'GetPersonaRankingsFunction', {
+      functionName: 'CitationAnalysis-API-GetPersonaRankings',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'get-persona-rankings.handler',
+      code: createApiLambdaCode('get-persona-rankings.py'),
+      layers: [sharedLayer],
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 256,
+      description: 'API: Get per-persona brand ranking breakdowns',
+      environment: {
+        DYNAMODB_TABLE_SEARCH_RESULTS: searchResultsTable.tableName,
+        QUERY_PROMPTS_TABLE: queryPromptsTable.tableName,
+      },
+    });
+    searchResultsTable.grantReadData(getPersonaRankingsFunction);
+    queryPromptsTable.grantReadData(getPersonaRankingsFunction);
+
+    // ========================================
+    // Self-Reflection API
+    // ========================================
+
+    const selfReflectionFunction = new lambda.Function(this, 'SelfReflectionFunction', {
+      functionName: 'CitationAnalysis-API-SelfReflection',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'self-reflection.handler',
+      code: createApiLambdaCode('self-reflection.py'),
+      layers: [sharedLayer],
+      timeout: cdk.Duration.seconds(60),
+      memorySize: 256,
+      description: 'API: LLM self-reflection analysis for brand rankings',
+      environment: {
+        DYNAMODB_TABLE_SEARCH_RESULTS: searchResultsTable.tableName,
+        DYNAMODB_TABLE_SELF_REFLECTION: selfReflectionTable.tableName,
+        QUERY_PROMPTS_TABLE: queryPromptsTable.tableName,
+        BEDROCK_MODEL_ID: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+      },
+    });
+    searchResultsTable.grantReadData(selfReflectionFunction);
+    brandConfigTable.grantReadData(selfReflectionFunction);
+    queryPromptsTable.grantReadData(selfReflectionFunction);
+    selfReflectionTable.grantReadWriteData(selfReflectionFunction);
+    selfReflectionFunction.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'bedrock:InvokeModel',
+      ],
+      resources: [
+        `arn:aws:bedrock:*:${this.account}:inference-profile/global.anthropic.claude-*`,
+        `arn:aws:bedrock:*::foundation-model/anthropic.claude-*`,
+        `arn:aws:bedrock:::foundation-model/anthropic.claude-*`,
+      ],
+    }));
+
     brandConfigTable.grantReadWriteData(manageBrandConfigFunction);
     
     // Grant Bedrock access for brand expansion feature
@@ -1661,6 +1738,15 @@ export class CitationAnalysisStack extends cdk.Stack {
     const trendsResource = apiResource.addResource('trends');
     trendsResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
 
+    // Persona Rankings API Route
+    const personaRankingsResource = apiResource.addResource('persona-rankings');
+    personaRankingsResource.addMethod('GET', new apigateway.LambdaIntegration(getPersonaRankingsFunction, integrationOptions), methodOptions);
+
+    // Self-Reflection API Routes
+    const selfReflectionResource = apiResource.addResource('self-reflection');
+    selfReflectionResource.addMethod('POST', new apigateway.LambdaIntegration(selfReflectionFunction, integrationOptions), methodOptions);
+    selfReflectionResource.addMethod('GET', new apigateway.LambdaIntegration(selfReflectionFunction, integrationOptions), methodOptions);
+
     // ========================================
     // Content Studio API
     // ========================================
@@ -1682,6 +1768,7 @@ export class CitationAnalysisStack extends cdk.Stack {
         DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,
         DYNAMODB_TABLE_CONTENT_STUDIO: contentStudioTable.tableName,
         DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
+        DYNAMODB_TABLE_SELF_REFLECTION: selfReflectionTable.tableName,
         GENERATION_TIMEOUT_SECONDS: '240',
       },
     });
@@ -1691,6 +1778,7 @@ export class CitationAnalysisStack extends cdk.Stack {
     brandConfigTable.grantReadData(contentStudioFunction);
     contentStudioTable.grantReadWriteData(contentStudioFunction);
     keywordsTable.grantReadData(contentStudioFunction);
+    selfReflectionTable.grantReadData(contentStudioFunction);
     // Grant Bedrock access for content generation using Converse API
     // Uses global.anthropic.claude-* inference profiles (Haiku 4.5 for speed)
     // Note: Converse API requires bedrock:InvokeModel permission (not bedrock:Converse)
@@ -2113,7 +2201,8 @@ def delete_waf(waf, arn):
       statsInsightsFunction, citationsContentFunction,
       keywordMgmtFunction, configMgmtFunction, executionMgmtFunction,
       getBrandMentionsFunction, manageBrandConfigFunction,
-      contentStudioFunction, manageUsersFunction
+      contentStudioFunction, manageUsersFunction,
+      getPersonaRankingsFunction, selfReflectionFunction
     ];
     
     for (const fn of apiLambdaFunctions) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.250.0",
+        "aws-cdk-lib": "^2.245.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.263",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
+      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -47,9 +47,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.16.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.16.0.tgz",
-      "integrity": "sha512-k9LJusrF2sxLN59QCAVj6PPmGMKtHAUWtfC7BraHJfE6DNp/9bHmh083Q3fyDNoE8lUd1Sakza5MBng9HYC1CQ==",
+      "version": "53.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.10.0.tgz",
+      "integrity": "sha512-/gJgJQh9SHIIN82GZ4BB0WS3z3HcKFF734yNOkX0stBeyIfaBl2x476dihVCCM1GpVqnueC9DUA3CyZJOOPitg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -163,6 +163,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
@@ -1820,32 +1831,21 @@
         "node": ">=12"
       }
     },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1863,17 +1863,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
-      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
+      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.58.0",
-        "comment-parser": "1.4.6",
+        "@typescript-eslint/types": "^8.54.0",
+        "comment-parser": "1.4.5",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.2.0"
+        "jsdoc-type-pratt-parser": "~7.1.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1952,15 +1952,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^3.1.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1993,21 +1993,52 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.14.0",
+        "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2040,9 +2071,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2172,6 +2203,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
@@ -2181,6 +2223,17 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2201,15 +2254,22 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@ltd/j-toml": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
+      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==",
+      "dev": true,
+      "license": "LGPL-3.0"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
@@ -2224,14 +2284,14 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.6.5.tgz",
-      "integrity": "sha512-9kvAI+kk2pfEXLqS8OyjI9XvWmp+Gdn7jPfxDAz8BOqxMyPy3p5hYl+jc4TIsLOWunAFl8azqrcYsHzEpaWCIA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.6.3.tgz",
+      "integrity": "sha512-GUGQGU1XcNHLQcUEq/JqNqTGikfdJQAgiyauwKr5z2dUNWK+OmUJE9J0tqANbPBZO5wtwMpRNXtVWtxQqgX8nQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@zkochan/js-yaml": "0.0.7",
-        "ejs": "5.0.1",
+        "ejs": "^3.1.7",
         "enquirer": "~2.3.6",
         "minimatch": "10.2.4",
         "semver": "^7.6.3",
@@ -2243,14 +2303,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-22.6.5.tgz",
-      "integrity": "sha512-G1DkvBMzBAqxxrJ7Zfky5HN4HQjrULKZQ5J5YCnTm5qZpah58U7xAP4g8D0aJzKMWMUJkgXAU1ojiLbeZUDJkw==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-22.6.3.tgz",
+      "integrity": "sha512-Ln7SnrTXjNh1AHsTGYGZeqo4HsvPkFYsCd6kYz/ntPQEHhPb2Uj67YQ05H/Bg4yN8Yn7XWQR6GQ63xAHe5lFoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.6.5",
-        "@nx/js": "22.6.5",
+        "@nx/devkit": "22.6.3",
+        "@nx/js": "22.6.3",
         "@phenomnomnominal/tsquery": "~6.1.4",
         "@typescript-eslint/type-utils": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0",
@@ -2272,9 +2332,9 @@
       }
     },
     "node_modules/@nx/js": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.6.5.tgz",
-      "integrity": "sha512-bmikz6qaBHfuAgsqPB/TfLIKfvI4g+EKIRAiU2FHnEtVWOKDAmSQXHFwE3rMS49jl2JLgxkdNjZHpg4g/OLy0g==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.6.3.tgz",
+      "integrity": "sha512-KKgN6TydaadkZFRu3XuOkC3aV+49pDzfiOad93nkHMXScevnbGFdyhqXXxc9FqaKW3ocrsNc6T7I4MjQ7ZUNaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2285,8 +2345,8 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-typescript": "^7.22.5",
         "@babel/runtime": "^7.22.6",
-        "@nx/devkit": "22.6.5",
-        "@nx/workspace": "22.6.5",
+        "@nx/devkit": "22.6.3",
+        "@nx/workspace": "22.6.3",
         "@zkochan/js-yaml": "0.0.7",
         "babel-plugin-const-enum": "^1.0.1",
         "babel-plugin-macros": "^3.1.0",
@@ -2299,7 +2359,7 @@
         "jsonc-parser": "3.2.0",
         "npm-run-path": "^4.0.1",
         "picocolors": "^1.1.0",
-        "picomatch": "4.0.4",
+        "picomatch": "4.0.2",
         "semver": "^7.6.3",
         "source-map-support": "0.5.19",
         "tinyglobby": "^0.2.12",
@@ -2336,9 +2396,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.6.5.tgz",
-      "integrity": "sha512-qT77Omkg5xQuL2+pDbneX2tI+XW5ZeayMylu7UUgK8OhTrAkJLKjpuYRH4xT5XBipxbDtlxmO3aLS3Ib1pKzJQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.6.3.tgz",
+      "integrity": "sha512-m8hEp2WufqUJzrl2uI5OItkPqIo8+0lbOBEKI7yZN9uoL6FKzP5LF6WlMFPJ8FlajtjBzQqaoDwp04+bkuXeaw==",
       "cpu": [
         "arm64"
       ],
@@ -2350,9 +2410,9 @@
       ]
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.6.5.tgz",
-      "integrity": "sha512-9jICxb7vfJ56y/7Yuh3b/n1QJqWxO9xnXKYEs6SO8xPoW/KomVckILGc1C6RQSs6/3ixVJC7k1Dh1wm5tKPFrg==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.6.3.tgz",
+      "integrity": "sha512-biPybnU2qlNuP7ytBYmRuusrU5TWXqVKMHr7Kxrqlin87iJR5MosXSZ+Pjr8H+0zFrB4rGf/9yro3s/dYG40Yw==",
       "cpu": [
         "x64"
       ],
@@ -2364,9 +2424,9 @@
       ]
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.6.5.tgz",
-      "integrity": "sha512-6B1wEKpqz5dI3AGMqttAVnA6M3DB/besAtuGyQiymK9ROlta1iuWgCcIYwcCQyhLn2Rx7vqj447KKcgCa8HlVw==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.6.3.tgz",
+      "integrity": "sha512-8C6hhvVuqPwnvjHMPAA77DeEZ/WSY6AxuuIiyRje9uKF2B5F26sV89lRjBoEiWnV1dmLdy5YY5HJZEjwqjifAQ==",
       "cpu": [
         "x64"
       ],
@@ -2378,9 +2438,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.6.5.tgz",
-      "integrity": "sha512-xV50B8mnDPboct7JkAHftajI02s+8FszA8WTzhore+YGR+lEKHTLpucwGEaQuMlSdLplH7pQix4B4uK5pcMhZw==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.6.3.tgz",
+      "integrity": "sha512-8gWDhe4lY3pegmKx5/z7z/h4adlmL+3wuPXMUlBtMkhJ5TX1z94PkVtHRprEsHuQHO7PsSFaOJdsIZbr/sx7SQ==",
       "cpu": [
         "arm"
       ],
@@ -2392,9 +2452,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.6.5.tgz",
-      "integrity": "sha512-2JkWuMGj+HpW6oPAvU5VdAx1afTnEbiM10Y3YOrl3fipWV4BiP5VDx762QTrfCraP4hl6yqTgvTe7F9xaby+jQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.6.3.tgz",
+      "integrity": "sha512-ZRP5qf4lsk0HFuvhhSJc+t3a0NKc+WXElKPXTEK9DGOluY327lUogeZrSSJfxGf+dBTtpuRIO8rOIrnZOf5Xww==",
       "cpu": [
         "arm64"
       ],
@@ -2406,9 +2466,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.6.5.tgz",
-      "integrity": "sha512-Z/zMqFClnEyqDXouJKEPoWVhMQIif5F0YuECWBYjd3ZLwQsXGTItoh+6Wm3XF/nGMA2uLOHyTq/X7iFXQY3RzA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.6.3.tgz",
+      "integrity": "sha512-AcOf/5UJD7Fyc2ujHYajxLw+ajJ8C1IhHoCQyLwBpd/15lu3pii9Z9G4cNBm0ejKnnzofzRmhv2xka9qqCtpXQ==",
       "cpu": [
         "arm64"
       ],
@@ -2420,9 +2480,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.6.5.tgz",
-      "integrity": "sha512-FlotSyqNnaXSn0K+yWw+hRdYBwusABrPgKLyixfJIYRzsy+xPKN6pON6vZfqGwzuWF/9mEGReRz+iM8PiW0XSg==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.6.3.tgz",
+      "integrity": "sha512-KxSdUCGOt2GGXzgggp9sSLJacWj7AAI410UPOEGw5F6GS5148e+kiy3piULF/0NE5/q40IK7gyS43HY99qgAqQ==",
       "cpu": [
         "x64"
       ],
@@ -2434,9 +2494,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.6.5.tgz",
-      "integrity": "sha512-RVOe2qcwhoIx6mxQURPjUfAW5SEOmT2gdhewvdcvX9ICq1hj5B2VarmkhTg0qroO7xiyqOqwq26mCzoV2I3NgQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.6.3.tgz",
+      "integrity": "sha512-Tvlw6XvTj+5IQRkprV3AdCKnlQFYh2OJYn0wgHrvQWeV1Eks/RaCoRChfHXdAyE4S64YrBA6NAOxfXANh3yLTg==",
       "cpu": [
         "x64"
       ],
@@ -2448,9 +2508,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.6.5.tgz",
-      "integrity": "sha512-ZqurqI8VuYnsr2Kn4K4t+Gx6j/BZdf6qz/6Tv4A7XQQ6oNYVQgTqoNEFj+CCkVaIe6aIdCWpousFLqs+ZgBqYQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.6.3.tgz",
+      "integrity": "sha512-9yRRuoVeQdV52GJtHo+vH6+es2PNF8skWlUa74jyWRsoZM9Ew8JmRZruRfhkUmhjJTrguqJLj9koa/NXgS0yeg==",
       "cpu": [
         "arm64"
       ],
@@ -2462,9 +2522,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.6.5.tgz",
-      "integrity": "sha512-i2QFBJIuaYg9BHxrrnBV4O7W9rVL2k0pSIdk/rRp3EYJEU93iUng+qbZiY9wh1xvmXuUCE2G7TRd+8/SG/RFKg==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.6.3.tgz",
+      "integrity": "sha512-21wjiUSV5hMa1oj8UfpfMTxpROksWrr/minAv8ejmGFwUSoztSzAkNf5i4PESPsbYNytjKooDzzAiQMLo6b0kg==",
       "cpu": [
         "x64"
       ],
@@ -2476,27 +2536,27 @@
       ]
     },
     "node_modules/@nx/workspace": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.6.5.tgz",
-      "integrity": "sha512-/CZtv1ESSfZ1MVqSlCsmnBWysU1z5VdNlwANlqL6BV2X6RUHKDPVj4YuNPvCK+0LsqyzfJdUt3pcnBYxnT5TIg==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.6.3.tgz",
+      "integrity": "sha512-Tdu3K6mpRAU0LI2gpi61WLY7mPR61nj1Szvhwj4T88PhGQXSlN6PuUhb5nMPHnZG/bDmUFeTSv/+MCgbEm563A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.6.5",
+        "@nx/devkit": "22.6.3",
         "@zkochan/js-yaml": "0.0.7",
         "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "nx": "22.6.5",
-        "picomatch": "4.0.4",
+        "nx": "22.6.3",
+        "picomatch": "4.0.2",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2518,9 +2578,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
       ],
@@ -2535,9 +2595,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
       ],
@@ -2552,9 +2612,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
       ],
@@ -2569,9 +2629,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
       ],
@@ -2586,9 +2646,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
       ],
@@ -2603,9 +2663,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
       ],
@@ -2620,9 +2680,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
       ],
@@ -2637,9 +2697,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2654,9 +2714,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
       ],
@@ -2671,9 +2731,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
       ],
@@ -2688,9 +2748,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
       ],
@@ -2705,9 +2765,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
       ],
@@ -2722,9 +2782,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
       ],
@@ -2732,41 +2792,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2794,9 +2831,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
       ],
@@ -2811,9 +2848,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
       ],
@@ -2828,9 +2865,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2887,6 +2924,37 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2977,9 +3045,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2994,17 +3062,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/type-utils": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3017,22 +3085,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.58.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3048,14 +3116,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3070,14 +3138,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3088,9 +3156,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3105,15 +3173,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3130,9 +3198,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3144,16 +3212,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3172,16 +3240,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3196,13 +3264,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.58.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3213,28 +3281,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.16.tgz",
-      "integrity": "sha512-2pBN1F1JXq6zTSaYC58CMJa7pGxXIRsLfOioeZM4cPE3pRdSh1ySTSoHPQlOTEF5WgoVzWZQxhGQ3ygT78hOVg==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.13.tgz",
+      "integrity": "sha512-ui7JGWBoQpS5NKKW0FDb1eTuFEZ5EupEv2Psemuyfba7DfA5K52SeDLelt6P4pQJJ/4UGkker/BgMk/KrjH3WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "^8.58.0",
-        "@typescript-eslint/utils": "^8.58.0"
+        "@typescript-eslint/scope-manager": "^8.55.0",
+        "@typescript-eslint/utils": "^8.55.0"
       },
       "engines": {
         "node": ">=18"
@@ -3258,16 +3313,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.3.tgz",
+      "integrity": "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3275,10 +3330,37 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
+      "integrity": "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.3",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
+      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3289,13 +3371,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.3.tgz",
+      "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3303,14 +3385,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.3.tgz",
+      "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3319,9 +3401,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
+      "integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3329,13 +3411,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
+      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.3",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3402,9 +3484,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3425,9 +3507,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3711,6 +3793,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3745,9 +3834,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1118.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.2.tgz",
-      "integrity": "sha512-jHuShSx0JI14enDz2Hk2Qe0LYTDPzLyF2nBhWCvoXyRCpz31sI3XsCh4KO5ZXKfw9ET0bHvDTVnMZQPBpswg8A==",
+      "version": "2.1115.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1115.0.tgz",
+      "integrity": "sha512-PpNNflDt1L2TxpMh2h7cPHnFkDVeY1hwIxuGuvswS08mA0syOT4OmZx8hZYdcLru6NceCsn0x/7uTHpb6Hzo5A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3758,9 +3847,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.250.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.250.0.tgz",
-      "integrity": "sha512-8U8/S9VcmKSc3MHZWiB7P0IecgXoohI8Ya3dgtZMgbzC4mB+MEQmsYBeNgm4vzGQdRos8HjQLnFX1IBlZh7jQA==",
+      "version": "2.245.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.245.0.tgz",
+      "integrity": "sha512-Yfeb+wKC6s+Ttm/N93C6vY6ksyCh68WaG/j3N6dalJWTW/V4o6hUolHm+v2c2IofJEUS45c5AF/EEj24e9hfMA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -3777,7 +3866,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
         "@aws-cdk/cloud-assembly-api": "^2.2.0",
         "@aws-cdk/cloud-assembly-schema": "^53.0.0",
@@ -3897,7 +3986,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4039,11 +4128,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.5",
+      "version": "10.2.4",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4151,9 +4240,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -4161,9 +4250,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4275,15 +4364,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4306,16 +4386,13 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
+      "integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/bl": {
@@ -4330,22 +4407,10 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -4363,11 +4428,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4432,15 +4497,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -4492,9 +4557,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001765",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
+      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
       "dev": true,
       "funding": [
         {
@@ -4547,9 +4612,9 @@
       "license": "MIT"
     },
     "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
       "dev": true,
       "funding": [
         {
@@ -4684,9 +4749,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
-      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4714,9 +4779,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
+      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4742,6 +4807,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/create-require": {
@@ -4950,9 +5025,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5017,22 +5092,25 @@
       }
     },
     "node_modules/ejs": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
-      "integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
       "bin": {
         "ejs": "bin/cli.js"
       },
       "engines": {
-        "node": ">=0.12.18"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.277",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.277.tgz",
+      "integrity": "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw==",
       "dev": true,
       "license": "ISC"
     },
@@ -5077,9 +5155,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
-      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5166,16 +5244,16 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
+        "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.2",
+        "es-abstract": "^1.24.1",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -5187,7 +5265,7 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0"
+        "safe-array-concat": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5284,25 +5362,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-array": "^0.21.1",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -5321,7 +5399,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -5344,15 +5422,15 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
-      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.16.1",
-        "resolve": "^2.0.0-next.6"
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -5363,30 +5441,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -5472,19 +5526,19 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
-      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
+      "version": "62.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.1.tgz",
+      "integrity": "sha512-e9358PdHgvcMF98foNd3L7hVCw70Lt+YcSL7JzlJebB8eT5oRJtW6bHMQKoAwJtw6q0q0w/fRIr2kwnHdFDI6A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.86.0",
+        "@es-joy/jsdoccomment": "~0.84.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.6",
+        "comment-parser": "1.4.5",
         "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^11.2.0",
+        "espree": "^11.1.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.0",
@@ -5498,37 +5552,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -5595,24 +5618,18 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5733,11 +5750,42 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5756,18 +5804,18 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
+      "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5931,6 +5979,16 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5993,9 +6051,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -6429,6 +6487,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6591,9 +6650,9 @@
       }
     },
     "node_modules/is-builtin-module/node_modules/builtin-modules": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.1.0.tgz",
-      "integrity": "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
+      "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7008,6 +7067,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-diff": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
@@ -7045,9 +7122,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
+      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7607,6 +7684,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7616,6 +7694,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7638,6 +7717,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -7647,6 +7727,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -7692,39 +7795,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flatmap": "^1.3.3",
-        "es-errors": "^1.3.0",
-        "object.entries": "^1.1.9",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-exports-info/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7742,24 +7816,25 @@
       }
     },
     "node_modules/nx": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-22.6.5.tgz",
-      "integrity": "sha512-VRKhDAt684dXNSz9MNjE7MekkCfQF41P2PSx5jEWQjDEP1Z4jFZbyeygWs5ZyOroG7/n0MoWAJTe6ftvIcBOAg==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.6.3.tgz",
+      "integrity": "sha512-8eIkEAlvkTvR2zY+yjhuTxMD6z4AtM1SumSBbwMmUMEXMtXE88fH0RL59T5V6MLjaov1exUM3lhUqPE3IyuBPg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@ltd/j-toml": "^1.38.0",
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.2",
         "@zkochan/js-yaml": "0.0.7",
-        "axios": "1.15.0",
+        "axios": "^1.12.0",
         "cli-cursor": "3.1.0",
         "cli-spinners": "2.6.1",
         "cliui": "^8.0.1",
         "dotenv": "~16.4.5",
         "dotenv-expand": "~11.0.6",
-        "ejs": "5.0.1",
+        "ejs": "^3.1.7",
         "enquirer": "~2.3.6",
         "figures": "3.2.0",
         "flat": "^5.0.2",
@@ -7775,7 +7850,6 @@
         "picocolors": "^1.1.0",
         "resolve.exports": "2.0.3",
         "semver": "^7.6.3",
-        "smol-toml": "1.6.1",
         "string-width": "^4.2.3",
         "tar-stream": "~2.2.0",
         "tmp": "~0.2.1",
@@ -7791,16 +7865,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "22.6.5",
-        "@nx/nx-darwin-x64": "22.6.5",
-        "@nx/nx-freebsd-x64": "22.6.5",
-        "@nx/nx-linux-arm-gnueabihf": "22.6.5",
-        "@nx/nx-linux-arm64-gnu": "22.6.5",
-        "@nx/nx-linux-arm64-musl": "22.6.5",
-        "@nx/nx-linux-x64-gnu": "22.6.5",
-        "@nx/nx-linux-x64-musl": "22.6.5",
-        "@nx/nx-win32-arm64-msvc": "22.6.5",
-        "@nx/nx-win32-x64-msvc": "22.6.5"
+        "@nx/nx-darwin-arm64": "22.6.3",
+        "@nx/nx-darwin-x64": "22.6.3",
+        "@nx/nx-freebsd-x64": "22.6.3",
+        "@nx/nx-linux-arm-gnueabihf": "22.6.3",
+        "@nx/nx-linux-arm64-gnu": "22.6.3",
+        "@nx/nx-linux-arm64-musl": "22.6.3",
+        "@nx/nx-linux-x64-gnu": "22.6.3",
+        "@nx/nx-linux-x64-musl": "22.6.3",
+        "@nx/nx-win32-arm64-msvc": "22.6.3",
+        "@nx/nx-win32-x64-msvc": "22.6.3"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.11.1",
@@ -8263,9 +8337,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -8362,6 +8436,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8516,9 +8591,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
-      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8552,13 +8627,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -8608,14 +8682,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -8624,21 +8698,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
       }
     },
     "node_modules/safe-array-concat": {
@@ -8736,6 +8810,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8837,14 +8912,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
+        "object-inspect": "^1.13.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8906,19 +8981,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8969,9 +9031,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
-      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -8990,9 +9052,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9265,14 +9327,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9524,16 +9586,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
+      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.58.0",
+        "@typescript-eslint/parser": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9672,134 +9734,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+    "node_modules/vite": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
+      "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
+        "rolldown": "1.0.0-rc.13",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -9867,22 +9812,94 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+    "node_modules/vitest": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
+      "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.3",
+        "@vitest/mocker": "4.1.3",
+        "@vitest/pretty-format": "4.1.3",
+        "@vitest/runner": "4.1.3",
+        "@vitest/snapshot": "4.1.3",
+        "@vitest/spy": "4.1.3",
+        "@vitest/utils": "4.1.3",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
       "bin": {
-        "yaml": "bin.mjs"
+        "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": ">= 14.6"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/eemeli"
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.3",
+        "@vitest/browser-preview": "4.1.3",
+        "@vitest/browser-webdriverio": "4.1.3",
+        "@vitest/coverage-istanbul": "4.1.3",
+        "@vitest/coverage-v8": "4.1.3",
+        "@vitest/ui": "4.1.3",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "node_modules/wcwidth": {
@@ -10068,15 +10085,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/web/src/api/visibility.ts
+++ b/web/src/api/visibility.ts
@@ -13,6 +13,7 @@ import type {
 interface FetchVisibilityOptions {
   keyword: string;
   brand?: string;
+  queryPromptId?: string;
   signal?: AbortSignal;
 }
 
@@ -23,10 +24,11 @@ export function fetchVisibilityMetrics(
   options: FetchVisibilityOptions
 ): Promise<VisibilityMetricsResponse> {
   const {
-    keyword, brand, signal 
+    keyword, brand, queryPromptId, signal 
   } = options;
   const params: Record<string, string> = { keyword };
   if (brand) params.brand = brand;
+  if (queryPromptId) params.query_prompt_id = queryPromptId;
   return apiGet<VisibilityMetricsResponse>('/visibility', {
     params,
     signal 

--- a/web/src/components/Brands/BrandDetailModal.tsx
+++ b/web/src/components/Brands/BrandDetailModal.tsx
@@ -7,20 +7,23 @@ import type {
 } from '../../types';
 import { ProviderResponsesTab } from './ProviderResponsesTab';
 import { BrandOverviewTab } from './BrandOverviewTab';
+import { SelfReflectionPanel } from '../SelfReflection/SelfReflectionPanel';
 
 interface BrandDetailModalProps {
   brand: AggregatedBrand;
   providerData: ProviderBrandData[];
   keyword: string;
+  queryPromptId?: string | null;
   onClose: () => void;
 }
 
-type ModalTab = 'overview' | 'responses';
+type ModalTab = 'overview' | 'responses' | 'ranking-analysis';
 
 export const BrandDetailModal = ({
   brand,
   providerData,
   keyword,
+  queryPromptId,
   onClose,
 }: BrandDetailModalProps) => {
   const [activeTab, setActiveTab] = useState<ModalTab>('overview');
@@ -131,6 +134,24 @@ export const BrandDetailModal = ({
               </svg>
               AI Responses ({providerData.length})
             </button>
+            <button
+              onClick={() => setActiveTab('ranking-analysis')}
+              className={`py-3 px-1 border-b-2 font-medium text-sm transition-colors flex items-center gap-2 whitespace-nowrap ${
+                activeTab === 'ranking-analysis'
+                  ? 'border-gray-900 text-gray-900'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+                />
+              </svg>
+              Ranking Analysis
+            </button>
           </nav>
         </div>
 
@@ -141,6 +162,13 @@ export const BrandDetailModal = ({
           )}
           {activeTab === 'responses' && (
             <ProviderResponsesTab brand={brand} providerData={providerData} keyword={keyword} />
+          )}
+          {activeTab === 'ranking-analysis' && (
+            <SelfReflectionPanel
+              keyword={keyword}
+              brand={brand.name}
+              queryPromptId={queryPromptId ?? ''}
+            />
           )}
         </div>
 

--- a/web/src/components/Brands/BrandsView.tsx
+++ b/web/src/components/Brands/BrandsView.tsx
@@ -4,6 +4,7 @@ import { useBrandConfig } from '../../hooks/useBrandConfig';
 import { BrandMentionsTable } from './BrandMentionsTable';
 import { BrandDetailModal } from './BrandDetailModal';
 import { BrandConfigPanel } from './BrandConfigPanel';
+import { PersonaSelector } from '../shared/PersonaSelector';
 import { Spinner } from '../ui/Spinner';
 import type {
   Keyword, AggregatedBrand, BrandMentionsResponse, BrandConfig 
@@ -169,6 +170,7 @@ const useViewState = () => {
   const [selectedBrand, setSelectedBrand] = useState<AggregatedBrand | null>(null);
   const [showConfig, setShowConfig] = useState(false);
   const [classificationFilter, setClassificationFilter] = useState<string | null>(null);
+  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
   
   return {
     selectedKeyword,
@@ -178,7 +180,9 @@ const useViewState = () => {
     showConfig,
     setShowConfig,
     classificationFilter,
-    setClassificationFilter
+    setClassificationFilter,
+    selectedPersonaId,
+    setSelectedPersonaId
   };
 };
 
@@ -194,6 +198,7 @@ const renderModals = (props: {
   setShowConfig: (show: boolean) => void;
   expandAllBrands: ReturnType<typeof useBrandConfig>['expandAllBrands'];
   findCompetitors: ReturnType<typeof useBrandConfig>['findCompetitors'];
+  selectedPersonaId: string | null;
 }) => (
   <>
     {props.selectedBrand && props.data && (
@@ -201,6 +206,7 @@ const renderModals = (props: {
         brand={props.selectedBrand} 
         providerData={props.data.by_provider} 
         keyword={props.data.keyword} 
+        queryPromptId={props.selectedPersonaId}
         onClose={() => props.setSelectedBrand(null)} 
       />
     )}
@@ -221,12 +227,13 @@ const renderModals = (props: {
 export const BrandsView = ({ keywords }: BrandsViewProps) => {
   const {
     selectedKeyword, setSelectedKeyword, selectedBrand, setSelectedBrand,
-    showConfig, setShowConfig, classificationFilter, setClassificationFilter
+    showConfig, setShowConfig, classificationFilter, setClassificationFilter,
+    selectedPersonaId, setSelectedPersonaId
   } = useViewState();
 
   const {
     data, loading, error 
-  } = useBrandMentions(selectedKeyword, classificationFilter);
+  } = useBrandMentions(selectedKeyword, classificationFilter, selectedPersonaId);
   const {
     config, presets, loading: configLoading, saveConfig, expandAllBrands, findCompetitors 
   } = useBrandConfig();
@@ -242,6 +249,10 @@ export const BrandsView = ({ keywords }: BrandsViewProps) => {
         onConfigClick={() => setShowConfig(true)}
       />
       <KeywordSelector keywords={keywords} selectedKeyword={selectedKeyword} onSelect={setSelectedKeyword} />
+      <PersonaSelector selectedPersonaId={selectedPersonaId} onPersonaChange={setSelectedPersonaId} />
+      {selectedPersonaId && (
+        <div className="text-xs text-gray-500 px-1">Filtering by persona</div>
+      )}
       <BrandContent
         data={data}
         loading={loading}
@@ -263,7 +274,8 @@ export const BrandsView = ({ keywords }: BrandsViewProps) => {
         saveConfig,
         setShowConfig,
         expandAllBrands,
-        findCompetitors
+        findCompetitors,
+        selectedPersonaId
       })}
     </div>
   );

--- a/web/src/components/ContentStudio/ContentIdeaCard.tsx
+++ b/web/src/components/ContentStudio/ContentIdeaCard.tsx
@@ -29,6 +29,11 @@ const typeIcons: Record<string, JSX.Element> = {
     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
     </svg>
+  ),
+  self_reflection: (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+    </svg>
   )
 };
 
@@ -141,6 +146,11 @@ export const ContentIdeaCard = ({
               <span className={`px-2 py-0.5 text-xs font-medium rounded-full border ${priorityStyles[idea.priority]}`}>
                 {idea.priority}
               </span>
+              {idea.persona_name && (
+                <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-purple-50 border border-purple-200 text-purple-700">
+                  {idea.persona_name}
+                </span>
+              )}
             </div>
 
             <p className="text-sm text-gray-600 mb-3">{idea.description}</p>

--- a/web/src/components/Personas/PersonaSelector.tsx
+++ b/web/src/components/Personas/PersonaSelector.tsx
@@ -1,0 +1,86 @@
+import {
+  useEffect, useState, useCallback
+} from 'react';
+import {
+  API_BASE_URL, authenticatedFetch
+} from '../../infrastructure';
+
+interface Persona {
+  persona_id: string;
+  persona_name: string;
+}
+
+interface PersonaSelectorProps {
+  readonly selectedPersonaId: string | null;
+  readonly onPersonaChange: (personaId: string | null) => void;
+  readonly personas?: Persona[];
+}
+
+interface QueryPromptRecord {
+  id: string;
+  name: string;
+}
+
+function isQueryPromptArray(data: unknown): data is QueryPromptRecord[] {
+  return Array.isArray(data) && data.every(
+    (item) => typeof item === 'object' && item !== null && 'id' in item && 'name' in item
+  );
+}
+
+export function PersonaSelector({
+  selectedPersonaId, onPersonaChange, personas: externalPersonas
+}: PersonaSelectorProps) {
+  const [fetchedPersonas, setFetchedPersonas] = useState<Persona[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPersonas = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await authenticatedFetch(`${API_BASE_URL}/query-prompts`);
+      if (!response.ok) return;
+      const json: unknown = await response.json();
+      if (isQueryPromptArray(json)) {
+        setFetchedPersonas(json.map((p) => ({
+          persona_id: p.id,
+          persona_name: p.name,
+        })));
+      }
+    } catch {
+      setFetchedPersonas([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!externalPersonas) {
+      fetchPersonas();
+    }
+  }, [externalPersonas, fetchPersonas]);
+
+  const personaList = externalPersonas ?? fetchedPersonas;
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    onPersonaChange(value === '' ? null : value);
+  };
+
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-500 mb-1.5">Filter by persona</label>
+      <select
+        value={selectedPersonaId ?? ''}
+        onChange={handleChange}
+        disabled={loading}
+        className="w-full px-4 py-2.5 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 text-sm bg-gray-50"
+      >
+        <option value="">All Personas</option>
+        {personaList.map((p) => (
+          <option key={p.persona_id} value={p.persona_id}>{p.persona_name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default PersonaSelector;

--- a/web/src/components/SelfReflection/SelfReflectionPanel.tsx
+++ b/web/src/components/SelfReflection/SelfReflectionPanel.tsx
@@ -1,0 +1,128 @@
+import { useSelfReflection } from '../../hooks/useSelfReflection';
+import { Spinner } from '../ui/Spinner';
+import type { ContentRecommendation } from '../../types';
+
+interface SelfReflectionPanelProps {
+  readonly keyword: string;
+  readonly brand: string;
+  readonly queryPromptId: string;
+}
+
+const PRIORITY_BADGE_CLASSES: Record<ContentRecommendation['priority'], string> = {
+  high: 'bg-red-100 text-red-800',
+  medium: 'bg-yellow-100 text-yellow-800',
+  low: 'bg-green-100 text-green-800',
+};
+
+export function SelfReflectionPanel({ keyword, brand, queryPromptId }: SelfReflectionPanelProps) {
+  const { data, loading, error, triggerReflection } = useSelfReflection();
+
+  const handleAnalyse = () => {
+    triggerReflection(keyword, brand, queryPromptId);
+  };
+
+  const handleReanalyse = () => {
+    triggerReflection(keyword, brand, queryPromptId, true);
+  };
+
+  const displayRank = data?.current_rank != null ? String(data.current_rank) : 'Not ranked';
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">Ranking Analysis</h3>
+        <p className="text-sm text-gray-500 mt-1">
+          Understand why {brand} ranks where it does for &quot;{keyword}&quot;
+        </p>
+      </div>
+
+      {!data && !loading && (
+        <button
+          type="button"
+          onClick={handleAnalyse}
+          className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
+        >
+          Analyse Ranking
+        </button>
+      )}
+
+      {data && !loading && (
+        <button
+          type="button"
+          onClick={handleReanalyse}
+          className="px-3 py-1.5 bg-gray-100 text-gray-700 text-xs font-medium rounded-lg hover:bg-gray-200 transition-colors mb-4"
+        >
+          Re-analyse
+        </button>
+      )}
+
+      {loading && (
+        <div className="flex items-center gap-2 text-sm text-gray-500 py-4">
+          <Spinner size="sm" />
+          <span>Analysing ranking factors...</span>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-600 mt-2">{error}</p>
+      )}
+
+      {data && (
+        <div className="mt-6 space-y-5">
+          <section>
+            <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide">Current Rank</h4>
+            <p className="mt-1 text-2xl font-bold text-gray-900">{displayRank}</p>
+          </section>
+
+          <section>
+            <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide">Explanation</h4>
+            <p className="mt-1 text-sm text-gray-700 leading-relaxed">{data.explanation}</p>
+          </section>
+
+          <section>
+            <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide">Content Contributions</h4>
+            <p className="mt-1 text-sm text-gray-700 leading-relaxed">{data.content_contributions}</p>
+          </section>
+
+          <section>
+            <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide">Competitor Advantages</h4>
+            <p className="mt-1 text-sm text-gray-700 leading-relaxed">{data.competitor_advantages}</p>
+          </section>
+
+          <section>
+            <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide">Missing Data Points</h4>
+            <p className="mt-1 text-sm text-gray-700 leading-relaxed">{data.missing_data_points}</p>
+          </section>
+
+          {data.recommendations.length > 0 && (
+            <section>
+              <h4 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-3">Recommendations</h4>
+              <ul className="space-y-3">
+                {data.recommendations.map((rec) => (
+                  <li key={rec.title} className="border border-gray-100 rounded-lg p-3">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-sm font-medium text-gray-900">{rec.title}</span>
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${PRIORITY_BADGE_CLASSES[rec.priority]}`}>
+                        {rec.priority}
+                      </span>
+                      <span className="text-xs text-gray-400">{rec.content_type}</span>
+                    </div>
+                    <p className="text-sm text-gray-600">{rec.description}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          <div className="pt-2">
+            <a href="/content-studio" className="text-sm text-blue-600 hover:text-blue-800 font-medium">
+              View in Content Studio
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SelfReflectionPanel;

--- a/web/src/components/Visibility/PersonaComparisonChart.tsx
+++ b/web/src/components/Visibility/PersonaComparisonChart.tsx
@@ -1,0 +1,126 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import type { TooltipItem } from 'chart.js';
+import type { PersonaRankingsResponse } from '../../types';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+interface PersonaComparisonChartProps { readonly data: PersonaRankingsResponse | null; }
+
+function computeAverageRank(brands: ReadonlyArray<{ rank: number }>): number | null {
+  if (brands.length === 0) return null;
+  const sum = brands.reduce((acc, b) => acc + b.rank, 0);
+  return sum / brands.length;
+}
+
+export function PersonaComparisonChart({ data }: PersonaComparisonChartProps) {
+  if (!data) return null;
+
+  const personasWithResults = data.personas.filter((p) => p.brands.length > 0);
+
+  if (personasWithResults.length < 2) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
+        <h3 className="text-sm font-medium text-gray-900 mb-4">Brand Ranking by Persona</h3>
+        <p className="text-center text-gray-500 text-sm">
+          At least two personas are needed for comparison.
+        </p>
+      </div>
+    );
+  }
+
+  const labels = personasWithResults.map((p) => p.persona_name);
+
+  const firstPartyAverages = personasWithResults.map((p) => {
+    const matching = p.brands.filter((b) => b.classification === 'first_party');
+    return computeAverageRank(matching);
+  });
+
+  const competitorAverages = personasWithResults.map((p) => {
+    const matching = p.brands.filter((b) => b.classification === 'competitor');
+    return computeAverageRank(matching);
+  });
+
+  const firstPartyCounts = personasWithResults.map(
+    (p) => p.brands.filter((b) => b.classification === 'first_party').length
+  );
+
+  const competitorCounts = personasWithResults.map(
+    (p) => p.brands.filter((b) => b.classification === 'competitor').length
+  );
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'First-party brands',
+        data: firstPartyAverages,
+        backgroundColor: 'rgba(16, 185, 129, 0.7)',
+        borderColor: 'rgb(16, 185, 129)',
+        borderWidth: 1,
+      },
+      {
+        label: 'Competitor brands',
+        data: competitorAverages,
+        backgroundColor: 'rgba(239, 68, 68, 0.7)',
+        borderColor: 'rgb(239, 68, 68)',
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: { position: 'top' as const },
+      tooltip: {
+        callbacks: {
+          label(context: TooltipItem<'bar'>) {
+            const personaIndex = context.dataIndex;
+            const persona = personasWithResults[personaIndex];
+            const isFirstParty = context.datasetIndex === 0;
+            const brandType = isFirstParty ? 'First-party' : 'Competitor';
+            const avgRank = context.parsed.y ?? 0;
+            const brandCount = isFirstParty
+              ? firstPartyCounts[personaIndex]
+              : competitorCounts[personaIndex];
+            return `${persona.persona_name} — ${brandType}: avg rank ${avgRank.toFixed(1)} (${brandCount} brands)`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        reverse: true,
+        beginAtZero: false,
+        title: {
+          display: true,
+          text: 'Average Brand Rank (lower is better)',
+        },
+      },
+      x: {
+        title: {
+          display: true,
+          text: 'Persona',
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
+      <h3 className="text-sm font-medium text-gray-900 mb-4">Brand Ranking by Persona</h3>
+      <Bar data={chartData} options={options} />
+    </div>
+  );
+}
+
+export default PersonaComparisonChart;

--- a/web/src/components/Visibility/VisibilityDashboard.spec.tsx
+++ b/web/src/components/Visibility/VisibilityDashboard.spec.tsx
@@ -11,11 +11,15 @@ vi.mock('../../hooks/useVisibilityMetrics', () => ({useVisibilityMetrics: vi.fn(
 
 vi.mock('../../hooks/useHistoricalTrends', () => ({useHistoricalTrends: vi.fn(),}));
 
+vi.mock('../../hooks/usePersonaRankings', () => ({usePersonaRankings: vi.fn(),}));
+
 import { useVisibilityMetrics } from '../../hooks/useVisibilityMetrics';
 import { useHistoricalTrends } from '../../hooks/useHistoricalTrends';
+import { usePersonaRankings } from '../../hooks/usePersonaRankings';
 
 const mockUseVisibilityMetrics = useVisibilityMetrics as ReturnType<typeof vi.fn>;
 const mockUseHistoricalTrends = useHistoricalTrends as ReturnType<typeof vi.fn>;
+const mockUsePersonaRankings = usePersonaRankings as ReturnType<typeof vi.fn>;
 
 function buildProps(overrides = {}) {
   return {
@@ -40,6 +44,12 @@ describe('VisibilityDashboard', () => {
       loading: false,
       fetchHistoricalTrends: vi.fn(),
     });
+    mockUsePersonaRankings.mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+      fetchPersonaRankings: vi.fn(),
+    });
   });
 
   describe('initial render', () => {
@@ -53,8 +63,8 @@ describe('VisibilityDashboard', () => {
     it('renders keyword selector with all keywords', () => {
       render(<VisibilityDashboard {...buildProps()} />);
 
-      const select = screen.getByRole('combobox');
-      expect(select).toBeInTheDocument();
+      const selects = screen.getAllByRole('combobox');
+      expect(selects[0]).toBeInTheDocument();
       expect(screen.getByText('hotels')).toBeInTheDocument();
       expect(screen.getByText('resorts')).toBeInTheDocument();
     });
@@ -69,7 +79,7 @@ describe('VisibilityDashboard', () => {
 
       render(<VisibilityDashboard {...buildProps()} />);
 
-      expect(fetchVisibilityMetrics).toHaveBeenCalledWith('hotels');
+      expect(fetchVisibilityMetrics).toHaveBeenCalledWith('hotels', undefined, undefined);
     });
   });
 
@@ -162,10 +172,10 @@ describe('VisibilityDashboard', () => {
 
       render(<VisibilityDashboard {...buildProps()} />);
 
-      const select = screen.getByRole('combobox');
-      await userEvent.selectOptions(select, 'resorts');
+      const selects = screen.getAllByRole('combobox');
+      await userEvent.selectOptions(selects[0], 'resorts');
 
-      expect(fetchVisibilityMetrics).toHaveBeenCalledWith('resorts');
+      expect(fetchVisibilityMetrics).toHaveBeenCalledWith('resorts', undefined, undefined);
       expect(fetchHistoricalTrends).toHaveBeenCalledWith('resorts', 'day', 30);
     });
   });

--- a/web/src/components/Visibility/VisibilityDashboard.tsx
+++ b/web/src/components/Visibility/VisibilityDashboard.tsx
@@ -3,20 +3,27 @@ import {
 } from 'react';
 import { useVisibilityMetrics } from '../../hooks/useVisibilityMetrics';
 import { useHistoricalTrends } from '../../hooks/useHistoricalTrends';
+import { usePersonaRankings } from '../../hooks/usePersonaRankings';
 import {
   BrandRow, SummaryCards, TrendChart 
 } from './VisibilityComponents';
+import { PersonaSelector } from '../shared/PersonaSelector';
+import { PersonaComparisonChart } from './PersonaComparisonChart';
 
 interface Props { readonly keywords: Array<{ keyword: string }>; }
 
 export function VisibilityDashboard({ keywords }: Props) {
   const [selectedKeyword, setSelectedKeyword] = useState<string>('');
+  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
   const {
     data: visibility, loading: visLoading, fetchVisibilityMetrics 
   } = useVisibilityMetrics();
   const {
     data: trends, loading: trendsLoading, fetchHistoricalTrends 
   } = useHistoricalTrends();
+  const {
+    data: personaRankings, fetchPersonaRankings 
+  } = usePersonaRankings();
 
   useEffect(() => {
     if (keywords.length > 0 && !selectedKeyword) setSelectedKeyword(keywords[0].keyword);
@@ -24,10 +31,16 @@ export function VisibilityDashboard({ keywords }: Props) {
 
   useEffect(() => {
     if (selectedKeyword) {
-      fetchVisibilityMetrics(selectedKeyword);
+      fetchVisibilityMetrics(selectedKeyword, undefined, selectedPersonaId ?? undefined);
       fetchHistoricalTrends(selectedKeyword, 'day', 30);
     }
-  }, [selectedKeyword, fetchVisibilityMetrics, fetchHistoricalTrends]);
+  }, [selectedKeyword, selectedPersonaId, fetchVisibilityMetrics, fetchHistoricalTrends]);
+
+  useEffect(() => {
+    if (selectedKeyword) {
+      fetchPersonaRankings(selectedKeyword);
+    }
+  }, [selectedKeyword, fetchPersonaRankings]);
 
   const hasTrendData = trends?.trend_data && trends.trend_data.length > 0;
 
@@ -45,6 +58,7 @@ export function VisibilityDashboard({ keywords }: Props) {
               {keywords.map(k => <option key={k.keyword} value={k.keyword}>{k.keyword}</option>)}
             </select>
           </div>
+          <PersonaSelector selectedPersonaId={selectedPersonaId} onPersonaChange={setSelectedPersonaId} />
         </div>
       </div>
 
@@ -87,6 +101,8 @@ export function VisibilityDashboard({ keywords }: Props) {
               </table>
             </div>
           </div>
+
+          <PersonaComparisonChart data={personaRankings} />
         </>
       )}
     </div>

--- a/web/src/components/shared/PersonaSelector.tsx
+++ b/web/src/components/shared/PersonaSelector.tsx
@@ -1,0 +1,59 @@
+import {
+  useState, useEffect, useCallback
+} from 'react';
+import {
+  API_BASE_URL, authenticatedFetch
+} from '../../infrastructure';
+
+interface QueryPrompt {
+  id: string;
+  name: string;
+  template: string;
+  enabled: boolean;
+}
+
+interface PersonaSelectorProps {
+  readonly selectedPersonaId: string | null;
+  readonly onPersonaChange: (personaId: string | null) => void;
+}
+
+export function PersonaSelector({ selectedPersonaId, onPersonaChange }: PersonaSelectorProps) {
+  const [personas, setPersonas] = useState<QueryPrompt[]>([]);
+
+  useEffect(() => {
+    const fetchPersonas = async () => {
+      try {
+        const response = await authenticatedFetch(`${API_BASE_URL}/query-prompts`);
+        if (!response.ok) return;
+        const data: unknown = await response.json();
+        if (Array.isArray(data)) {
+          setPersonas(data as QueryPrompt[]);
+        }
+      } catch {
+        setPersonas([]);
+      }
+    };
+    fetchPersonas();
+  }, []);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    onPersonaChange(value === '' ? null : value);
+  }, [onPersonaChange]);
+
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-500 mb-1.5">Filter by persona</label>
+      <select
+        value={selectedPersonaId ?? ''}
+        onChange={handleChange}
+        className="w-full px-4 py-2.5 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 text-sm bg-gray-50"
+      >
+        <option value="">All Personas</option>
+        {personas.map(p => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/src/hooks/useBrandMentions.ts
+++ b/web/src/hooks/useBrandMentions.ts
@@ -35,7 +35,7 @@ function isBrandMentionsResponse(data: unknown): data is BrandMentionsResponse {
  * return <BrandTable brands={data?.aggregated.brands} />;
  * ```
  */
-export const useBrandMentions = (keyword: string | null, classificationFilter: string | null = null) => {
+export const useBrandMentions = (keyword: string | null, classificationFilter: string | null = null, queryPromptId: string | null = null) => {
   const [data, setData] = useState<BrandMentionsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,9 +54,12 @@ export const useBrandMentions = (keyword: string | null, classificationFilter: s
 
       try {
         const baseUrl = `${API_BASE_URL}/brand-mentions?keyword=${encodeURIComponent(keyword)}`;
-        const url = classificationFilter
+        const classificationUrl = classificationFilter
           ? `${baseUrl}&classification=${encodeURIComponent(classificationFilter)}`
           : baseUrl;
+        const url = queryPromptId
+          ? `${classificationUrl}&query_prompt_id=${encodeURIComponent(queryPromptId)}`
+          : classificationUrl;
 
         const response = await authenticatedFetch(url, { signal: controller.signal });
 
@@ -84,7 +87,7 @@ export const useBrandMentions = (keyword: string | null, classificationFilter: s
     fetchBrandMentions();
 
     return () => controller.abort();
-  }, [keyword, classificationFilter]);
+  }, [keyword, classificationFilter, queryPromptId]);
 
   return {
     data,

--- a/web/src/hooks/usePersonaRankings.ts
+++ b/web/src/hooks/usePersonaRankings.ts
@@ -4,12 +4,12 @@ import {
 import {
   API_BASE_URL, authenticatedFetch, getErrorMessage 
 } from '../infrastructure';
-import type { VisibilityMetricsResponse } from '../types';
+import type { PersonaRankingsResponse } from '../types';
 
-class VisibilityFetchError extends Error {
-  constructor(message = 'Failed to fetch visibility metrics') {
+class PersonaRankingsFetchError extends Error {
+  constructor(message = 'Failed to fetch persona rankings') {
     super(message);
-    this.name = 'VisibilityFetchError';
+    this.name = 'PersonaRankingsFetchError';
   }
 }
 
@@ -19,45 +19,41 @@ function isBackendErrorResponse(data: unknown): data is BackendErrorResponse {
   return typeof data === 'object' && data !== null && 'error' in data && typeof (data as BackendErrorResponse).error === 'string';
 }
 
-function isVisibilityMetricsResponse(data: unknown): data is VisibilityMetricsResponse {
+function isPersonaRankingsResponse(data: unknown): data is PersonaRankingsResponse {
   if (typeof data !== 'object' || data === null) return false;
-  
-  // Check for error response from backend
   if ('error' in data) return false;
-  
-  return 'keyword' in data && 'brands' in data;
+  return 'keyword' in data && 'personas' in data && 'cross_persona_summary' in data;
 }
 
-export function useVisibilityMetrics() {
-  const [data, setData] = useState<VisibilityMetricsResponse | null>(null);
+export function usePersonaRankings() {
+  const [data, setData] = useState<PersonaRankingsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchVisibilityMetrics = useCallback(async (keyword: string, brand?: string, queryPromptId?: string) => {
+  const fetchPersonaRankings = useCallback(async (keyword: string, queryPromptId?: string) => {
     setLoading(true);
     setError(null);
-    
+
     try {
       const params = new URLSearchParams({ keyword });
-      if (brand) params.append('brand', brand);
       if (queryPromptId) params.append('query_prompt_id', queryPromptId);
-      
-      const response = await authenticatedFetch(`${API_BASE_URL}/visibility?${params}`);
-      if (!response.ok) throw new VisibilityFetchError();
-      
+
+      const response = await authenticatedFetch(`${API_BASE_URL}/persona-rankings?${params}`);
+      if (!response.ok) throw new PersonaRankingsFetchError();
+
       const json: unknown = await response.json();
       if (isBackendErrorResponse(json)) {
-        throw new VisibilityFetchError(json.error);
+        throw new PersonaRankingsFetchError(json.error);
       }
-      if (!isVisibilityMetricsResponse(json)) {
-        throw new VisibilityFetchError('Invalid response format');
+      if (!isPersonaRankingsResponse(json)) {
+        throw new PersonaRankingsFetchError('Invalid response format');
       }
       setData(json);
       return json;
     } catch (err) {
       const message = getErrorMessage(err, 'visibility');
       setError(message);
-      console.error('[visibility] Error fetching metrics:', err);
+      console.error('[persona-rankings] Error fetching rankings:', err);
       return null;
     } finally {
       setLoading(false);
@@ -68,6 +64,6 @@ export function useVisibilityMetrics() {
     data,
     loading,
     error,
-    fetchVisibilityMetrics 
+    fetchPersonaRankings 
   };
 }

--- a/web/src/hooks/useSelfReflection.ts
+++ b/web/src/hooks/useSelfReflection.ts
@@ -1,0 +1,116 @@
+import {
+  useState, useCallback 
+} from 'react';
+import {
+  API_BASE_URL, authenticatedFetch, getErrorMessage 
+} from '../infrastructure';
+import type { SelfReflectionResponse, SelfReflectionResult } from '../types';
+
+class SelfReflectionFetchError extends Error {
+  constructor(message = 'Failed to fetch self-reflection data') {
+    super(message);
+    this.name = 'SelfReflectionFetchError';
+  }
+}
+
+interface BackendErrorResponse {error: string;}
+
+function isBackendErrorResponse(data: unknown): data is BackendErrorResponse {
+  return typeof data === 'object' && data !== null && 'error' in data && typeof (data as BackendErrorResponse).error === 'string';
+}
+
+function isSelfReflectionResponse(data: unknown): data is SelfReflectionResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  if ('error' in data) return false;
+  return 'keyword' in data && 'brand' in data && 'explanation' in data;
+}
+
+interface SelfReflectionListResponse {
+  keyword: string;
+  results: SelfReflectionResult[];
+  count: number;
+}
+
+function isSelfReflectionListResponse(data: unknown): data is SelfReflectionListResponse {
+  return typeof data === 'object' && data !== null && 'results' in data && Array.isArray((data as SelfReflectionListResponse).results);
+}
+
+export function useSelfReflection() {
+  const [data, setData] = useState<SelfReflectionResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const triggerReflection = useCallback(async (keyword: string, brand: string, queryPromptId: string, forceRefresh = false) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await authenticatedFetch(`${API_BASE_URL}/self-reflection`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          keyword,
+          brand,
+          query_prompt_id: queryPromptId,
+          force_refresh: forceRefresh,
+        }),
+      });
+      if (!response.ok) throw new SelfReflectionFetchError();
+
+      const json: unknown = await response.json();
+      if (isBackendErrorResponse(json)) {
+        throw new SelfReflectionFetchError(json.error);
+      }
+      if (!isSelfReflectionResponse(json)) {
+        throw new SelfReflectionFetchError('Invalid response format');
+      }
+      setData(json);
+      return json;
+    } catch (err) {
+      const message = getErrorMessage(err, 'self-reflection');
+      setError(message);
+      console.error('[self-reflection] Error triggering reflection:', err);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchReflections = useCallback(async (keyword: string, brand?: string, queryPromptId?: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({ keyword });
+      if (brand) params.append('brand', brand);
+      if (queryPromptId) params.append('query_prompt_id', queryPromptId);
+
+      const response = await authenticatedFetch(`${API_BASE_URL}/self-reflection?${params}`);
+      if (!response.ok) throw new SelfReflectionFetchError();
+
+      const json: unknown = await response.json();
+      if (isBackendErrorResponse(json)) {
+        throw new SelfReflectionFetchError(json.error);
+      }
+      if (!isSelfReflectionListResponse(json)) {
+        throw new SelfReflectionFetchError('Invalid response format');
+      }
+      return json.results;
+    } catch (err) {
+      const message = getErrorMessage(err, 'self-reflection');
+      setError(message);
+      console.error('[self-reflection] Error fetching reflections:', err);
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    data,
+    loading,
+    error,
+    triggerReflection,
+    fetchReflections 
+  };
+}

--- a/web/src/types/domain/content.ts
+++ b/web/src/types/domain/content.ts
@@ -1,4 +1,4 @@
-export type ContentIdeaType = 'visibility_gap' | 'ranking_improvement' | 'provider_gap' | 'configuration' | 'data';
+export type ContentIdeaType = 'visibility_gap' | 'ranking_improvement' | 'provider_gap' | 'configuration' | 'data' | 'self_reflection';
 export type ContentPriority = 'high' | 'medium' | 'low';
 export type ContentAngle = 'comprehensive_guide' | 'differentiation' | 'provider_optimization';
 export type ContentStatus = 'pending' | 'generating' | 'generated' | 'failed';
@@ -18,6 +18,9 @@ export interface ContentIdea {
   current_rank?: number;
   actionable: boolean;
   content_angle?: ContentAngle;
+  persona_name?: string;
+  persona_id?: string;
+  gap_reference?: string;
 }
 
 export interface GeneratedContent {

--- a/web/src/types/domain/visibility.ts
+++ b/web/src/types/domain/visibility.ts
@@ -178,3 +178,60 @@ export interface HistoricalTrendsResponse {
     avg_score: number;
   };
 }
+
+export interface PersonaBrandRanking {
+  name: string;
+  rank: number;
+  mention_count: number;
+  sentiment: string;
+  visibility_score: number;
+  classification: BrandClassification;
+}
+
+export interface PersonaRankingGroup {
+  persona_id: string;
+  persona_name: string;
+  brands: PersonaBrandRanking[];
+}
+
+export interface CrossPersonaBrandSummary {
+  name: string;
+  avg_rank: number;
+  best_rank: number;
+  worst_rank: number;
+  best_persona: string;
+  classification: BrandClassification;
+}
+
+export interface PersonaRankingsResponse {
+  keyword: string;
+  personas: PersonaRankingGroup[];
+  cross_persona_summary: {
+    brands: CrossPersonaBrandSummary[];
+  };
+}
+
+export interface ContentRecommendation {
+  title: string;
+  description: string;
+  priority: 'high' | 'medium' | 'low';
+  content_type: string;
+  gap_reference: string;
+}
+
+export interface SelfReflectionResult {
+  keyword: string;
+  brand: string;
+  query_prompt_id: string;
+  query_prompt_name: string;
+  current_rank: number | null;
+  explanation: string;
+  content_contributions: string;
+  competitor_advantages: string;
+  missing_data_points: string;
+  recommendations: ContentRecommendation[];
+  industry: string;
+  created_at: string;
+}
+
+export type SelfReflectionResponse = SelfReflectionResult;


### PR DESCRIPTION
## Summary

Adds two new capabilities based on customer feedback:

1. **Per-persona brand ranking**: filter visibility metrics and brand mentions by persona (query prompt) to see how brand rankings change depending on the audience segment. Includes a comparison chart plotting average brand rank across personas.

2. **LLM self-reflection**: ask the AI to explain why it ranked a brand in a certain position and what content changes would improve that ranking. Returns structured analysis with actionable content recommendations.

## Changes

### Backend (Python Lambda handlers)
- Modified `get-visibility-metrics.py` and `get-brand-mentions.py` to accept optional `query_prompt_id` filter
- New `get-persona-rankings.py` endpoint for cross-persona comparison data
- New `self-reflection.py` endpoint (POST to trigger analysis, GET to retrieve results) using Bedrock Converse API
- Modified `content-studio.py` to surface self-reflection recommendations as content ideas

### Infrastructure (CDK)
- New `CitationAnalysis-SelfReflection` DynamoDB table with 24h TTL caching
- Two new Lambda functions with API Gateway routes
- Bedrock invoke permissions for self-reflection Lambda
- Content Studio Lambda granted read access to self-reflection table

### Frontend (React + TypeScript)
- New TypeScript types for persona rankings and self-reflection responses
- `usePersonaRankings` and `useSelfReflection` hooks
- Modified `useVisibilityMetrics` and `useBrandMentions` to accept persona filter
- `PersonaSelector` reusable dropdown component
- `PersonaComparisonChart` (Chart.js bar chart, inverted y-axis)
- `SelfReflectionPanel` with structured analysis display and re-analyse button
- Persona selector integrated into Visibility Dashboard and Brand Mentions
- Ranking Analysis tab added to brand detail modal
- Self-reflection icon and persona badge in Content Studio idea cards

### Tests
- Updated `VisibilityDashboard.spec.tsx` for new persona selector (675/675 passing)

## How to test

1. Ensure at least two personas are configured in Settings > Personas
2. Run a fresh analysis
3. Check Visibility Dashboard: persona dropdown and comparison chart
4. Check Brand Mentions: persona dropdown and filtered results
5. Click any brand > Ranking Analysis tab > Analyse Ranking
6. Check Content Studio for self-reflection recommendations

## Notes
- All existing behaviour is preserved when no persona is selected ("All Personas" default)
- Self-reflection results are cached for 24 hours per keyword/brand/persona combination
- The self-reflection feature is industry-agnostic, reading industry from brand config