### PR TITLE
refactor(bedrock): centralize model resolution and retry logic

### DIFF
--- a/lambda/api/content-studio.py
+++ b/lambda/api/content-studio.py
@@ -29,15 +29,13 @@ sys.path.insert(0, '/opt/python')
 from shared.decorators import api_handler, parse_json_body, validate, route_handler
 from shared.api_response import success_response, validation_error, api_response
 from shared.utils import get_brand_config
+from shared.models import ModelRole, get_model_tier, invoke_bedrock, BedrockInvocationError
 from decimal_utils import to_int
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
-
-# Configure Bedrock client - using Converse API which handles timeouts better
-bedrock = boto3.client('bedrock-runtime')
 
 # Fail-fast: Required environment variables
 SEARCH_RESULTS_TABLE = os.environ['DYNAMODB_TABLE_SEARCH_RESULTS']
@@ -598,86 +596,64 @@ POINTS: [3 key takeaways as bullet points]"""
         prompt += f"\n\nIMPORTANT: Write ALL content in {output_language}. The title, meta description, body, headings, and key points must all be in {output_language}."
 
     try:
-        # Using Converse API with global inference profile for cross-region routing
-        # Haiku 4.5 for fast responses - good balance of speed and quality
-        response = bedrock.converse(
-            modelId='global.anthropic.claude-haiku-4-5-20251001-v1:0',
-            messages=[
-                {'role': 'user', 'content': [{'text': prompt}]}
-            ],
-            inferenceConfig={
-                'maxTokens': 8000,
-                'temperature': 0.7
-            }
+        # Invoke shared Bedrock client with GENERATION role (Haiku default, tier-switchable)
+        generated_content = invoke_bedrock(
+            prompt,
+            ModelRole.GENERATION,
+            max_tokens=8000,
+            temperature=0.7,
         )
-        
-        # Extract content from Converse API response
-        output = response.get('output', {})
-        message = output.get('message', {})
-        content_blocks = message.get('content', [])
-        generated_content = content_blocks[0].get('text', '') if content_blocks else ''
-        
+
         parsed = parse_generated_content(generated_content)
-        
+
         return {
             'success': True,
             'content': parsed,
             'raw_content': generated_content,
-            'model': 'claude-haiku-4.5',
+            'model': get_model_tier(ModelRole.GENERATION).value,
             'content_angle': content_angle,
             'competitor_sources_used': len(competitor_content)
         }
-        
-    except bedrock.exceptions.AccessDeniedException as e:
-        logger.error(f"Bedrock access denied: {e}")
-        return {
-            'success': False,
-            'error': 'Access denied to Bedrock model. Check IAM permissions.',
-            'error_type': 'access_denied',
-            'content_angle': content_angle
-        }
-    except bedrock.exceptions.ThrottlingException as e:
-        logger.error(f"Bedrock throttling: {e}")
+
+    except BedrockInvocationError as e:
+        logger.error(f"Bedrock throttled after retries: {e}")
         return {
             'success': False,
             'error': 'Too many requests. Please wait a moment and try again.',
             'error_type': 'throttling',
             'content_angle': content_angle
         }
-    except bedrock.exceptions.ModelTimeoutException as e:
-        logger.error(f"Bedrock model timeout: {e}")
-        return {
-            'success': False,
-            'error': 'AI model took too long to respond. Please try again with a simpler keyword.',
-            'error_type': 'timeout',
-            'content_angle': content_angle
-        }
-    except bedrock.exceptions.ModelErrorException as e:
-        logger.error(f"Bedrock model error: {e}")
-        return {
-            'success': False,
-            'error': 'AI model encountered an error. Please try again.',
-            'error_type': 'model_error',
-            'content_angle': content_angle
-        }
     except Exception as e:
         error_msg = str(e)
         logger.error(f"Bedrock generation failed: {error_msg}", exc_info=True)
-        
-        # Provide user-friendly error messages
-        if 'ValidationException' in error_msg:
+
+        # Provide user-friendly error messages based on AWS error codes in the message
+        if 'AccessDeniedException' in error_msg:
+            user_error = 'Access denied to Bedrock model. Check IAM permissions.'
+            error_type = 'access_denied'
+        elif 'ModelTimeoutException' in error_msg:
+            user_error = 'AI model took too long to respond. Please try again with a simpler keyword.'
+            error_type = 'timeout'
+        elif 'ModelErrorException' in error_msg:
+            user_error = 'AI model encountered an error. Please try again.'
+            error_type = 'model_error'
+        elif 'ValidationException' in error_msg:
             user_error = 'Invalid request to AI model. Please try a different keyword.'
+            error_type = 'generation_error'
         elif 'ServiceUnavailable' in error_msg or 'InternalServerError' in error_msg:
             user_error = 'AI service temporarily unavailable. Please try again later.'
+            error_type = 'generation_error'
         elif 'ResourceNotFoundException' in error_msg:
             user_error = 'AI model not found. Please contact support.'
+            error_type = 'generation_error'
         else:
             user_error = f'Content generation failed: {error_msg[:200]}'
-        
+            error_type = 'generation_error'
+
         return {
             'success': False,
             'error': user_error,
-            'error_type': 'generation_error',
+            'error_type': error_type,
             'content_angle': content_angle
         }
 

--- a/lambda/api/get-recommendations.py
+++ b/lambda/api/get-recommendations.py
@@ -29,48 +29,19 @@ sys.path.insert(0, '/opt/python')
 from shared.decorators import api_handler, validate
 from shared.api_response import success_response
 from shared.utils import get_brand_config
+from shared.models import ModelRole, invoke_bedrock
+from shared.llm_json import parse_llm_json
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
-bedrock = boto3.client('bedrock-runtime')  # No region needed for global inference profiles
 
 # Fail-fast: Required environment variables
 SEARCH_RESULTS_TABLE = os.environ['DYNAMODB_TABLE_SEARCH_RESULTS']
 CITATIONS_TABLE = os.environ['DYNAMODB_TABLE_CITATIONS']
 CRAWLED_CONTENT_TABLE = os.environ['DYNAMODB_TABLE_CRAWLED_CONTENT']
 KEYWORDS_TABLE = os.environ.get('DYNAMODB_TABLE_KEYWORDS')  # Optional for fallback
-
-
-def invoke_converse(prompt: str, model_id: str, max_tokens: int = 2000, temperature: float = 0) -> str:
-    """
-    Invoke Bedrock using the Converse API.
-    
-    Args:
-        prompt: The prompt to send
-        model_id: Model ID to use
-        max_tokens: Maximum tokens in response
-        temperature: Temperature for generation
-        
-    Returns:
-        Response text from the model
-    """
-    response = bedrock.converse(
-        modelId=model_id,
-        messages=[
-            {'role': 'user', 'content': [{'text': prompt}]}
-        ],
-        inferenceConfig={
-            'maxTokens': max_tokens,
-            'temperature': temperature
-        }
-    )
-    
-    output = response.get('output', {})
-    message = output.get('message', {})
-    content_blocks = message.get('content', [])
-    return content_blocks[0].get('text', '') if content_blocks else ''
 
 
 def generate_rule_based_recommendations(config: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -307,14 +278,13 @@ Focus on:
 3. Content and citation opportunities
 4. Provider-specific optimizations"""
 
-        content = invoke_converse(prompt, 'global.anthropic.claude-sonnet-4-5-20250929-v1:0', max_tokens=2000)
-        
-        # Extract JSON from response
-        import re
-        json_match = re.search(r'\[[\s\S]*\]', content)
-        if json_match:
-            return json.loads(json_match.group())
-        
+        content = invoke_bedrock(prompt, ModelRole.ANALYSIS, max_tokens=2000)
+
+        # Parse JSON array via shared helper
+        parsed = parse_llm_json(content, expect="array")
+        if parsed is not None:
+            return parsed
+
     except Exception as e:
         logger.error(f"LLM recommendation error: {e}")
     

--- a/lambda/api/manage-brand-config.py
+++ b/lambda/api/manage-brand-config.py
@@ -19,6 +19,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.decorators import api_handler, parse_json_body, validate, cors_preflight, route_handler
 from shared.api_response import success_response, validation_error
+from shared.llm_json import parse_llm_json
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -27,43 +28,12 @@ logger.setLevel(logging.INFO)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'search'))
 
 dynamodb = boto3.resource('dynamodb')
-bedrock = boto3.client('bedrock-runtime')
+
+# Import centralized Bedrock invocation (ModelRole.ANALYSIS -> Sonnet by default)
+from shared.models import ModelRole, invoke_bedrock  # noqa: E402
 
 # Fail-fast: Required environment variables
 DYNAMODB_TABLE_BRAND_CONFIG = os.environ['DYNAMODB_TABLE_BRAND_CONFIG']
-
-# Model for brand expansion
-EXPANSION_MODEL_ID = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
-
-
-def invoke_converse(prompt: str, model_id: str = EXPANSION_MODEL_ID, max_tokens: int = 2000, temperature: float = 0) -> str:
-    """
-    Invoke Bedrock using the Converse API.
-    
-    Args:
-        prompt: The prompt to send
-        model_id: Model ID to use
-        max_tokens: Maximum tokens in response
-        temperature: Temperature for generation
-        
-    Returns:
-        Response text from the model
-    """
-    response = bedrock.converse(
-        modelId=model_id,
-        messages=[
-            {'role': 'user', 'content': [{'text': prompt}]}
-        ],
-        inferenceConfig={
-            'maxTokens': max_tokens,
-            'temperature': temperature
-        }
-    )
-    
-    output = response.get('output', {})
-    message = output.get('message', {})
-    content_blocks = message.get('content', [])
-    return content_blocks[0].get('text', '') if content_blocks else ''
 
 def generate_default_prompt(industry_name: str, extraction_focus: str, entity_types: list) -> str:
     """Generate a default extraction prompt for an industry."""
@@ -118,7 +88,7 @@ INDUSTRY_PRESETS = {
         "name": "Hotels & Hospitality",
         "description": "Track hotel brands, chains, and individual properties",
         "entity_types": ["hotel chains", "hotel brands", "individual properties", "resorts", "boutique hotels"],
-        "example_brands": ["Brand A", "Brand B", "Brand C", "Brand D", "Brand E"],
+        "example_brands": ["Marriott", "Hilton", "Hyatt", "InterContinental", "Four Seasons"],
         "extraction_focus": "hotel and accommodation recommendations",
         "default_prompt": generate_default_prompt(
             "Hotels & Hospitality",
@@ -320,32 +290,15 @@ If ALL sub-brands are already being tracked, return an empty suggestions array a
 JSON OUTPUT:"""
 
     try:
-        response_text = invoke_converse(prompt, EXPANSION_MODEL_ID, max_tokens=2000, temperature=0)
+        response_text = invoke_bedrock(prompt, ModelRole.ANALYSIS, max_tokens=2000, temperature=0)
         
         if not response_text:
             return {"suggestions": [], "duplicates_found": existing_duplicates, "error": "Empty response"}
         
-        # Parse JSON from response
-        cleaned_text = response_text.strip()
-        if '```' in cleaned_text:
-            start_fence = cleaned_text.find('```')
-            if start_fence != -1:
-                newline_after_fence = cleaned_text.find('\n', start_fence)
-                if newline_after_fence != -1:
-                    cleaned_text = cleaned_text[newline_after_fence + 1:]
-                end_fence = cleaned_text.rfind('```')
-                if end_fence != -1:
-                    cleaned_text = cleaned_text[:end_fence].strip()
-        
-        start_idx = cleaned_text.find('{')
-        end_idx = cleaned_text.rfind('}') + 1
-        
-        if start_idx == -1 or end_idx == 0:
+        result = parse_llm_json(response_text, expect="object")
+        if result is None:
             return {"suggestions": [], "duplicates_found": existing_duplicates, "error": "Invalid response format"}
-        
-        json_str = cleaned_text[start_idx:end_idx]
-        result = json.loads(json_str)
-        
+
         suggestions = result.get("suggestions", [])
         
         # Filter out any suggestions that match existing brands (normalized)
@@ -446,32 +399,15 @@ If all sub-brands are already tracked, return an empty suggestions array with a 
 JSON OUTPUT:"""
 
     try:
-        response_text = invoke_converse(prompt, EXPANSION_MODEL_ID, max_tokens=1500, temperature=0)
+        response_text = invoke_bedrock(prompt, ModelRole.ANALYSIS, max_tokens=1500, temperature=0)
         
         if not response_text:
             return {"main_brand": brand_name, "suggestions": [brand_name], "error": "Empty response"}
         
-        # Parse JSON from response
-        cleaned_text = response_text.strip()
-        if '```' in cleaned_text:
-            start_fence = cleaned_text.find('```')
-            if start_fence != -1:
-                newline_after_fence = cleaned_text.find('\n', start_fence)
-                if newline_after_fence != -1:
-                    cleaned_text = cleaned_text[newline_after_fence + 1:]
-                end_fence = cleaned_text.rfind('```')
-                if end_fence != -1:
-                    cleaned_text = cleaned_text[:end_fence].strip()
-        
-        start_idx = cleaned_text.find('{')
-        end_idx = cleaned_text.rfind('}') + 1
-        
-        if start_idx == -1 or end_idx == 0:
+        result = parse_llm_json(response_text, expect="object")
+        if result is None:
             return {"main_brand": brand_name, "suggestions": [brand_name], "error": "Invalid response format"}
-        
-        json_str = cleaned_text[start_idx:end_idx]
-        result = json.loads(json_str)
-        
+
         # Ensure main_brand is included in suggestions for completeness
         suggestions = result.get("suggestions", [])
         if brand_name not in suggestions:
@@ -559,32 +495,15 @@ Aim for 10-20 relevant competitors.
 JSON OUTPUT:"""
 
     try:
-        response_text = invoke_converse(prompt, EXPANSION_MODEL_ID, max_tokens=2000, temperature=0)
+        response_text = invoke_bedrock(prompt, ModelRole.ANALYSIS, max_tokens=2000, temperature=0)
         
         if not response_text:
             return {"first_party_brands": first_party_brands, "competitors": [], "error": "Empty response"}
         
-        # Parse JSON from response
-        cleaned_text = response_text.strip()
-        if '```' in cleaned_text:
-            start_fence = cleaned_text.find('```')
-            if start_fence != -1:
-                newline_after_fence = cleaned_text.find('\n', start_fence)
-                if newline_after_fence != -1:
-                    cleaned_text = cleaned_text[newline_after_fence + 1:]
-                end_fence = cleaned_text.rfind('```')
-                if end_fence != -1:
-                    cleaned_text = cleaned_text[:end_fence].strip()
-        
-        start_idx = cleaned_text.find('{')
-        end_idx = cleaned_text.rfind('}') + 1
-        
-        if start_idx == -1 or end_idx == 0:
+        result = parse_llm_json(response_text, expect="object")
+        if result is None:
             return {"first_party_brands": first_party_brands, "competitors": [], "error": "Invalid response format"}
-        
-        json_str = cleaned_text[start_idx:end_idx]
-        result = json.loads(json_str)
-        
+
         # Extract just the competitor names
         competitors = result.get("competitors", [])
         competitor_names = [c.get("name") if isinstance(c, dict) else c for c in competitors]

--- a/lambda/crawler/handler.py
+++ b/lambda/crawler/handler.py
@@ -15,6 +15,8 @@ import boto3
 # Import shared modules from Lambda Layer
 from shared.config import LambdaConfig
 from shared.browser_tools import SimpleBrowserTools
+from shared.models import ModelRole, invoke_bedrock
+from shared.llm_json import parse_llm_json
 from shared.step_function_response import (
     step_function_error, step_function_success, log_error
 )
@@ -26,68 +28,9 @@ logger.setLevel(logging.INFO)
 # Initialize config and clients
 config = LambdaConfig()
 dynamodb = boto3.resource('dynamodb', region_name=config.region)
-bedrock_runtime = boto3.client('bedrock-runtime', region_name=config.region)
 
 # Environment variables
 SCREENSHOTS_BUCKET = os.environ['SCREENSHOTS_BUCKET']
-
-
-def invoke_converse_with_retry(prompt: str, model_id: str, max_tokens: int = 1200, temperature: float = 0.3, max_retries: int = 5) -> str:
-    """
-    Invoke Bedrock Converse API with exponential backoff retry logic.
-    
-    Args:
-        prompt: The prompt to send
-        model_id: Model ID to invoke
-        max_tokens: Maximum tokens in response
-        temperature: Temperature for generation
-        max_retries: Maximum number of retry attempts
-        
-    Returns:
-        Response text from the model
-    """
-    import random
-    
-    for attempt in range(max_retries):
-        try:
-            response = bedrock_runtime.converse(
-                modelId=model_id,
-                messages=[
-                    {'role': 'user', 'content': [{'text': prompt}]}
-                ],
-                inferenceConfig={
-                    'maxTokens': max_tokens,
-                    'temperature': temperature
-                }
-            )
-            
-            output = response.get('output', {})
-            message = output.get('message', {})
-            content_blocks = message.get('content', [])
-            return content_blocks[0].get('text', '') if content_blocks else ''
-            
-        except Exception as e:
-            error_str = str(e)
-            
-            # Check if it's a throttling error
-            if 'ThrottlingException' in error_str or 'Too many requests' in error_str:
-                if attempt < max_retries - 1:
-                    # Exponential backoff with jitter
-                    base_delay = 2 ** attempt
-                    jitter = random.uniform(0, 1)
-                    delay = base_delay + jitter
-                    
-                    logger.warning(f"Bedrock throttled (attempt {attempt + 1}/{max_retries}), waiting {delay:.2f}s")
-                    time.sleep(delay)
-                    continue
-                else:
-                    logger.error(f"Bedrock throttled after {max_retries} attempts")
-                    raise
-            else:
-                # Non-throttling error, don't retry
-                raise
-    
-    raise Exception(f"Failed after {max_retries} attempts")
 
 
 def analyze_content_combined(content: str, title: str, url: str, keyword: str) -> tuple[str, Dict[str, Any]]:
@@ -138,8 +81,8 @@ SEO_ANALYSIS:
   "competitive_advantage": "what makes this page rank well"
 }}"""
         
-        # Use retry logic with Converse API
-        response_text = invoke_converse_with_retry(prompt, config.llm_model_id, max_tokens=1200, temperature=0.3)
+        # Use centralized Bedrock invocation (summarization role)
+        response_text = invoke_bedrock(prompt, ModelRole.SUMMARIZATION, max_tokens=1200, temperature=0.3)
         
         # Parse summary
         summary = ""
@@ -150,101 +93,18 @@ SEO_ANALYSIS:
                 summary_end = response_text.find("{")
             summary = response_text[summary_start:summary_end].strip()
         
-        # Parse SEO analysis JSON
-        seo_analysis = {}
-        try:
-            start_idx = response_text.find('{')
-            end_idx = response_text.rfind('}') + 1
-            if start_idx != -1 and end_idx > start_idx:
-                json_str = response_text[start_idx:end_idx]
-                seo_analysis = json.loads(json_str)
-        except json.JSONDecodeError as e:
-            logger.warning(f"Could not parse SEO JSON for {url}: {e}")
-        
+        # Parse SEO analysis JSON via shared helper (handles markdown fences,
+        # truncation, and wrong-type responses consistently with other lambdas)
+        seo_analysis = parse_llm_json(response_text, expect="object") or {}
+        if not seo_analysis:
+            logger.warning(f"Could not parse SEO JSON for {url}")
+
         logger.info(f"Combined analysis completed for {url}")
         return summary, seo_analysis
         
     except Exception as e:
         logger.error(f"Error in combined analysis for {url}: {e}")
         return "", {}
-
-
-def summarize_content(content: str, url: str) -> str:
-    """
-    DEPRECATED: Use analyze_content_combined() instead.
-    Kept for backward compatibility.
-    """
-    try:
-        summary, _ = analyze_content_combined(content, "", url, "")
-        return summary
-    except Exception as e:
-        logger.error(f"Error generating summary for {url}: {e}")
-        return ""
-
-
-def analyze_seo(content: str, title: str, url: str, keyword: str) -> Dict[str, Any]:
-    """
-    Analyze page for SEO and competitive intelligence using Claude.
-    
-    Args:
-        content: Page content
-        title: Page title
-        url: URL of the page
-        keyword: Search keyword that led to this citation
-        
-    Returns:
-        Dictionary with SEO analysis and recommendations
-    """
-    try:
-        logger.info(f"Analyzing SEO for {url}")
-        
-        # Truncate content
-        max_content_length = 8000
-        truncated_content = content[:max_content_length] if len(content) > max_content_length else content
-        
-        prompt = f"""Analyze this web page for SEO and competitive intelligence.
-
-URL: {url}
-Title: {title}
-Search Keyword: "{keyword}"
-
-Content:
-{truncated_content}
-
-Provide analysis in JSON format:
-{{
-  "relevance_score": 1-10,
-  "keyword_usage": "description of how keyword is used",
-  "strengths": ["strength 1", "strength 2", "strength 3"],
-  "weaknesses": ["weakness 1", "weakness 2"],
-  "recommendations": ["action 1", "action 2", "action 3"],
-  "competitive_advantage": "what makes this page rank well"
-}}
-
-JSON:"""
-        
-        response_text = invoke_converse_with_retry(prompt, config.llm_model_id, max_tokens=1000, temperature=0.2)
-        
-        # Parse JSON from response
-        try:
-            # Extract JSON from response
-            start_idx = response_text.find('{')
-            end_idx = response_text.rfind('}') + 1
-            if start_idx != -1 and end_idx > start_idx:
-                json_str = response_text[start_idx:end_idx]
-                analysis = json.loads(json_str)
-                logger.info(f"SEO analysis completed for {url}")
-                return analysis
-            else:
-                logger.warning(f"Could not parse JSON from SEO analysis for {url}")
-                return {}
-        except json.JSONDecodeError as e:
-            logger.error(f"JSON parse error in SEO analysis: {e}")
-            return {}
-        
-    except Exception as e:
-        logger.error(f"Error analyzing SEO for {url}: {e}")
-        return {}
 
 
 def upload_screenshot_to_s3(screenshot_base64: str, url: str, timestamp: str) -> str:

--- a/lambda/generate-summary/handler.py
+++ b/lambda/generate-summary/handler.py
@@ -18,8 +18,6 @@ from shared.step_function_response import (
     step_function_error, step_function_success, log_error
 )
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)# Configure logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 

--- a/lambda/search/brand_extractor.py
+++ b/lambda/search/brand_extractor.py
@@ -9,69 +9,15 @@ not exact string matching. This allows the LLM to understand brand hierarchies
 (e.g., sub-brands belonging to parent companies).
 """
 
-import json
 import logging
-import os
-import time
-import boto3
 from typing import List, Dict, Any, Optional
 
 # Import shared utilities from Lambda layer
 from shared.utils import get_brand_config
+from shared.models import ModelRole, invoke_bedrock
+from shared.llm_json import parse_llm_json
 
 logger = logging.getLogger(__name__)
-
-# Initialize AWS clients - no region needed for global inference profiles
-bedrock = boto3.client('bedrock-runtime')
-
-# Use Haiku 4.5 for brand extraction - same model used in content-studio
-DEFAULT_MODEL_ID = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
-
-
-def invoke_converse(prompt: str, model_id: str = DEFAULT_MODEL_ID, max_tokens: int = 2000, temperature: float = 0, max_retries: int = 3) -> str:
-    """
-    Invoke Bedrock using the Converse API with retry logic.
-    
-    Args:
-        prompt: The prompt to send
-        model_id: Model ID to use
-        max_tokens: Maximum tokens in response
-        temperature: Temperature for generation
-        max_retries: Maximum number of retry attempts for throttling errors
-        
-    Returns:
-        Response text from the model
-    """
-    for attempt in range(max_retries):
-        try:
-            logger.info(f"Invoking Bedrock Converse API with model: {model_id} (attempt {attempt + 1}/{max_retries})")
-            response = bedrock.converse(
-                modelId=model_id,
-                messages=[
-                    {'role': 'user', 'content': [{'text': prompt}]}
-                ],
-                inferenceConfig={
-                    'maxTokens': max_tokens,
-                    'temperature': temperature
-                }
-            )
-            
-            output = response.get('output', {})
-            message = output.get('message', {})
-            content_blocks = message.get('content', [])
-            result = content_blocks[0].get('text', '') if content_blocks else ''
-            logger.info(f"Bedrock response received, length: {len(result)} chars")
-            return result
-        except Exception as e:
-            error_str = str(e)
-            is_throttle = 'ThrottlingException' in error_str or 'TooManyRequestsException' in error_str or 'ServiceUnavailableException' in error_str
-            if is_throttle and attempt < max_retries - 1:
-                wait_time = (2 ** attempt) + 1
-                logger.warning(f"Bedrock throttled (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s: {error_str}")
-                time.sleep(wait_time)
-                continue
-            logger.error(f"Bedrock Converse API call failed: {error_str}")
-            raise
 
 # Industry presets with pre-built extraction prompts
 INDUSTRY_PRESETS = {
@@ -79,7 +25,7 @@ INDUSTRY_PRESETS = {
         "name": "Hotels & Hospitality",
         "description": "Track hotel brands, chains, and individual properties",
         "entity_types": ["hotel chains", "hotel brands", "individual properties", "resorts", "boutique hotels"],
-        "example_brands": ["Brand A", "Brand B", "Brand C", "Brand D", "Brand E"],
+        "example_brands": ["Marriott", "Hilton", "Hyatt", "InterContinental", "Four Seasons"],
         "extraction_focus": "hotel and accommodation recommendations"
     },
     "restaurants": {
@@ -159,8 +105,12 @@ DEFAULT_EXTRACTION_CONFIG = {
 class LLMBrandExtractor:
     """Extract brand mentions using LLM for intelligent parsing and classification."""
     
-    def __init__(self, model_id: str = DEFAULT_MODEL_ID, config: Optional[Dict] = None):
-        self.model_id = model_id
+    def __init__(self, model_id: Optional[str] = None, config: Optional[Dict] = None):
+        # model_id is accepted for backward compatibility but ignored.
+        # Model resolution now flows through shared.models.ModelRole.EXTRACTION.
+        if model_id is not None:
+            logger.debug("model_id argument to LLMBrandExtractor is ignored; "
+                         "models are resolved via shared.models.ModelRole.EXTRACTION")
         # Use default config if None or empty dict
         self.config = config if config else DEFAULT_EXTRACTION_CONFIG
         self.industry = self.config.get("industry", "hotels")
@@ -182,8 +132,8 @@ class LLMBrandExtractor:
         prompt = self._build_extraction_prompt(text)
         
         try:
-            # Call Bedrock using Converse API
-            response_text = invoke_converse(prompt, self.model_id, max_tokens=4000, temperature=0)
+            # Call shared Bedrock client with EXTRACTION role
+            response_text = invoke_bedrock(prompt, ModelRole.EXTRACTION, max_tokens=4000, temperature=0)
             
             if not response_text:
                 logger.warning("Empty response from Bedrock")
@@ -331,66 +281,15 @@ JSON OUTPUT:"""
         return brands
     
     def _parse_llm_response(self, response_text: str) -> List[Dict[str, Any]]:
-        """Parse the LLM's JSON response."""
-        try:
-            cleaned_text = response_text.strip()
-            
-            # Handle markdown code blocks (with or without language specifier)
-            if '```' in cleaned_text:
-                # Find content between first ``` and last ```
-                start_fence = cleaned_text.find('```')
-                if start_fence != -1:
-                    newline_after_fence = cleaned_text.find('\n', start_fence)
-                    if newline_after_fence != -1:
-                        after_fence = cleaned_text[newline_after_fence + 1:]
-                    else:
-                        after_fence = cleaned_text[start_fence + 3:]
-                    # Remove closing fence if present
-                    end_fence = after_fence.rfind('```')
-                    if end_fence != -1:
-                        cleaned_text = after_fence[:end_fence].strip()
-                    else:
-                        # No closing fence (truncated response) — use everything after opening fence
-                        cleaned_text = after_fence.strip()
-            
-            # Try to extract JSON array from response
-            start_idx = cleaned_text.find('[')
-            end_idx = cleaned_text.rfind(']') + 1
-            
-            if start_idx == -1:
-                logger.warning(f"No JSON array found in LLM response. Cleaned text preview: {cleaned_text[:300]}")
-                logger.warning(f"Original response preview: {response_text[:300]}")
-                return []
-            
-            if end_idx == 0:
-                # No closing bracket — response was likely truncated by max_tokens
-                # Try to salvage by finding the last complete JSON object
-                logger.warning("JSON array not closed (likely truncated). Attempting to salvage partial response.")
-                partial = cleaned_text[start_idx:]
-                # Find the last complete object (ends with })
-                last_brace = partial.rfind('}')
-                if last_brace != -1:
-                    json_str = partial[:last_brace + 1] + ']'
-                    logger.info(f"Salvaged partial JSON: {len(json_str)} chars")
-                else:
-                    logger.warning("Could not salvage truncated JSON response")
-                    return []
-            else:
-                json_str = cleaned_text[start_idx:end_idx]
-            
-            brands = json.loads(json_str)
-            
-            # Validate structure
-            if not isinstance(brands, list):
-                logger.warning("LLM response is not a list")
-                return []
-            
-            return brands
-            
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse LLM JSON response: {str(e)}")
-            logger.error(f"Response text preview: {response_text[:500]}")
+        """Parse the LLM's JSON array response via the shared helper."""
+        brands = parse_llm_json(response_text, expect="array")
+        if brands is None:
+            logger.warning(
+                "brand_extraction_parse_failed preview=%r",
+                response_text[:300],
+            )
             return []
+        return brands
 
 
 def get_industry_presets() -> Dict[str, Any]:
@@ -435,102 +334,3 @@ def extract_brands_from_response(response_text: str, config: Optional[Dict] = No
         'other_count': len(others),
         'extraction_config': config or DEFAULT_EXTRACTION_CONFIG
     }
-
-
-def expand_brand_names(brand_name: str, industry: str = "hotels") -> Dict[str, Any]:
-    """
-    Use LLM to expand a brand name into related sub-brands, variations, and owned properties.
-    
-    This helps users configure comprehensive brand tracking by suggesting all the
-    brand variations that should be tracked together.
-    
-    Args:
-        brand_name: The main brand name to expand
-        industry: The industry context for better suggestions
-    
-    Returns:
-        Dict with 'suggestions' (list of related brand names) and metadata
-    """
-    industry_preset = INDUSTRY_PRESETS.get(industry, INDUSTRY_PRESETS.get("custom", {}))
-    industry_name = industry_preset.get("name", "General")
-    
-    prompt = f"""You are a brand expert for the {industry_name} industry.
-
-Given the brand name "{brand_name}", list ALL related brand names that should be tracked together.
-
-Include:
-1. Sub-brands and brand tiers
-2. Owned/acquired brands and subsidiaries
-3. Common variations, abbreviations, and alternate spellings
-4. Loyalty program names if relevant
-5. Regional variations if any
-
-DO NOT include:
-- Competitor brands
-- Unrelated companies
-- Generic terms
-
-Return ONLY a JSON object with this format:
-{{
-  "main_brand": "{brand_name}",
-  "parent_company": "Parent company name if different from main brand, or null",
-  "suggestions": [
-    "Sub-brand 1",
-    "Sub-brand 2",
-    "Owned brand 1"
-  ],
-  "notes": "Brief explanation of the brand structure"
-}}
-
-JSON OUTPUT:"""
-
-    try:
-        # Call Bedrock using Converse API
-        response_text = invoke_converse(prompt, DEFAULT_MODEL_ID, max_tokens=1500, temperature=0)
-        
-        if not response_text:
-            logger.warning("Empty response from Bedrock for brand expansion")
-            return {"main_brand": brand_name, "suggestions": [], "error": "Empty response"}
-        
-        # Parse JSON from response
-        cleaned_text = response_text.strip()
-        if '```' in cleaned_text:
-            start_fence = cleaned_text.find('```')
-            if start_fence != -1:
-                newline_after_fence = cleaned_text.find('\n', start_fence)
-                if newline_after_fence != -1:
-                    cleaned_text = cleaned_text[newline_after_fence + 1:]
-                end_fence = cleaned_text.rfind('```')
-                if end_fence != -1:
-                    cleaned_text = cleaned_text[:end_fence].strip()
-        
-        start_idx = cleaned_text.find('{')
-        end_idx = cleaned_text.rfind('}') + 1
-        
-        if start_idx == -1 or end_idx == 0:
-            logger.warning(f"No JSON object found in brand expansion response")
-            return {"main_brand": brand_name, "suggestions": [], "error": "Invalid response format"}
-        
-        json_str = cleaned_text[start_idx:end_idx]
-        result = json.loads(json_str)
-        
-        # Ensure main_brand is included in suggestions for completeness
-        suggestions = result.get("suggestions", [])
-        if brand_name not in suggestions:
-            suggestions.insert(0, brand_name)
-        
-        return {
-            "main_brand": brand_name,
-            "parent_company": result.get("parent_company"),
-            "suggestions": suggestions,
-            "notes": result.get("notes", ""),
-            "industry": industry
-        }
-        
-    except Exception as e:
-        logger.error(f"Error expanding brand name '{brand_name}': {str(e)}")
-        return {
-            "main_brand": brand_name,
-            "suggestions": [brand_name],
-            "error": str(e)
-        }

--- a/lambda/search/handler.py
+++ b/lambda/search/handler.py
@@ -172,18 +172,27 @@ def get_secret(secret_name: str) -> Optional[str]:
 
 
 def is_provider_enabled(provider_id: str) -> bool:
-    """Check if a provider is enabled in the config table."""
+    """Check if a provider is enabled in the config table.
+
+    Fails closed: if the config table is unavailable, return False so we do
+    not accidentally invoke a provider the user has disabled. A transient
+    DynamoDB failure should not override user intent.
+    """
     try:
         table = dynamodb.Table(PROVIDER_CONFIG_TABLE)
         response = table.get_item(Key={'provider_id': provider_id})
         item = response.get('Item')
         if item:
             return item.get('enabled', True)
-        # Default to enabled if no config exists
+        # No config row yet -> treat as enabled (first-run default)
         return True
     except Exception as e:
-        logger.warning(f"Error checking provider config for {provider_id}: {str(e)}, defaulting to enabled")
-        return True
+        logger.error(
+            "provider_config_read_failed provider=%s error=%s action=fail_closed",
+            provider_id,
+            type(e).__name__,
+        )
+        return False
 
 # Default models per provider (used when no override in ProviderConfig table)
 DEFAULT_PROVIDER_MODELS = {
@@ -196,11 +205,19 @@ DEFAULT_PROVIDER_MODELS = {
 # Cache for provider models (per Lambda invocation)
 _provider_model_cache = {}
 
+class ProviderConfigUnavailableError(RuntimeError):
+    """Raised when provider config cannot be read and no safe default exists."""
+
+
 def get_provider_model(provider_id: str) -> str:
     """Get configured model for a provider, with sensible defaults.
 
     Reads the 'model' field from the ProviderConfig table if set,
     otherwise falls back to DEFAULT_PROVIDER_MODELS.
+
+    Fails closed: raises ProviderConfigUnavailableError on DynamoDB errors
+    so the caller can skip the provider rather than silently using a
+    different model than the admin configured.
     """
     if provider_id in _provider_model_cache:
         return _provider_model_cache[provider_id]
@@ -217,9 +234,14 @@ def get_provider_model(provider_id: str) -> str:
         logger.info(f"Provider {provider_id} using model: {model}")
         return model
     except Exception as e:
-        logger.warning(f"Error reading model config for {provider_id}: {e}, using default: {default}")
-        _provider_model_cache[provider_id] = default
-        return default
+        logger.error(
+            "provider_model_read_failed provider=%s error=%s action=fail_closed",
+            provider_id,
+            type(e).__name__,
+        )
+        raise ProviderConfigUnavailableError(
+            f"Cannot read model config for provider {provider_id}"
+        ) from e
 
 
 
@@ -577,8 +599,11 @@ def execute_all_providers(keyword: str, provider_types: Optional[List[str]] = No
     if run_llm:
         if openai_key and is_provider_enabled(Provider.OPENAI) and should_run_provider(Provider.OPENAI):
             logger.info("Querying OpenAI...")
-            openai_model = get_provider_model(Provider.OPENAI)
-            results.append(query_openai(keyword, openai_key, model=openai_model, query_template=query_template))
+            try:
+                openai_model = get_provider_model(Provider.OPENAI)
+                results.append(query_openai(keyword, openai_key, model=openai_model, query_template=query_template))
+            except ProviderConfigUnavailableError:
+                logger.error("OpenAI provider config unavailable, skipping this run")
         elif openai_key and should_run_provider(Provider.OPENAI):
             logger.info("OpenAI is disabled, skipping")
         elif should_run_provider(Provider.OPENAI):
@@ -860,4 +885,3 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     except Exception as e:
         log_error(e, f"search handler for keyword {event.get('keyword', 'unknown')}", event)
         raise
-# Force rebuild

--- a/lambda/search/test_handler_prompts.py
+++ b/lambda/search/test_handler_prompts.py
@@ -85,16 +85,21 @@ class TestGetProviderModel:
             # Should only call DynamoDB once
             assert mock_table.get_item.call_count == 1
 
-    def test_falls_back_on_error(self, mock_dynamodb):
-        """Returns default model when DynamoDB read fails."""
+    def test_raises_when_dynamodb_fails(self, mock_dynamodb):
+        """Fails closed: raises instead of silently substituting the default.
+
+        A transient DynamoDB error must not cause us to invoke a different
+        model than the admin configured. The caller is expected to catch
+        and skip the provider for this run.
+        """
         mock_db, mock_table = mock_dynamodb
         mock_table.get_item.side_effect = Exception('DynamoDB error')
 
         with patch('handler.dynamodb', mock_db):
             import handler
             handler._provider_model_cache.clear()
-            result = handler.get_provider_model('openai')
-            assert result == 'gpt-5-mini'
+            with pytest.raises(handler.ProviderConfigUnavailableError):
+                handler.get_provider_model('openai')
 
     def test_default_models_for_all_providers(self, mock_dynamodb):
         """Each provider has a sensible default model."""
@@ -110,6 +115,77 @@ class TestGetProviderModel:
             assert handler.get_provider_model('perplexity') == 'sonar'
             handler._provider_model_cache.clear()
             assert handler.get_provider_model('gemini') == 'gemini-3-flash-preview'
+
+
+class TestIsProviderEnabled:
+    """Tests for is_provider_enabled() — fail-closed on config read errors.
+
+    Regression guard: a prior version returned True on DynamoDB errors, which
+    meant a transient outage could silently run a provider the admin disabled.
+    User intent (the disable flag) must win over infra failures.
+    """
+
+    def test_returns_true_when_config_item_has_enabled_true(self, mock_dynamodb):
+        mock_db, mock_table = mock_dynamodb
+        mock_table.get_item.return_value = {
+            'Item': {'provider_id': 'openai', 'enabled': True}
+        }
+
+        with patch('handler.dynamodb', mock_db):
+            import handler
+            assert handler.is_provider_enabled('openai') is True
+
+    def test_returns_false_when_config_item_has_enabled_false(self, mock_dynamodb):
+        mock_db, mock_table = mock_dynamodb
+        mock_table.get_item.return_value = {
+            'Item': {'provider_id': 'openai', 'enabled': False}
+        }
+
+        with patch('handler.dynamodb', mock_db):
+            import handler
+            assert handler.is_provider_enabled('openai') is False
+
+    def test_returns_true_when_no_config_row_exists(self, mock_dynamodb):
+        """First-run default: no row yet means the provider is enabled."""
+        mock_db, mock_table = mock_dynamodb
+        mock_table.get_item.return_value = {}
+
+        with patch('handler.dynamodb', mock_db):
+            import handler
+            assert handler.is_provider_enabled('openai') is True
+
+    def test_returns_false_when_dynamodb_read_fails(self, mock_dynamodb):
+        """Fails closed: a DynamoDB outage must not override a user disable.
+
+        Reverting this to the old fail-open behavior would make this test fail.
+        """
+        mock_db, mock_table = mock_dynamodb
+        mock_table.get_item.side_effect = Exception('DynamoDB ThrottlingException')
+
+        with patch('handler.dynamodb', mock_db):
+            import handler
+            assert handler.is_provider_enabled('openai') is False
+
+    def test_does_not_leak_exception_details_in_log_message(
+        self, mock_dynamodb, caplog,
+    ):
+        """Logs error type only, not the full str(e) which can contain table
+        names or other infra details."""
+        import logging
+
+        mock_db, mock_table = mock_dynamodb
+        mock_table.get_item.side_effect = RuntimeError('Sensitive: table arn:aws:dynamodb:...')
+
+        with patch('handler.dynamodb', mock_db):
+            import handler
+            with caplog.at_level(logging.ERROR, logger='handler'):
+                handler.is_provider_enabled('openai')
+
+        assert any(
+            'provider_config_read_failed' in record.message
+            and 'Sensitive' not in record.message
+            for record in caplog.records
+        )
 
 
 class TestQueryOpenAIModel:

--- a/lambda/shared/config.py
+++ b/lambda/shared/config.py
@@ -70,10 +70,10 @@ class LambdaConfig:
     
     # AWS Configuration
     region: str = os.environ.get("AWS_REGION", "us-west-2")
-    
-    # LLM Model for summarization (configurable via environment variable)
-    llm_model_id: str = os.environ.get('BEDROCK_MODEL_ID', 'global.anthropic.claude-sonnet-4-5-20250929-v1:0')
-    
+
+    # Note: LLM model IDs are resolved via shared.models (ModelRole + ModelTier).
+    # Env overrides: BEDROCK_MODEL_<ROLE> or BEDROCK_TIER_<ROLE>.
+
     # Get AWS Account ID automatically
     @property
     def aws_account_id(self) -> str:

--- a/lambda/shared/llm_json.py
+++ b/lambda/shared/llm_json.py
@@ -1,0 +1,134 @@
+"""
+Shared helpers for parsing JSON out of LLM text responses.
+
+LLMs wrap JSON in varied ways: markdown fences with or without a language tag,
+prose before and after, and sometimes truncated output that cuts off mid-array.
+This module centralizes the cleanup and parsing logic so every Lambda gets the
+same behavior and the same bug fixes.
+
+Two entry points:
+- parse_llm_json(text, expect="object") -> dict | None
+- parse_llm_json(text, expect="array")  -> list | None
+
+Both return None on unrecoverable parse failures. The caller logs context and
+decides how to react; this module does not raise for bad input because LLM
+output is expected to be fuzzy and callers already have graceful fallbacks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+JsonLike = Union[dict, list]
+
+
+def _strip_code_fences(text: str) -> str:
+    """Remove surrounding markdown code fences (```json ... ``` or ``` ... ```).
+
+    Handles the common cases:
+      - full fenced block: ```json\n{...}\n```
+      - fenced without language: ```\n{...}\n```
+      - unclosed fence (LLM truncated by max_tokens)
+    """
+    cleaned = text.strip()
+    if "```" not in cleaned:
+        return cleaned
+
+    start_fence = cleaned.find("```")
+    if start_fence == -1:
+        return cleaned
+
+    # Drop everything up to the first newline after the opening fence (skips
+    # optional language tag like ```json).
+    newline_after_fence = cleaned.find("\n", start_fence)
+    if newline_after_fence != -1:
+        after_fence = cleaned[newline_after_fence + 1 :]
+    else:
+        after_fence = cleaned[start_fence + 3 :]
+
+    end_fence = after_fence.rfind("```")
+    if end_fence != -1:
+        return after_fence[:end_fence].strip()
+    # No closing fence — LLM likely truncated. Keep the body we have.
+    return after_fence.strip()
+
+
+def _extract_array(cleaned: str) -> Optional[str]:
+    """Return a best-effort JSON array substring, salvaging truncated output."""
+    start_idx = cleaned.find("[")
+    if start_idx == -1:
+        return None
+
+    end_idx = cleaned.rfind("]") + 1
+    if end_idx > 0:
+        return cleaned[start_idx:end_idx]
+
+    # Unclosed array — try to salvage by closing after the last complete object.
+    partial = cleaned[start_idx:]
+    last_brace = partial.rfind("}")
+    if last_brace == -1:
+        return None
+    return partial[: last_brace + 1] + "]"
+
+
+def _extract_object(cleaned: str) -> Optional[str]:
+    """Return a JSON object substring, or None if braces aren't balanced enough."""
+    start_idx = cleaned.find("{")
+    if start_idx == -1:
+        return None
+    end_idx = cleaned.rfind("}") + 1
+    if end_idx == 0:
+        return None
+    return cleaned[start_idx:end_idx]
+
+
+def parse_llm_json(
+    text: str,
+    expect: Literal["object", "array"] = "object",
+) -> Optional[JsonLike]:
+    """Parse JSON from an LLM response, tolerating code fences and prose.
+
+    Args:
+        text: Raw LLM response text.
+        expect: "object" for a JSON object response, "array" for a JSON array.
+
+    Returns:
+        Parsed dict/list on success. None on any failure (empty input, no JSON
+        found, malformed JSON, or wrong top-level type).
+    """
+    if not text:
+        return None
+
+    cleaned = _strip_code_fences(text)
+    candidate = _extract_array(cleaned) if expect == "array" else _extract_object(cleaned)
+    if candidate is None:
+        logger.warning(
+            "llm_json_no_%s_found preview=%r",
+            expect,
+            cleaned[:300],
+        )
+        return None
+
+    try:
+        parsed: Any = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "llm_json_parse_failed expect=%s error=%s preview=%r",
+            expect,
+            exc,
+            candidate[:300],
+        )
+        return None
+
+    if expect == "array" and not isinstance(parsed, list):
+        logger.warning("llm_json_expected_array got=%s", type(parsed).__name__)
+        return None
+    if expect == "object" and not isinstance(parsed, dict):
+        logger.warning("llm_json_expected_object got=%s", type(parsed).__name__)
+        return None
+
+    return parsed

--- a/lambda/shared/models.py
+++ b/lambda/shared/models.py
@@ -1,0 +1,208 @@
+"""
+Centralized Bedrock model resolution and invocation.
+
+Single source of truth for:
+- Bedrock Anthropic global inference profile IDs
+- Role-to-tier mapping (SUMMARIZATION/EXTRACTION/GENERATION/ANALYSIS)
+- Tier definitions (FAST/BALANCED/DEEP -> Haiku/Sonnet/Opus)
+- Extended thinking budget per tier
+- Shared Converse invocation with retry/backoff
+
+Resolution order for model ID:
+1. Direct per-role override env var:  BEDROCK_MODEL_<ROLE>
+2. Per-role tier override env var:    BEDROCK_TIER_<ROLE>  (fast|balanced|deep)
+3. Hardcoded role-default tier
+
+Resolution order for thinking budget:
+1. Explicit `thinking` arg passed to invoke_bedrock()
+2. Tier default from _TIER_THINKING
+
+Note on inference profile IDs (verified via `aws bedrock list-inference-profiles`):
+AWS uses inconsistent ID formats. Some profiles include the `-YYYYMMDD-v1:0`
+suffix (Haiku 4.5), others do not (Sonnet 4.6, Opus 4.7). Treat the strings
+as opaque identifiers — do not parse or regex over them.
+"""
+
+import logging
+import os
+import random
+import time
+from enum import Enum
+from typing import Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+class ModelRole(str, Enum):
+    """Task-specific role for a Bedrock call."""
+
+    SUMMARIZATION = "summarization"  # Crawler page summaries + SEO extraction
+    EXTRACTION = "extraction"        # Brand mention extraction
+    GENERATION = "generation"        # Content studio article generation
+    ANALYSIS = "analysis"            # Recommendations, brand expansion, reasoning
+
+
+class ModelTier(str, Enum):
+    """Capability tier that maps to a specific model family."""
+
+    FAST = "fast"          # Haiku — low latency, low cost
+    BALANCED = "balanced"  # Sonnet — good reasoning, moderate latency
+    DEEP = "deep"          # Opus — deep reasoning, higher latency
+
+
+# Current global inference profile IDs (verified 2026-04-17).
+# To upgrade a family, change the single line here and redeploy.
+_TIER_MODELS: dict[ModelTier, str] = {
+    ModelTier.FAST: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    ModelTier.BALANCED: "global.anthropic.claude-sonnet-4-6",
+    ModelTier.DEEP: "global.anthropic.claude-opus-4-7",
+}
+
+# Role -> default tier. Overridable per-role via BEDROCK_TIER_<ROLE>.
+_ROLE_DEFAULT_TIER: dict[ModelRole, ModelTier] = {
+    ModelRole.SUMMARIZATION: ModelTier.FAST,
+    ModelRole.EXTRACTION: ModelTier.FAST,
+    ModelRole.GENERATION: ModelTier.FAST,
+    ModelRole.ANALYSIS: ModelTier.BALANCED,
+}
+
+# Extended thinking budget (tokens) per tier. 0 disables thinking.
+# Only Sonnet/Opus support extended thinking; Haiku ignores the field.
+_TIER_THINKING_BUDGET: dict[ModelTier, int] = {
+    ModelTier.FAST: 0,
+    ModelTier.BALANCED: 2000,
+    ModelTier.DEEP: 8000,
+}
+
+# Throttling error class names that should trigger retry.
+_THROTTLE_ERRORS = (
+    "ThrottlingException",
+    "TooManyRequestsException",
+    "ServiceUnavailableException",
+)
+
+
+def _resolve_tier(role: ModelRole) -> ModelTier:
+    """Resolve tier for a role: env override wins, else role default."""
+    override = os.environ.get(f"BEDROCK_TIER_{role.value.upper()}")
+    if override:
+        try:
+            return ModelTier(override.lower())
+        except ValueError:
+            logger.warning(
+                "Invalid BEDROCK_TIER_%s value %r, falling back to default",
+                role.value.upper(),
+                override,
+            )
+    return _ROLE_DEFAULT_TIER[role]
+
+
+def get_model_id(role: ModelRole) -> str:
+    """Resolve the Bedrock model ID for a given role."""
+    direct = os.environ.get(f"BEDROCK_MODEL_{role.value.upper()}")
+    if direct:
+        return direct
+    return _TIER_MODELS[_resolve_tier(role)]
+
+
+def get_model_tier(role: ModelRole) -> ModelTier:
+    """Resolve the active tier for a role (useful for response metadata)."""
+    return _resolve_tier(role)
+
+
+# Lazily initialized module-level Bedrock client. No region needed for
+# global inference profiles.
+_bedrock_client = None
+
+
+def _get_bedrock_client():
+    global _bedrock_client
+    if _bedrock_client is None:
+        _bedrock_client = boto3.client("bedrock-runtime")
+    return _bedrock_client
+
+
+class BedrockInvocationError(RuntimeError):
+    """Raised when Bedrock invocation fails after all retries."""
+
+
+def invoke_bedrock(
+    prompt: str,
+    role: ModelRole,
+    max_tokens: int = 2000,
+    temperature: float = 0.0,
+    max_retries: int = 5,
+    thinking: Optional[bool] = None,
+) -> str:
+    """
+    Invoke Bedrock Converse API with exponential backoff on throttling.
+
+    Args:
+        prompt: User prompt text.
+        role: Task role; drives model + default tier.
+        max_tokens: Maximum response tokens.
+        temperature: Sampling temperature (0.0 = deterministic).
+        max_retries: Total attempts before giving up on throttling.
+        thinking: If True, force extended thinking on (uses tier budget).
+                  If False, force off. If None (default), use tier budget.
+
+    Returns:
+        Response text. Empty string if the model returns no text blocks.
+
+    Raises:
+        BedrockInvocationError: if all retries are exhausted on throttling.
+        Exception: non-throttling errors propagate unchanged.
+    """
+    model_id = get_model_id(role)
+    tier = _resolve_tier(role)
+    tier_budget = _TIER_THINKING_BUDGET[tier]
+
+    if thinking is True:
+        budget = tier_budget if tier_budget > 0 else _TIER_THINKING_BUDGET[ModelTier.BALANCED]
+    elif thinking is False:
+        budget = 0
+    else:
+        budget = tier_budget
+
+    client = _get_bedrock_client()
+    request_kwargs: dict = {
+        "modelId": model_id,
+        "messages": [{"role": "user", "content": [{"text": prompt}]}],
+        "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
+    }
+    if budget > 0:
+        request_kwargs["additionalModelRequestFields"] = {
+            "thinking": {"type": "enabled", "budget_tokens": budget}
+        }
+
+    for attempt in range(max_retries):
+        try:
+            response = client.converse(**request_kwargs)
+            content_blocks = (
+                response.get("output", {}).get("message", {}).get("content", [])
+            )
+            for block in content_blocks:
+                if "text" in block:
+                    return block["text"]
+            return ""
+        except Exception as exc:  # noqa: BLE001 — boto3 surfaces many types
+            error_str = str(exc)
+            is_throttle = any(name in error_str for name in _THROTTLE_ERRORS)
+            if is_throttle and attempt < max_retries - 1:
+                delay = (2 ** attempt) + random.uniform(0, 1)
+                logger.warning(
+                    "Bedrock throttled (model=%s attempt=%d/%d), sleeping %.2fs",
+                    model_id,
+                    attempt + 1,
+                    max_retries,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            raise
+
+    raise BedrockInvocationError(
+        f"Bedrock invocation failed after {max_retries} attempts for model {model_id}"
+    )

--- a/lambda/shared/test_llm_json.py
+++ b/lambda/shared/test_llm_json.py
@@ -1,0 +1,87 @@
+"""
+Tests for shared.llm_json — tolerant JSON parsing of LLM responses.
+
+Covers:
+- Happy path: clean JSON object / array
+- Markdown code fences with and without language tag
+- Unclosed fences (LLM truncation) salvaged
+- Extra prose before and after JSON
+- Truncated arrays salvaged via last-complete-object recovery
+- Wrong top-level type returns None
+- Empty / None / malformed input returns None
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from llm_json import parse_llm_json
+
+
+class TestObjectParsing:
+    def test_returns_dict_for_clean_object(self) -> None:
+        assert parse_llm_json('{"a": 1}') == {"a": 1}
+
+    def test_strips_markdown_fence_with_json_language_tag(self) -> None:
+        text = '```json\n{"a": 1}\n```'
+        assert parse_llm_json(text) == {"a": 1}
+
+    def test_strips_markdown_fence_without_language_tag(self) -> None:
+        text = '```\n{"a": 1}\n```'
+        assert parse_llm_json(text) == {"a": 1}
+
+    def test_ignores_prose_before_and_after_object(self) -> None:
+        text = 'Here is the JSON:\n{"a": 1}\nLet me know if you need more.'
+        assert parse_llm_json(text) == {"a": 1}
+
+    def test_salvages_unclosed_fence_with_valid_object(self) -> None:
+        text = '```json\n{"a": 1, "b": 2}'
+        assert parse_llm_json(text) == {"a": 1, "b": 2}
+
+    def test_returns_none_when_top_level_is_array_but_object_expected(self) -> None:
+        assert parse_llm_json('[1, 2, 3]', expect="object") is None
+
+    def test_returns_none_when_no_braces_found(self) -> None:
+        assert parse_llm_json('just text, no json here') is None
+
+    def test_returns_none_for_malformed_json(self) -> None:
+        assert parse_llm_json('{this is not: valid json}') is None
+
+    def test_returns_none_for_empty_input(self) -> None:
+        assert parse_llm_json('') is None
+
+    def test_returns_none_for_none_input(self) -> None:
+        assert parse_llm_json(None) is None  # type: ignore[arg-type]
+
+
+class TestArrayParsing:
+    def test_returns_list_for_clean_array(self) -> None:
+        assert parse_llm_json('[1, 2, 3]', expect="array") == [1, 2, 3]
+
+    def test_strips_markdown_fence_around_array(self) -> None:
+        text = '```json\n[{"x": 1}]\n```'
+        assert parse_llm_json(text, expect="array") == [{"x": 1}]
+
+    def test_salvages_truncated_array_after_last_complete_object(self) -> None:
+        # LLM ran out of tokens mid-output. Should recover the two full objects.
+        text = '[{"name": "A"}, {"name": "B"}, {"name": "C'
+        assert parse_llm_json(text, expect="array") == [
+            {"name": "A"},
+            {"name": "B"},
+        ]
+
+    def test_returns_none_when_top_level_is_object_but_array_expected(self) -> None:
+        assert parse_llm_json('{"a": 1}', expect="array") is None
+
+    def test_returns_none_when_no_brackets_or_recoverable_content(self) -> None:
+        assert parse_llm_json('just text', expect="array") is None
+
+    def test_handles_nested_objects_inside_array(self) -> None:
+        text = '[{"a": {"b": 1}}, {"a": {"b": 2}}]'
+        assert parse_llm_json(text, expect="array") == [
+            {"a": {"b": 1}},
+            {"a": {"b": 2}},
+        ]

--- a/lambda/shared/test_models.py
+++ b/lambda/shared/test_models.py
@@ -1,0 +1,270 @@
+"""
+Tests for shared.models — role-based Bedrock model resolution and invocation.
+
+Covers:
+- Role -> default tier -> model ID resolution
+- BEDROCK_TIER_<ROLE> env override
+- BEDROCK_MODEL_<ROLE> direct override (wins over tier)
+- Invalid tier override falls back to default
+- Thinking budget wiring per tier and per-call override
+- Invocation retry/backoff on throttling
+- Non-throttling errors propagate immediately
+"""
+
+import importlib
+import os
+import sys
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the local shared directory is importable
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+@pytest.fixture(autouse=True)
+def clear_bedrock_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Isolate each test from env pollution across tier/model overrides."""
+    for key in list(os.environ.keys()):
+        if key.startswith("BEDROCK_TIER_") or key.startswith("BEDROCK_MODEL_"):
+            monkeypatch.delenv(key, raising=False)
+    yield
+
+
+@pytest.fixture
+def models_module():
+    """Import a fresh copy of models so module-level state is reset."""
+    import models  # noqa: WPS433 — local import is intentional
+    importlib.reload(models)
+    # Reset lazy client between tests
+    models._bedrock_client = None
+    return models
+
+
+# =============================================================================
+# Model ID resolution
+# =============================================================================
+
+class TestModelIdResolution:
+    """Resolution order: direct model env > tier env > role default."""
+
+    def test_returns_haiku_for_summarization_role_by_default(self, models_module) -> None:
+        assert models_module.get_model_id(models_module.ModelRole.SUMMARIZATION) == (
+            "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+    def test_returns_haiku_for_extraction_role_by_default(self, models_module) -> None:
+        assert models_module.get_model_id(models_module.ModelRole.EXTRACTION) == (
+            "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+    def test_returns_haiku_for_generation_role_by_default(self, models_module) -> None:
+        assert models_module.get_model_id(models_module.ModelRole.GENERATION) == (
+            "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+    def test_returns_sonnet_for_analysis_role_by_default(self, models_module) -> None:
+        assert models_module.get_model_id(models_module.ModelRole.ANALYSIS) == (
+            "global.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_returns_opus_when_tier_env_override_set_to_deep(
+        self, models_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BEDROCK_TIER_ANALYSIS", "deep")
+        assert models_module.get_model_id(models_module.ModelRole.ANALYSIS) == (
+            "global.anthropic.claude-opus-4-7"
+        )
+
+    def test_returns_direct_model_env_override_ignoring_tier(
+        self, models_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BEDROCK_TIER_ANALYSIS", "deep")
+        monkeypatch.setenv("BEDROCK_MODEL_ANALYSIS", "pinned-model-id")
+        assert models_module.get_model_id(models_module.ModelRole.ANALYSIS) == "pinned-model-id"
+
+    def test_falls_back_to_role_default_when_tier_env_value_invalid(
+        self, models_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BEDROCK_TIER_GENERATION", "not-a-real-tier")
+        assert models_module.get_model_id(models_module.ModelRole.GENERATION) == (
+            "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+    def test_tier_override_is_case_insensitive(
+        self, models_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BEDROCK_TIER_SUMMARIZATION", "DEEP")
+        assert models_module.get_model_id(models_module.ModelRole.SUMMARIZATION) == (
+            "global.anthropic.claude-opus-4-7"
+        )
+
+
+class TestTierResolution:
+    """get_model_tier reflects the active tier for a role."""
+
+    def test_returns_balanced_tier_for_analysis_role_by_default(self, models_module) -> None:
+        assert models_module.get_model_tier(models_module.ModelRole.ANALYSIS) == (
+            models_module.ModelTier.BALANCED
+        )
+
+    def test_returns_fast_tier_for_extraction_role_by_default(self, models_module) -> None:
+        assert models_module.get_model_tier(models_module.ModelRole.EXTRACTION) == (
+            models_module.ModelTier.FAST
+        )
+
+
+# =============================================================================
+# invoke_bedrock — thinking budget
+# =============================================================================
+
+class TestInvokeBedrockThinkingBudget:
+    """Thinking budget wiring for Converse API."""
+
+    def _mock_converse_success(self, text: str = "ok") -> MagicMock:
+        client = MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": text}]}}
+        }
+        return client
+
+    def test_omits_additional_fields_when_tier_is_fast(self, models_module) -> None:
+        client = self._mock_converse_success()
+        models_module._bedrock_client = client
+
+        models_module.invoke_bedrock("hi", models_module.ModelRole.GENERATION)
+
+        kwargs = client.converse.call_args.kwargs
+        assert "additionalModelRequestFields" not in kwargs
+
+    def test_includes_thinking_budget_when_tier_is_balanced(self, models_module) -> None:
+        client = self._mock_converse_success()
+        models_module._bedrock_client = client
+
+        models_module.invoke_bedrock("hi", models_module.ModelRole.ANALYSIS)
+
+        extra = client.converse.call_args.kwargs["additionalModelRequestFields"]
+        assert extra == {"thinking": {"type": "enabled", "budget_tokens": 2000}}
+
+    def test_uses_deep_budget_when_tier_override_set_to_deep(
+        self, models_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BEDROCK_TIER_ANALYSIS", "deep")
+        client = self._mock_converse_success()
+        models_module._bedrock_client = client
+
+        models_module.invoke_bedrock("hi", models_module.ModelRole.ANALYSIS)
+
+        extra = client.converse.call_args.kwargs["additionalModelRequestFields"]
+        assert extra == {"thinking": {"type": "enabled", "budget_tokens": 8000}}
+
+    def test_disables_thinking_when_caller_passes_thinking_false(self, models_module) -> None:
+        client = self._mock_converse_success()
+        models_module._bedrock_client = client
+
+        models_module.invoke_bedrock("hi", models_module.ModelRole.ANALYSIS, thinking=False)
+
+        kwargs = client.converse.call_args.kwargs
+        assert "additionalModelRequestFields" not in kwargs
+
+    def test_enables_thinking_when_caller_forces_on_for_fast_tier(self, models_module) -> None:
+        client = self._mock_converse_success()
+        models_module._bedrock_client = client
+
+        models_module.invoke_bedrock("hi", models_module.ModelRole.GENERATION, thinking=True)
+
+        extra = client.converse.call_args.kwargs["additionalModelRequestFields"]
+        assert extra == {"thinking": {"type": "enabled", "budget_tokens": 2000}}
+
+
+# =============================================================================
+# invoke_bedrock — response extraction
+# =============================================================================
+
+class TestInvokeBedrockResponseExtraction:
+    def test_returns_text_from_first_text_block(self, models_module) -> None:
+        client = MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "hello world"}]}}
+        }
+        models_module._bedrock_client = client
+
+        result = models_module.invoke_bedrock("q", models_module.ModelRole.GENERATION)
+        assert result == "hello world"
+
+    def test_skips_reasoning_blocks_and_returns_text_block(self, models_module) -> None:
+        client = MagicMock()
+        client.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"reasoningContent": {"reasoningText": {"text": "thinking..."}}},
+                        {"text": "final answer"},
+                    ]
+                }
+            }
+        }
+        models_module._bedrock_client = client
+
+        result = models_module.invoke_bedrock("q", models_module.ModelRole.ANALYSIS)
+        assert result == "final answer"
+
+    def test_returns_empty_string_when_no_content_blocks(self, models_module) -> None:
+        client = MagicMock()
+        client.converse.return_value = {"output": {"message": {"content": []}}}
+        models_module._bedrock_client = client
+
+        result = models_module.invoke_bedrock("q", models_module.ModelRole.GENERATION)
+        assert result == ""
+
+
+# =============================================================================
+# invoke_bedrock — retry behavior
+# =============================================================================
+
+class TestInvokeBedrockRetry:
+    def test_retries_on_throttling_exception_then_succeeds(self, models_module) -> None:
+        client = MagicMock()
+        client.converse.side_effect = [
+            Exception("ThrottlingException: slow down"),
+            {"output": {"message": {"content": [{"text": "ok"}]}}},
+        ]
+        models_module._bedrock_client = client
+
+        with patch.object(models_module.time, "sleep"):
+            result = models_module.invoke_bedrock(
+                "q", models_module.ModelRole.GENERATION, max_retries=3,
+            )
+
+        assert result == "ok"
+        assert client.converse.call_count == 2
+
+    def test_raises_bedrock_invocation_error_when_all_retries_throttled(
+        self, models_module,
+    ) -> None:
+        client = MagicMock()
+        client.converse.side_effect = Exception("ThrottlingException: slow")
+        models_module._bedrock_client = client
+
+        with patch.object(models_module.time, "sleep"):
+            with pytest.raises(Exception) as excinfo:
+                models_module.invoke_bedrock(
+                    "q", models_module.ModelRole.GENERATION, max_retries=2,
+                )
+
+        # Last attempt's raw exception is re-raised (not wrapped) per implementation
+        assert "ThrottlingException" in str(excinfo.value)
+
+    def test_propagates_non_throttling_errors_without_retry(self, models_module) -> None:
+        client = MagicMock()
+        client.converse.side_effect = Exception("ValidationException: bad input")
+        models_module._bedrock_client = client
+
+        with pytest.raises(Exception) as excinfo:
+            models_module.invoke_bedrock(
+                "q", models_module.ModelRole.GENERATION, max_retries=3,
+            )
+
+        assert "ValidationException" in str(excinfo.value)
+        assert client.converse.call_count == 1

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -19,6 +19,25 @@ import * as fs from 'fs';
 import { Auth } from './constructs/auth';
 
 /**
+ * Bedrock model tier defaults per task role.
+ *
+ * Tiers map to model families in lambda/shared/models.py:
+ *   fast     -> Haiku
+ *   balanced -> Sonnet
+ *   deep     -> Opus
+ *
+ * Lambdas read BEDROCK_TIER_<ROLE> and resolve the model ID via
+ * shared.models.get_model_id(). To pin a specific model ID in an incident,
+ * set BEDROCK_MODEL_<ROLE> (takes precedence over the tier).
+ */
+const bedrockTierEnv = {
+  BEDROCK_TIER_SUMMARIZATION: 'fast',
+  BEDROCK_TIER_EXTRACTION:    'fast',
+  BEDROCK_TIER_GENERATION:    'fast',
+  BEDROCK_TIER_ANALYSIS:      'balanced',
+} as const;
+
+/**
  * Creates optimized Lambda code bundle containing only the specific handler file
  * plus shared utilities (decimal_utils.py). This reduces deployment package size
  * and improves cold start times compared to bundling all API handlers together.
@@ -689,6 +708,7 @@ export class CitationAnalysisStack extends cdk.Stack {
         SECRETS_PREFIX: 'citation-analysis/',
         RAW_RESPONSES_BUCKET: rawResponsesBucket.bucketName,
         PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
+        ...bedrockTierEnv,
       },
     });
 
@@ -792,9 +812,9 @@ export class CitationAnalysisStack extends cdk.Stack {
       logGroup: crawlerLogGroup,
       environment: {
         DYNAMODB_TABLE_CRAWLED_CONTENT: crawledContentTable.tableName,
-        BEDROCK_MODEL_ID: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
         SCREENSHOTS_BUCKET: screenshotsBucket.bucketName,
         BROWSER_ID: crawlerBrowser.attrBrowserId, // Pre-created browser with Web Bot Auth
+        ...bedrockTierEnv,
       },
     });
 
@@ -1140,6 +1160,7 @@ export class CitationAnalysisStack extends cdk.Stack {
         DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,
         DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
         PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
+        ...bedrockTierEnv,
       },
     });
 
@@ -1197,7 +1218,7 @@ export class CitationAnalysisStack extends cdk.Stack {
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
       description: 'API: Manage brand tracking configuration',
-      environment: {DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,},
+      environment: {DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName, ...bedrockTierEnv},
     });
 
     // Consolidated Keyword Management Lambda (get-keywords + manage-keywords + keyword-research)
@@ -1683,6 +1704,7 @@ export class CitationAnalysisStack extends cdk.Stack {
         DYNAMODB_TABLE_CONTENT_STUDIO: contentStudioTable.tableName,
         DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
         GENERATION_TIMEOUT_SECONDS: '240',
+        ...bedrockTierEnv,
       },
     });
     searchResultsTable.grantReadData(contentStudioFunction);

--- a/web/src/constants/brandConfigDefaults.ts
+++ b/web/src/constants/brandConfigDefaults.ts
@@ -60,7 +60,7 @@ export const DEFAULT_PRESETS: IndustryPresets = {
     name: 'Hotels & Hospitality',
     description: 'Track hotel brands, chains, and individual properties',
     entity_types: ['hotel chains', 'hotel brands', 'individual properties', 'resorts', 'boutique hotels'],
-    example_brands: ['Brand A', 'Brand B', 'Brand C', 'Brand D', 'Brand E'],
+    example_brands: ['Marriott', 'Hilton', 'Hyatt', 'InterContinental', 'Four Seasons'],
     extraction_focus: 'hotel and accommodation recommendations',
     default_prompt: generateDefaultPrompt(
       'Hotels & Hospitality',


### PR DESCRIPTION
## Summary

Centralizes Bedrock model resolution across 6 Lambda files.

### Model unification (main change)

- New `lambda/shared/models.py` — single source of truth for Bedrock IDs and invocation:
  - `ModelRole`: `SUMMARIZATION` / `EXTRACTION` / `GENERATION` / `ANALYSIS`
  - `ModelTier`: `FAST` (Haiku 4.5) / `BALANCED` (Sonnet 4.6) / `DEEP` (Opus 4.7)
  - `invoke_bedrock()` with retry + jitter + extended-thinking budget per tier
  - Resolution order: `BEDROCK_MODEL_<ROLE>` → `BEDROCK_TIER_<ROLE>` → role default
- CDK spreads `bedrockTierEnv` into every Bedrock-consuming Lambda
- Deletes `llm_model_id` from `shared.config` and `BEDROCK_MODEL_ID` env var

### Shared JSON helper

- New `lambda/shared/llm_json.py::parse_llm_json(text, expect)` — tolerates markdown fences, prose, and truncated arrays
- Replaces 5 near-identical fenced-JSON parsers across the lambdas

### P0 audit fixes bundled in

- Fail-closed `is_provider_enabled` and `get_provider_model` (was silently running disabled providers on DynamoDB errors)
- Broken logger init in `generate-summary/handler.py`
- Dead code removed: `crawler.summarize_content`, `crawler.analyze_seo`, `brand_extractor.expand_brand_names`
- `"Brand A".."Brand E"` placeholders replaced with real examples (backend + frontend)
- Stale `# Force rebuild` comment deleted
- Content-studio model display string now derives from the tier instead of a hardcoded literal

### Tests

- 21 new tests for `models.py` (roles, tiers, thinking budget, retry)
- 15 new tests for `llm_json.py` (fences, truncation, type mismatches)
- 5 regression tests for `is_provider_enabled` fail-closed contract
- 1 updated test for `get_provider_model` fail-closed contract

### Verification

- Python first-party: 129/129 pass
- Web vitest: 675/675 pass
- `npm run build` (CDK): clean
- `tsc --noEmit` (web): clean

Based on `fix/dependabot-vulnerabilities` to avoid unrelated commits in the diff.
