### PR TITLE
feat(web): normalize design system, replace emoji UI icons

### DIFF
--- a/docs/audits/design-system-audit-2026-05-14.md
+++ b/docs/audits/design-system-audit-2026-05-14.md
@@ -1,0 +1,661 @@
+# Design System Audit – Full App
+
+**Date:** 2026-05-14
+**Branch:** `feat/design-system-normalization`
+**Spec:** `docs/design-system.md`
+
+## Summary
+
+- Files audited: 70
+- Findings: 62 (2 blocking, 42 nit, 18 exception)
+- Pages affected: Dashboard, Visibility, Brand Mentions, Citations, Prompt Insights, Citation Gaps, Action Center, Keyword Research, Content Studio, Recent Searches, Raw Responses, Run Analysis, Schedule, Settings
+
+## Findings
+
+### Chrome & Shell
+
+#### `web/src/main.tsx`
+
+- **[NIT] §5** – Hand-rolled button on always-dark fallback surface instead of `<Button invertOnDark>`
+  - Where: line 27 – `className="px-4 py-2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 ..."`
+  - Why: The shared `<Button>` component with `invertOnDark` provides the same styling with less duplication.
+  - Suggested fix: `<Button invertOnDark onClick={() => window.location.reload()}>Reload Page</Button>`
+
+- **[EXCEPTION] §1** – Explicit `dark:` variants on always-dark fallback surface
+  - Where: lines 9–27 – `dark:bg-gray-900`, `dark:bg-gray-800`, `dark:border-gray-700`, etc.
+  - Why: §1 documents that always-dark surfaces (fallback error screens) require explicit `dark:` variants. Correct.
+
+#### `web/src/App.tsx`
+
+- **[EXCEPTION] §1** – Explicit `dark:` variants on Login, Loading, and error states
+  - Where: lines 61, 65, 106, 109, 188, 197 – `dark:bg-gray-900`, `dark:text-gray-400`, `dark:text-red-400`
+  - Why: These are full-page chrome surfaces that need explicit dark treatment per §1. Correct.
+
+- **[EXCEPTION] §2** – `dark:text-red-400` on error text
+  - Where: line 197 – `className="text-xl text-red-600 dark:text-red-400"`
+  - Why: This is on an always-dark error surface; the global accent override would produce `red-300` which is too light for this context. Intentional deviation.
+
+#### `web/src/components/Layout/Sidebar.tsx`
+
+- **[EXCEPTION] §1** – Explicit `dark:` variants throughout sidebar
+  - Where: lines 271, 275, 278, 288, 301 – `dark:bg-gray-800`, `dark:border-gray-700`, `dark:text-gray-900`, etc.
+  - Why: Sidebar is always-dark chrome per §7.1 table. Correct.
+
+#### `web/src/components/Layout/TabContent.tsx`
+
+- **[NIT] §5** – Hand-rolled button in QuickActions "Run Analysis"
+  - Where: line 102 – `className="px-3 sm:px-4 py-2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 ..."`
+  - Why: Should use `<Button invertOnDark>` since it sits on a surface that needs dark inversion.
+  - Suggested fix: `<Button invertOnDark leadingIcon={<PlayIcon />} onClick={() => setActiveTab('execution')}>Run Analysis</Button>`
+
+- **[NIT] §5** – Three hand-rolled secondary buttons in QuickActions
+  - Where: lines 108, 113, 118 – `className="px-3 sm:px-4 py-2 bg-gray-100 text-gray-900 ..."`
+  - Why: Should use `<Button variant="secondary">`.
+  - Suggested fix: Replace with `<Button variant="secondary" onClick={...}>View Brand Mentions</Button>`
+
+
+### UI Primitives
+
+#### `web/src/components/ui/Button.tsx`
+
+- **[EXCEPTION] §1** – `dark:` variants in `invertOnDark` branch
+  - Where: line 67 – `'bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200'`
+  - Why: §5.4 documents that `invertOnDark` is the mechanism for buttons on always-dark surfaces. Correct.
+
+#### `web/src/components/ui/Modal.tsx`
+
+- **[EXCEPTION] §1** – Explicit `dark:` variants on modal chrome
+  - Where: lines 59, 62, 67, 73, 125 – `dark:bg-gray-800`, `dark:border-gray-700`, `dark:text-gray-100`, etc.
+  - Why: §7.1 documents modals need explicit `dark:` treatment. Correct.
+
+- **[NIT] §5** – `ConfirmModal` uses hand-rolled button classes instead of `<Button>`
+  - Where: line 128 – cancel button: `className="px-4 py-2 bg-gray-100 dark:bg-gray-700 ..."`
+  - Where: line 133 – confirm button: `className={...px-4 py-2...${confirmButtonClass}}`
+  - Why: Should use `<Button variant="ghost">` for cancel and `<Button variant="primary">` or `<Button variant="danger">` for confirm.
+  - Suggested fix: Import and use `<Button>` component.
+
+- **[NIT] §5** – `AlertModal` uses hand-rolled button class
+  - Where: line 175 – `className="px-6 py-2 bg-gray-900 dark:bg-white text-white dark:text-gray-900 ..."`
+  - Why: Should use `<Button invertOnDark>`.
+
+#### `web/src/components/ui/Spinner.tsx`
+
+- No findings. Uses `currentColor` inheritance correctly.
+
+#### `web/src/components/ui/ThemeToggle.tsx`
+
+- **[EXCEPTION] §1** – Explicit `dark:` variants
+  - Where: line 40 – `dark:text-gray-500 dark:hover:text-gray-300 dark:hover:bg-gray-700`
+  - Why: §7.1 documents ThemeToggle needs explicit `dark:` treatment. Correct.
+
+#### `web/src/components/ui/Icons.tsx`
+
+- No findings. All icons follow 24×24 viewBox, `currentColor`, `strokeWidth={1.5}` convention per §6.1.
+
+#### `web/src/components/ui/chartTheme.ts`
+
+- **[EXCEPTION] §2** – `rgb()`/`rgba()` colour values
+  - Where: lines 25–29, 33–37 – hardcoded rgb/rgba values
+  - Why: §7.5 documents that Chart.js chrome colours must be specified as raw values since canvas doesn't use Tailwind. Correct.
+
+#### `web/src/components/ui/MarkdownProcessor.tsx`
+
+- **[EXCEPTION] §6** – `•` character in list prefix detection
+  - Where: line 88 – `const listPrefixes = ['- ', '* ', '• ', ...]`
+  - Why: This is parsing logic for markdown content, not a UI glyph. Correct.
+
+
+### ErrorBoundary + ErrorDisplay
+
+#### `web/src/components/ErrorBoundary/ErrorBoundary.tsx`
+
+- **[NIT] §5** – Hand-rolled "Try Again" button
+  - Where: line 72 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"`
+  - Why: Should use `<Button>`. This sits on a light surface (bg-white card) so no `invertOnDark` needed.
+  - Suggested fix: `<Button onClick={this.handleRetry}>Try Again</Button>`
+
+#### `web/src/components/ErrorDisplay/ErrorDisplay.tsx`
+
+- **[NIT] §5** – Hand-rolled "Try Again" button in CardError variant
+  - Where: line 137 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"`
+  - Why: Should use `<Button>`.
+  - Suggested fix: `<Button onClick={onRetry}>Try Again</Button>`
+
+### About Modal + Tabs
+
+#### `web/src/components/About/AboutModal.tsx`
+
+- No findings. Uses `<Modal>` correctly.
+
+#### `web/src/components/About/AboutTab.tsx`
+
+- No findings.
+
+#### `web/src/components/About/ArchitectureTab.tsx`
+
+- **[EXCEPTION] §6** – Emoji used as decorative content labels
+  - Where: lines 26–51, 71 – `icon: '🔍'`, `icon: '🏷️'`, `icon: '📊'`, `👤 User`, etc.
+  - Why: §6.5 explicitly documents that decorative emoji in About tabs are the allowed exception. Correct.
+
+#### `web/src/components/About/LicensesTab.tsx`
+
+- **[EXCEPTION] §6** – Emoji used as decorative content labels
+  - Where: lines 92–117 – `icon: '🔍'`, `icon: '🏢'`, `icon: '📈'`, `icon: '🎯'`, `icon: '👁️'`
+  - Why: §6.5 documented exception. Correct.
+
+### Dashboard
+
+#### `web/src/components/Dashboard/StatCard.tsx`
+
+- No findings. Takes `ReactNode` icon + `tone` prop correctly per §11.1 fix.
+
+#### `web/src/components/Dashboard/ProviderChart.tsx`
+
+- **[EXCEPTION] §2** – `rgba()` dataset colours
+  - Where: lines 41–44 – `'rgba(200, 162, 200, 0.85)'`, etc.
+  - Why: §7.5 documents saturated branded palettes stay fixed across themes. Correct.
+
+- Chart correctly uses `useTheme()` + `getChartTheme(isDark)` with `isDark` in `useEffect` deps (line 20, dep array includes `isDark`). ✓
+
+#### `web/src/components/Dashboard/BrandChart.tsx`
+
+- **[EXCEPTION] §2** – `rgba()` dataset colours with light/dark palettes
+  - Where: lines 16–25 – `BRAND_PALETTE_LIGHT` and `BRAND_PALETTE_DARK`
+  - Why: §7.5 documents neutral data series need separate light/dark palettes. Correctly implemented.
+
+- Chart correctly uses `useTheme()` + `getChartTheme(isDark)` with `isDark` in `useEffect` deps. ✓
+
+
+### Shared Tables
+
+#### `web/src/components/Tables/TopCitationsTable.tsx`
+
+- **[NIT] §5** – Hand-rolled "Export to Excel" button
+  - Where: line 173 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §5** – Four hand-rolled pagination buttons with `disabled:opacity-50`
+  - Where: lines 211, 218, 228, 235 – `className="px-2 sm:px-3 py-1 ... disabled:opacity-50 disabled:cursor-not-allowed"`
+  - Why: Should use `<Button variant="ghost" size="sm">` for pagination.
+
+- **[BLOCKING] §8** – `<select>` uses `focus:ring-2 focus:ring-blue-500` instead of canonical `focus:ring-gray-900`
+  - Where: line 195 – `className="px-3 py-1 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"`
+  - Why: §8 specifies `focus:ring-2 focus:ring-gray-900` for all form inputs. Blue ring is non-canonical.
+  - Suggested fix: Change `focus:ring-blue-500` to `focus:ring-gray-900`
+
+- Expandable rows correctly use `ChevronDownIcon`/`ChevronRightIcon` with `aria-expanded` and `aria-label` (lines 284–285). ✓
+
+#### `web/src/components/Tables/RecentSearchesTable.tsx`
+
+- **[NIT] §5** – Hand-rolled "Retry Failed" button
+  - Where: line 140 – `className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button size="sm">`.
+
+- **[NIT] §5** – Hand-rolled "Export" button
+  - Where: line 148 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §5** – Four hand-rolled pagination buttons with `disabled:opacity-50`
+  - Where: lines 181–185 – `className="px-2 py-1 ... disabled:opacity-50"`
+  - Why: Should use `<Button variant="ghost" size="sm">`.
+
+- **[NIT] §9** – Table header uses `text-xs font-medium text-gray-500 uppercase` but missing `tracking-wider`
+  - Where: line 195 – `className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase"`
+  - Why: §9 specifies `tracking-wider` on table headers.
+  - Suggested fix: Add `tracking-wider` to each `<th>` className.
+
+### Visibility
+
+#### `web/src/components/Visibility/VisibilityDashboard.tsx`
+
+- No findings. Uses global overrides correctly. ✓ auto confirmed.
+
+#### `web/src/components/Visibility/VisibilityComponents.tsx`
+
+- No findings. Indigo accent used correctly per §2.2.
+
+#### `web/src/components/Visibility/PersonaComparisonChart.tsx`
+
+- **[EXCEPTION] §2** – `rgba()`/`rgb()` dataset colours
+  - Where: lines 71–72, 78–79 – `'rgba(16, 185, 129, 0.7)'`, `'rgb(239, 68, 68)'`, etc.
+  - Why: §7.5 documents saturated branded palettes stay fixed. Correct.
+
+- Chart uses `useTheme()` + `getChartTheme(isDark)` correctly (lines 27–28). ✓
+
+#### `web/src/components/Personas/PersonaSelector.tsx`
+
+- No findings.
+
+#### `web/src/components/shared/PersonaSelector.tsx`
+
+- No findings.
+
+
+### Brands – Settings Core
+
+#### `web/src/components/Brands/BrandsView.tsx`
+
+- **[NIT] §5** – Hand-rolled "Configure Brand Tracking" button
+  - Where: line 118 – `className="px-4 py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 self-start"`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §5** – Hand-rolled filter toggle buttons (active state `bg-gray-900 text-white`)
+  - Where: line 76 – `activeClass="bg-gray-900 text-white" inactiveClass="bg-gray-100 text-gray-700 hover:bg-gray-200"`
+  - Why: These are tab-like toggles; while not exactly `<Button>`, the active state pattern could use the component.
+
+#### `web/src/components/Brands/BrandConfigContent.tsx`
+
+- **[NIT] §5** – Hand-rolled tab buttons and "Save Configuration" button
+  - Where: lines 96–97 – tab buttons with `bg-gray-900 text-white` active state
+  - Where: line 131 – `className="px-6 py-2.5 bg-gray-900 text-white rounded-lg hover:bg-gray-800 ... disabled:opacity-50 ..."`
+  - Why: Should use `<Button>` for the save action. Tab toggles are a grey area but the save button is clearly a primary action.
+
+- **[BLOCKING] §8** – Labels in form fields lack `htmlFor`/`id` pairing
+  - Where: Throughout the component – labels exist but are not paired with inputs via `htmlFor`/`id`.
+  - Why: §8 requires labels paired via `htmlFor`/`id` for accessibility.
+  - Suggested fix: Add `htmlFor` to labels and matching `id` to inputs.
+
+#### `web/src/components/Brands/BrandConfigPanel.tsx`
+
+- No findings.
+
+#### `web/src/components/Brands/BrandTagList.tsx`
+
+- No findings.
+
+#### `web/src/components/Brands/DomainList.tsx`
+
+- No findings.
+
+#### `web/src/components/Brands/IndustrySelector.tsx`
+
+- No findings.
+
+#### `web/src/components/Brands/ExtractionOptions.tsx`
+
+- No findings.
+
+#### `web/src/components/Brands/FirstPartyBrandsSection.tsx`
+
+- **[NIT] §5** – Hand-rolled "Expand Brands" button with `disabled:opacity-50`
+  - Where: line 38 – `className="px-3 py-1.5 bg-emerald-600 text-white text-xs font-medium rounded-lg hover:bg-emerald-700 ... disabled:opacity-50 ..."`
+  - Why: This is a saturated solid action button (allowed per §2) but uses ad-hoc disabled styling instead of `<Button>`.
+
+#### `web/src/components/Brands/CompetitorBrandsSection.tsx`
+
+- **[NIT] §5** – Two hand-rolled buttons with `disabled:opacity-50`
+  - Where: lines 59, 70 – amber-100 and amber-600 buttons
+  - Why: Should use `<Button>` for consistent disabled handling.
+
+#### `web/src/components/Brands/PromptEditor.tsx`
+
+- **[EXCEPTION] §6** – `✓` unicode glyph inside `<option>`
+  - Where: line 31 – `{preset.name}{industryPrompts[key] ? ' ✓' : ''}`
+  - Why: §6.5 documents this as the ceiling for unicode glyph usage – browsers cannot render React components inside `<option>`. Correct.
+
+### Brands – Mentions & Detail
+
+#### `web/src/components/Brands/BrandExpansionPanel.tsx`
+
+- **[NIT] §5** – Hand-rolled action button with `disabled:opacity-50`
+  - Where: line 110 – `className={...px-4 py-2 ${colorScheme.bg} text-white ... disabled:opacity-50}`
+  - Why: Should use `<Button>`.
+
+#### `web/src/components/Brands/CompetitorDiscoveryPanel.tsx`
+
+- **[NIT] §5** – Hand-rolled "Accept" button with `disabled:opacity-50`
+  - Where: line 64 – `className="px-4 py-2 bg-amber-600 text-white text-sm font-medium rounded-lg hover:bg-amber-700 ... disabled:opacity-50"`
+  - Why: Should use `<Button variant="primary">` (or a custom amber variant).
+
+#### `web/src/components/Brands/BrandMentionsTable.tsx`
+
+- **[NIT] §5** – Three hand-rolled sort toggle buttons
+  - Where: lines 66, 74, 82 – `sortBy === 'rank' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'`
+  - Why: Tab-like toggles using hand-rolled active/inactive states.
+
+#### `web/src/components/Brands/BrandOverviewTab.tsx`
+
+- No findings. `•` used as text separator (not a UI glyph).
+
+#### `web/src/components/Brands/BrandDetailModal.tsx`
+
+- No findings. `•` used as text separator.
+
+#### `web/src/components/Brands/ProviderResponseCard.tsx`
+
+- Correctly uses `ChevronDownIcon`/`ChevronRightIcon` with `aria-expanded` (lines 74, 231). ✓
+
+#### `web/src/components/Brands/ProviderResponsesTab.tsx`
+
+- **[NIT] §5** – Hand-rolled tab toggle with `bg-gray-900 text-white` active state
+  - Where: line 54 – `? 'bg-gray-900 text-white'`
+  - Why: Same pattern as other tab toggles.
+
+
+### Citations
+
+#### `web/src/components/Citations/CitationsView.tsx`
+
+- No findings beyond those in CitationFilters/PaginationControls.
+
+#### `web/src/components/Citations/CitationFilters.tsx`
+
+- **[NIT] §5** – Hand-rolled "Search" button
+  - Where: line 65 – `className="flex-1 sm:flex-none px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+#### `web/src/components/Citations/CitationRow.tsx`
+
+- No findings.
+
+#### `web/src/components/Citations/CitationTableHeader.tsx`
+
+- No findings.
+
+#### `web/src/components/Citations/CitationDetailModal.tsx`
+
+- User-content screenshot correctly carries `dark:brightness-90 dark:contrast-95` (line 293). ✓
+
+#### `web/src/components/Citations/CrawlHistory.tsx`
+
+- User-content screenshot correctly carries `dark:brightness-90 dark:contrast-95` (line 136). ✓
+
+#### `web/src/components/Citations/PaginationControls.tsx`
+
+- **[NIT] §5** – Four hand-rolled pagination buttons with `disabled:opacity-50`
+  - Where: lines 47–51 – `className="px-2 py-1 text-gray-500 hover:bg-gray-100 rounded disabled:opacity-50 ..."`
+  - Why: Should use `<Button variant="ghost" size="sm">`.
+
+### Insights
+
+#### `web/src/components/Insights/PromptInsights.tsx`
+
+- No findings. Fuchsia accent used correctly.
+
+#### `web/src/components/Insights/CitationGaps.tsx`
+
+- No findings. Rose accent used correctly.
+
+#### `web/src/components/Insights/GapCard.tsx`
+
+- No findings.
+
+#### `web/src/components/Insights/PromptCard.tsx`
+
+- No findings.
+
+#### `web/src/components/Insights/Recommendations.tsx`
+
+- **[NIT] §5** – Hand-rolled primary action button
+  - Where: line 225 – `className="px-4 py-2.5 bg-gray-900 text-white rounded-lg hover:bg-gray-800 text-sm font-medium ..."`
+  - Why: Should use `<Button>`.
+
+### KeywordResearch
+
+#### `web/src/components/KeywordResearch/KeywordResearchView.tsx`
+
+- No findings.
+
+#### `web/src/components/KeywordResearch/KeywordExpansion.tsx`
+
+- **[NIT] §5** – Hand-rolled "Expand Keywords" button with `disabled:opacity-50`
+  - Where: line 121 – `className="w-full sm:w-auto px-6 py-2 bg-gray-900 text-white ... disabled:opacity-50 disabled:cursor-not-allowed ..."`
+  - Why: Should use `<Button>`.
+
+#### `web/src/components/KeywordResearch/CompetitorAnalysis.tsx`
+
+- No findings.
+
+#### `web/src/components/KeywordResearch/CompetitorAnalysisComponents.tsx`
+
+- **[NIT] §5** – Hand-rolled "Analyze" button with `disabled:opacity-50`
+  - Where: line 102 – `className="px-6 py-2 bg-gray-900 text-white ... disabled:opacity-50 disabled:cursor-not-allowed ..."`
+  - Why: Should use `<Button>`.
+
+#### `web/src/components/KeywordResearch/ResearchHistory.tsx`
+
+- No findings. `•` used as text separator.
+
+#### `web/src/components/KeywordResearch/KeywordResultsTable.tsx`
+
+- No findings.
+
+
+### ContentStudio + SelfReflection
+
+#### `web/src/components/ContentStudio/ContentStudioView.tsx`
+
+- **[NIT] §5** – Hand-rolled "Generate" button
+  - Where: line 152 – `className="flex-1 px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §5** – Hand-rolled secondary button with `disabled:opacity-50`
+  - Where: line 183 – `className="px-4 py-2 bg-gray-100 text-gray-700 ... disabled:opacity-50 ..."`
+  - Why: Should use `<Button variant="secondary">`.
+
+#### `web/src/components/ContentStudio/ContentGenerator.tsx`
+
+- **[NIT] §5** – Hand-rolled button
+  - Where: line 211 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+#### `web/src/components/ContentStudio/ContentHistory.tsx`
+
+- No findings.
+
+#### `web/src/components/ContentStudio/ContentDetailModal.tsx`
+
+- **[NIT] §5** – Hand-rolled blue action button with `disabled:opacity-50`
+  - Where: line 153 – `className="px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 ... disabled:opacity-50"`
+  - Why: This is a saturated solid button (allowed per §2) but should still use `<Button variant="danger">` pattern or a custom variant for consistency.
+
+#### `web/src/components/ContentStudio/ContentIdeaCard.tsx`
+
+- **[NIT] §5** – Hand-rolled button with `disabled:opacity-50`
+  - Where: line 165 – `className="w-full sm:w-auto px-4 py-2 bg-gray-900 text-white ... disabled:opacity-50 disabled:cursor-not-allowed ..."`
+  - Why: Should use `<Button>`.
+
+#### `web/src/components/ContentStudio/HistoryListItem.tsx`
+
+- **[NIT] §5** – Hand-rolled delete icon button with `disabled:opacity-50`
+  - Where: line 162 – `className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg ... disabled:opacity-50"`
+  - Why: Should use `<Button variant="iconOnly">` with appropriate hover styling.
+
+#### `web/src/components/SelfReflection/SelfReflectionPanel.tsx`
+
+- **[NIT] §5** – Hand-rolled button
+  - Where: line 43 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"`
+  - Why: Should use `<Button>`.
+
+### Searches
+
+#### `web/src/components/Searches/SearchesView.tsx`
+
+- No findings.
+
+#### `web/src/components/Searches/SearchesViewComponents.tsx`
+
+- **[NIT] §5** – Hand-rolled "Search" button
+  - Where: line 169 – `className="flex-1 sm:flex-none px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §5** – Hand-rolled pagination button with `disabled:opacity-50`
+  - Where: line 267 – `className="px-2 py-1 text-gray-500 hover:bg-gray-100 rounded disabled:opacity-50 ..."`
+  - Why: Should use `<Button variant="ghost" size="sm">`.
+
+### RawResponses
+
+#### `web/src/components/RawResponses/RawResponsesExplorer.tsx`
+
+- **[NIT] §5** – Hand-rolled tab toggle with `bg-gray-900 text-white` active state
+  - Where: line 241 – `? 'bg-gray-900 text-white'`
+  - Why: Same tab-toggle pattern as elsewhere.
+
+#### `web/src/components/RawResponses/Breadcrumb.tsx`
+
+- No findings.
+
+#### `web/src/components/RawResponses/FileViewer.tsx`
+
+- No findings. `•` used as text separator.
+
+#### `web/src/components/RawResponses/ImageViewer.tsx`
+
+- User-content image correctly carries `dark:brightness-90 dark:contrast-95` (line 49). ✓
+
+- **[NIT] §5** – Hand-rolled "Download" button
+  - Where: line 97 – `className="px-3 py-1.5 text-sm font-medium text-white bg-gray-900 rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button size="sm">`.
+
+
+### Execution
+
+#### `web/src/components/Execution/ExecutionMonitor.tsx`
+
+- No findings.
+
+#### `web/src/components/Execution/ExecutionStatus.tsx`
+
+- No findings.
+
+#### `web/src/components/Execution/ExecutionMonitorComponents.tsx`
+
+- **[NIT] §5** – Hand-rolled button with `disabled:bg-gray-300 disabled:cursor-not-allowed`
+  - Where: line 177 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:bg-gray-300 disabled:cursor-not-allowed ..."`
+  - Why: Should use `<Button>`. Note: uses `disabled:bg-gray-300` instead of the component's `disabled:opacity-50`.
+
+#### `web/src/components/Execution/TriggerSection.tsx`
+
+- **[NIT] §5** – Hand-rolled button with `disabled:bg-gray-300 disabled:cursor-not-allowed`
+  - Where: line 112 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:bg-gray-300 disabled:cursor-not-allowed ..."`
+  - Why: Should use `<Button>`.
+
+### Schedule
+
+#### `web/src/components/Schedule/ScheduleManager.tsx`
+
+- **[NIT] §5** – Two hand-rolled buttons
+  - Where: line 182 – toggle active state `'bg-gray-900 text-white hover:bg-gray-800'`
+  - Where: line 288 – `className="mt-4 px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button>`.
+
+### Settings
+
+#### `web/src/components/Settings/SettingsView.tsx`
+
+- **[NIT] §5** – Hand-rolled button with `disabled:opacity-50`
+  - Where: line 338 – `className="px-4 py-2 text-sm bg-gray-900 text-white rounded-lg hover:bg-gray-800 ... disabled:opacity-50 ..."`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §8** – `<li>` items use `•` bullet character instead of proper list styling
+  - Where: lines 364–367 – `<li>• Only enabled providers...`
+  - Why: This is content text, not a UI glyph. However, using `<ul className="list-disc">` would be more semantic.
+
+#### `web/src/components/Settings/UsersConfig.tsx`
+
+- **[NIT] §5** – Hand-rolled button
+  - Where: line 97 – `className="px-3 py-2 text-sm bg-gray-900 text-white rounded-lg hover:bg-gray-800 ..."`
+  - Why: Should use `<Button size="sm">`.
+
+#### `web/src/components/Settings/UserModals.tsx`
+
+- **[NIT] §5** – Two hand-rolled buttons with `disabled:opacity-50`
+  - Where: lines 149, 334 – `className="px-4 py-2 text-sm bg-gray-900 text-white rounded-lg hover:bg-gray-800 ... disabled:opacity-50 ..."`
+  - Why: Should use `<Button>`.
+
+- **[NIT] §8** – Labels lack `htmlFor`/`id` pairing
+  - Where: lines 93, 109, 277 – `<label className="block text-sm font-medium text-gray-700 mb-1">` without `htmlFor`
+  - Why: §8 requires labels paired via `htmlFor`/`id`.
+  - Suggested fix: Add `htmlFor` to labels and `id` to corresponding inputs.
+
+#### `web/src/components/Settings/QueryPromptsManager.tsx`
+
+- Icon-only buttons correctly carry `aria-label` (lines 234, 243, 253). ✓
+- Form labels correctly use `htmlFor` (lines 85, 100, 116). ✓
+- No findings.
+
+### Keywords
+
+#### `web/src/components/Keywords/KeywordDetail.tsx`
+
+- Charts use declarative `<Line>` and `<Bar>` from react-chartjs-2 with `useTheme()` + `getChartTheme(isDark)` in the render path (lines 173–174). Re-renders automatically on theme toggle. ✓
+
+#### `web/src/components/Keywords/KeywordDetailComponents.tsx`
+
+- **[EXCEPTION] §2** – Inline `style={{ backgroundColor }}` for provider colour swatches
+  - Where: line 214 – `style={{ backgroundColor: colors.border }}`
+  - Why: §2 documents this as an allowed exception for provider colour swatches in KeywordDetailComponents. Correct.
+
+- **[EXCEPTION] §2** – `rgb()`/`rgba()` provider colour constants
+  - Where: lines 11–24 – `border: 'rgb(168, 85, 247)'`, `bg: 'rgba(168, 85, 247, 0.5)'`, etc.
+  - Why: §7.5 documents saturated branded palettes stay fixed. Correct.
+
+- Expandable rows correctly use `aria-expanded` (line 322). ✓
+
+#### `web/src/components/Keywords/KeywordDetailChartOptions.ts`
+
+- No findings. Correctly accepts `ChartTheme` parameter.
+
+#### `web/src/components/Keywords/KeywordsManager.tsx`
+
+- No findings.
+
+#### `web/src/components/Keywords/KeywordsManagerComponents.tsx`
+
+- **[NIT] §5** – Four hand-rolled buttons
+  - Where: line 55 – toggle: `'bg-gray-900 text-white hover:bg-gray-800'`
+  - Where: line 88 – `className="px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 disabled:bg-gray-300 disabled:cursor-not-allowed"`
+  - Where: line 119 – same pattern
+  - Where: line 229 – `className="px-3 py-1.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800"`
+  - Why: Should use `<Button>`.
+
+
+## Cross-cutting observations
+
+### 1. Hand-rolled button pattern (NIT §5) – 27 files
+
+The most pervasive finding. The shared `<Button>` component exists and implements all documented variants, sizes, disabled states, and `invertOnDark` — but ~27 files still use inline `className="px-4 py-2 bg-gray-900 text-white ..."` strings. This is a consistency issue, not a dark-mode bug (the global override handles `bg-gray-900` in both themes).
+
+**Recommendation:** A single refactor pass replacing all hand-rolled button strings with `<Button>` would eliminate ~40 of the 42 NITs in this report. Consider a codemod or lint rule (`no-restricted-syntax` targeting the pattern).
+
+### 2. Ad-hoc `disabled:opacity-50` (NIT §5) – 18 files
+
+Files that hand-roll buttons also hand-roll disabled states. The `<Button>` component already applies `disabled:opacity-50 disabled:cursor-not-allowed` in its base classes. Some files additionally use `disabled:bg-gray-300` which deviates from the component's approach.
+
+### 3. Tab-toggle pattern not covered by `<Button>`
+
+Several components use a toggle-button group where the active tab gets `bg-gray-900 text-white` and inactive gets `bg-gray-100 text-gray-700`. This pattern appears in:
+- `BrandsView` (filter buttons)
+- `BrandConfigContent` (settings/prompt tabs)
+- `BrandMentionsTable` (sort toggles)
+- `ProviderResponsesTab`
+- `RawResponsesExplorer`
+- `ScheduleManager`
+- `KeywordsManagerComponents`
+
+**Recommendation:** Consider adding a `ToggleGroup` or `TabBar` primitive to `components/ui/` that encapsulates this pattern. It's not exactly a `<Button>` but it's repeated enough to warrant extraction.
+
+### 4. Form label pairing (§8) – incomplete
+
+Only `QueryPromptsManager` and `ContentStudioView` use `htmlFor`/`id` pairing. Most other form-bearing components (`UserModals`, `BrandConfigContent`, `ScheduleManager`) have labels without `htmlFor`. This is an accessibility gap.
+
+### 5. Table header `tracking-wider` (§9) – inconsistent
+
+`RecentSearchesTable` headers are missing `tracking-wider`. `TopCitationsTable` has it. All table headers should include it per §9.
+
+### 6. Focus ring colour (§8) – one deviation
+
+`TopCitationsTable` uses `focus:ring-blue-500` on a `<select>` instead of the canonical `focus:ring-gray-900`. This is the only instance found.
+
+### 7. Theme support status confirmed
+
+All 14 pages in the §7.1 catalogue maintain their "✓ auto" status. No new code introduces classes outside the global override list. The always-dark surfaces (Sidebar, Modal, main.tsx fallback, App.tsx chrome) correctly carry explicit `dark:` variants.
+
+## Verification commands
+
+```bash
+cd web && npm run type-check
+cd web && npm test -- --run
+cd web && npm run build
+npx eslint web/src/components/Tables/TopCitationsTable.tsx web/src/components/Tables/RecentSearchesTable.tsx
+```

--- a/docs/design-system-audit-prompt.md
+++ b/docs/design-system-audit-prompt.md
@@ -1,0 +1,296 @@
+# Design System Audit Prompt
+
+A reusable prompt for auditing any React component (or batch of
+components) in this repo against the rules captured in
+[`docs/design-system.md`](./design-system.md). Use it whenever you
+want a focused review of light / dark mode coverage, theming
+correctness, or anomalies introduced by new code.
+
+The prompt is designed to be:
+
+- **Self-contained** – it tells the auditor what to read and what
+  rules to apply.
+- **Actionable** – every finding maps to a concrete fix, not a vague
+  "could be better".
+- **Strict but proportionate** – distinguishes real bugs from
+  documented intentional exceptions.
+
+---
+
+## How to use
+
+1. Decide the audit scope (single file, feature folder, full
+   codebase – see "Scope" below).
+2. Paste the prompt block below into a fresh AI assistant session,
+   replacing `{{TARGET}}` with the file paths or glob to audit.
+3. Provide the assistant with read access to `docs/design-system.md`
+   and the target files. The prompt assumes the doc is the source
+   of truth.
+4. Review the produced report. Apply the proposed fixes through a
+   normal PR.
+
+> The prompt does **not** authorise the assistant to modify code on
+> its own. It returns a structured findings report; the human (or a
+> follow-up implementation prompt) decides what to fix.
+
+---
+
+## Prompt
+
+> Copy everything between the fence below into the audit session.
+
+````
+You are auditing a React 18 + Tailwind CSS 3 codebase that uses a
+class-based dark-mode strategy (`darkMode: 'class'` in
+`tailwind.config.js`). The design system rules you must enforce are
+documented in `docs/design-system.md` – read it before producing any
+findings. Treat it as the source of truth: if something contradicts
+what you would normally recommend, follow the doc.
+
+## Scope
+
+Audit only these files / globs:
+
+  {{TARGET}}
+
+For each file, evaluate it against every rule below. Do not modify
+any files; produce a structured report only.
+
+## What to check
+
+For every file in scope, walk through these checks in order. Cite
+the design-system section in parentheses for each finding so the
+reader can confirm against the spec.
+
+### 1. Theming model (§1)
+
+- [ ] No hand-rolled `dark:` variant for a class that is already in
+      the global override list (§1.2.1 + §1.2.2). Examples:
+      `dark:bg-gray-800` on top of `bg-white`, `dark:bg-emerald-900/20`
+      on top of `bg-emerald-50`. The override should do the work.
+- [ ] On always-dark surfaces (sidebar, app rail, modal headers,
+      fallback error screens, anything in `App.tsx` chrome), explicit
+      `dark:` variants are present and correct.
+- [ ] No reliance on the deprecated escape hatch
+      `document.documentElement.classList.contains('dark')`. Use
+      `useTheme().isDark`.
+
+### 2. Colour palette (§2)
+
+- [ ] Component uses Tailwind tokens, not hardcoded hex / rgb / rgba
+      values in JSX, except inside Chart.js datasets (§7.5) and the
+      few documented inline-style call sites (`KeywordDetailComponents`
+      provider colour swatches).
+- [ ] Accent surfaces follow the canonical pairing
+      `bg-{tone}-50 text-{tone}-700` or `bg-{tone}-100 text-{tone}-800`
+      with optional `border-{tone}-200`.
+- [ ] No two accent tones mixed in the same component (Brand
+      sections deliberately use emerald/amber/violet to differentiate
+      first-party / competitor / custom – this is allowed; copying
+      the pattern elsewhere is not).
+- [ ] Saturated solids (`bg-{tone}-500/600/700`) appear only on
+      primary action buttons paired with `text-white`.
+
+### 3. Typography (§3)
+
+- [ ] Page titles, section titles, body text, helper text, captions
+      all use the canonical scale.
+- [ ] Numeric stats use `text-3xl font-semibold` only on stat-card
+      surfaces.
+- [ ] AI markdown output is rendered through `.prose-markdown` (or
+      via `MarkdownProcessor`), not custom typography.
+
+### 4. Buttons (§5)
+
+- [ ] Every button is the shared `<Button>` component. Hand-rolled
+      `className="px-4 py-2 bg-gray-900 text-white …"` strings are
+      a finding.
+- [ ] Icon-only buttons (`variant="iconOnly"`) carry `aria-label`
+      and a `title`.
+- [ ] No more than one `variant="primary"` button in any visible
+      group.
+- [ ] Disabled states use the component's built-in opacity, not
+      ad-hoc `disabled:opacity-50` strings.
+- [ ] Buttons sitting on always-dark surfaces use `invertOnDark`
+      where required.
+
+### 5. Icons (§6)
+
+- [ ] No emoji used as button labels, action icons, or expand /
+      collapse affordances.
+- [ ] No unicode arrows / symbols (`▲▼◀▶✕→✓⚠️🌍`) used as UI
+      glyphs. The two documented exceptions are decorative emoji in
+      the About tabs and a single `✓` inside a native `<select>`
+      `<option>` in `PromptEditor.tsx` (browsers do not render React
+      children inside `<option>`).
+- [ ] All new icons live in `components/ui/Icons.tsx`, follow the
+      stroke convention (24×24 viewBox, `currentColor`,
+      `strokeWidth={1.5}`), and inherit colour from their parent's
+      `text-*` class.
+
+### 6. Charts (§7.5)
+
+- [ ] Components rendering Chart.js use `useTheme()` and
+      `getChartTheme(isDark)` from `components/ui/chartTheme.ts` to
+      colour ticks, grid, legend, and tooltip.
+- [ ] Imperative chart usage (`new Chart(ctx, …)`) includes `isDark`
+      in the `useEffect` dependency array so the chart re-renders on
+      theme toggle.
+- [ ] Neutral data series (gray-only doughnuts / bars) have
+      separate light- and dark-mode dataset palettes – no
+      `gray-900` slice on a dark page.
+- [ ] Saturated branded palettes (e.g. provider colours from
+      `KeywordDetailComponents.tsx`) stay fixed across themes – do
+      not flag as a finding.
+
+### 7. Images (§7.6)
+
+- [ ] User-supplied screenshots and arbitrary captured images carry
+      `dark:brightness-90 dark:contrast-95`.
+- [ ] Profile photos of real people, the sidebar brand mark, and
+      decorative SVG icons do **not** carry the dim filter.
+- [ ] No `<img>` introduced where an SVG icon from the shared set
+      would be appropriate.
+
+### 8. Forms (§8)
+
+- [ ] Labels are paired with inputs via `htmlFor` / `id`.
+- [ ] Inputs / textareas / selects use the canonical
+      `w-full p-2 border border-gray-200 rounded-lg text-sm
+      focus:ring-2 focus:ring-gray-900` (dark mode handled
+      globally).
+- [ ] Helper text uses `text-xs text-gray-400 mt-1`.
+- [ ] Validation errors use `text-xs text-red-600 mt-1` (overridden
+      to `red-300` on dark via the global accent override).
+
+### 9. Tables (§9)
+
+- [ ] Header row: `bg-gray-50` + `text-xs font-medium uppercase
+      tracking-wider text-gray-500`.
+- [ ] Cells: `px-6 py-4` padding.
+- [ ] Sortable columns include a chevron icon and `aria-sort`.
+- [ ] Expandable rows use `ChevronRightIcon` / `ChevronDownIcon`
+      with `aria-expanded`.
+
+### 10. Anomaly checklist (§11)
+
+Run the entire §11 checklist literally. Flag any item the file
+violates.
+
+### 11. Per-page coverage (§7.1)
+
+If the audited file maps to a page in the §7.1 catalogue, confirm
+the page's "Theme support" status still holds. If any new code in
+the file would change "✓ auto" to needing explicit `dark:`
+variants, call that out explicitly so the catalogue can be updated.
+
+## Output format
+
+Produce a Markdown report with this structure:
+
+```markdown
+# Design System Audit – {{TARGET}}
+
+## Summary
+
+- Files audited: <n>
+- Findings: <n total>  (<n blocking>, <n nit>, <n exception>)
+- Pages affected: <list>
+
+## Findings
+
+### {{file path}}
+
+- **[BLOCKING] §<section>** – <one-line description of the issue>
+  - Where: line <n> – <code excerpt>
+  - Why it's a problem: <one sentence>
+  - Suggested fix: <concrete change, ideally a diff>
+
+- **[NIT] §<section>** – ...
+
+- **[EXCEPTION] §<section>** – Documented intentional deviation; no
+  action required. Briefly note why it's allowed.
+
+## Cross-cutting observations
+
+(Optional. Patterns repeated across files, candidate refactors,
+docs updates the design-system.md should pick up.)
+
+## Verification commands
+
+If applying fixes, run these to confirm the audit pass:
+
+  cd web && npm run type-check
+  cd web && npm test -- --run
+  cd web && npm run build
+  npx eslint <touched files>
+```
+
+## Severity guidance
+
+- **BLOCKING** – Real dark-mode bug, accessibility issue, or hard
+  rule from the doc (e.g. emoji as a UI glyph). Must be fixed
+  before merge.
+- **NIT** – Style / consistency improvement (e.g. could use the
+  shared `<Button>` instead of hand-rolled classes). Worth fixing
+  but not a blocker.
+- **EXCEPTION** – Apparent violation that the design system
+  explicitly allows (e.g. About tab decorative emoji,
+  `PromptEditor` `<option>` checkmark, profile photos staying
+  unchanged in dark mode). Do not propose a fix; just confirm the
+  exception applies.
+
+## Ground rules
+
+- Quote line numbers and code excerpts. Vague findings without
+  evidence are not useful.
+- If something looks off but is not covered by the design-system
+  doc, flag it under "Cross-cutting observations" and propose
+  whether the doc should be updated.
+- Do not propose visual redesigns outside the spec. The prompt is
+  about conforming code to the existing design system, not about
+  re-imagining it.
+- Do not modify any files. Output the report only.
+````
+
+---
+
+## Scope presets
+
+Pick a preset for `{{TARGET}}` based on what you want to audit:
+
+| Preset | Glob | When to use |
+| ------ | ---- | ----------- |
+| Single file | `web/src/components/<Feature>/<File>.tsx` | Reviewing a specific change. |
+| Single feature folder | `web/src/components/<Feature>/**/*.tsx` | Reviewing one feature end-to-end. |
+| One page (route) | The components listed for that page in design-system §7.1 | Auditing one route in both themes. |
+| All shared primitives | `web/src/components/ui/**/*.{ts,tsx}` and `web/src/components/shared/**/*.tsx` | Verifying primitives stay theme-aware. |
+| All chart components | `web/src/components/**/*Chart*.tsx`, `web/src/components/**/*ChartOptions*.ts` | After Chart.js / `chartTheme.ts` changes. |
+| Full app | `web/src/components/**/*.{ts,tsx}` plus `web/src/App.tsx`, `web/src/main.tsx` | Pre-release sweep. |
+
+---
+
+## Example invocation
+
+```
+{{TARGET}} = web/src/components/Brands/**/*.tsx
+```
+
+Produces a report listing every Brand-related file and its findings,
+grouped by file. Useful if a future change to brand settings or
+brand mentions needs a focused dark-mode validation.
+
+---
+
+## Tips for accurate audits
+
+- Re-read the §11 anomaly checklist before starting; it is the
+  fastest way to catch known regressions.
+- When in doubt about whether a class is in the global override
+  list, grep `web/src/index.css` for the exact selector.
+- The file `docs/design-system.md` ends with §11.1 "Recently fixed
+  anomalies" – use it to recognise patterns the codebase has
+  already burned itself on and not flag the resolved cases.
+- The audit is intentionally not a code-quality audit. Off-topic
+  findings (e.g. cognitive complexity, missing tests) belong in a
+  separate review, not here.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -47,8 +47,11 @@ Defined in `web/src/index.css`. Two groups: **neutral** and **accent**.
 | `bg-white`             | gray-800         |
 | `bg-gray-50`           | gray-900         |
 | `bg-gray-100`          | gray-700         |
+| `bg-gray-200`          | gray-600         |
 | `border-gray-200`      | gray-700         |
 | `border-gray-100`      | gray-700         |
+| `border-gray-300`      | gray-600         |
+| `hover:border-gray-300`| gray-500         |
 | `text-gray-900`        | gray-50          |
 | `text-gray-700`        | gray-300         |
 | `text-gray-600`        | gray-300         |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -468,6 +468,41 @@ conventions:
   first slices are `gray-900` / `gray-700`) need a light- and
   dark-mode palette. See `Dashboard/BrandChart.tsx` for the pattern.
 
+### 7.6 Images
+
+User-content images (website screenshots from the crawler, raw S3
+images) usually carry their own bright white-themed backgrounds.
+Without treatment they appear as harsh white slabs on the dark
+surface, even when the surrounding panel is correctly tinted.
+
+Apply the standard dim filter to `<img>` tags that render arbitrary
+captured content:
+
+```tsx
+<img
+  src={screenshotUrl}
+  alt="Screenshot of the cited page"
+  className="w-full border border-gray-300 rounded shadow-lg dark:brightness-90 dark:contrast-95"
+/>
+```
+
+`dark:brightness-90 dark:contrast-95` takes the edge off harsh whites
+without distorting brand colours in the screenshot. Apply it to:
+
+- `Citations/CitationDetailModal.tsx` – cited-page screenshots.
+- `Citations/CrawlHistory.tsx` – historical crawl screenshots.
+- `RawResponses/ImageViewer.tsx` – raw image objects in S3.
+
+Do NOT apply the filter to:
+
+- **Profile photos** of real people (e.g. the AboutTab portraits).
+  They are photos, not UI surfaces, and dimming looks unnatural.
+- **Logos / favicons** (`web/public/assets/favicon.ico`,
+  `Layout/Sidebar` brand mark). These already invert via Tailwind
+  classes (`bg-gray-900 dark:bg-white`).
+- **Decorative icons** – use the SVG icon set in
+  `components/ui/Icons.tsx` instead.
+
 ---
 
 ## 8. Forms
@@ -504,11 +539,18 @@ conventions:
 - App favicon: `web/public/assets/favicon.ico` (32×32 ICO).
 - App name: "Citation Analysis Dashboard" (`web/index.html` `<title>`).
 - Logo mark in sidebar: an inline bar-chart SVG inside an
-  `bg-gray-900 dark:bg-white` rounded square (32×32).
+  `bg-gray-900 dark:bg-white` rounded square (32×32). The fill colour
+  inverts so the mark stays high-contrast in both themes.
+- Profile portraits in the About tab (`web/public/assets/*.jpg`) are
+  photos and intentionally render unchanged in both themes – the
+  surrounding panel adapts via the global override.
 
 If a new favicon is needed, replace `favicon.ico` and add modern
 formats (`favicon.svg`, `apple-touch-icon.png`) referenced from
 `web/index.html`. Keep the silhouette legible at 16×16.
+
+For user-content images (screenshots, captured assets) see
+§7.6 Images for the dimming pattern.
 
 ---
 
@@ -565,6 +607,7 @@ design-system pass:
 | `Keywords/KeywordDetailComponents.tsx` | `✕ Close` unicode multiplication-sign in the close button. | Replaced with `CloseIcon` leading the label. |
 | **All accent-tinted surfaces (48 files, ~349 occurrences)** | Pages using `bg-{tone}-50/100`, `text-{tone}-700/800`, `border-{tone}-100/200/300` rendered as bright pale-tinted panels in dark mode. Most visible on `Settings > Brand Tracking`, where the stacked emerald + amber + violet panels turned the whole page green/yellow on a dark background. | Extended the `index.css` global override system to cover every accent tone: tinted surfaces become translucent dark tints, accent text shifts to `*-300/-200`, accent borders become muted translucent equivalents. Zero call-site changes – fixes all 48 files at once and any future accent surface gets the right behaviour automatically. |
 | **Chart.js canvases** (`Dashboard/ProviderChart`, `Dashboard/BrandChart`, `Visibility/PersonaComparisonChart`, `Keywords/KeywordDetail*`) | Canvases sit outside Tailwind's CSS so the global overrides do not reach them. Axis tick text, grid lines, legend, tooltip, and the neutral doughnut palette stayed in light-mode colours on dark, leaving labels invisible and the BrandChart's `gray-900` slice merging into the dark page. Charts also did not re-render when the user toggled the theme. | Added shared `components/ui/chartTheme.ts` (`getChartTheme(isDark)`) that returns axis tick / grid / tooltip colours per theme, wired all 4 chart components to call it via `useTheme()`, added `isDark` to the imperative chart `useEffect` deps so they re-render on theme toggle, and split out a per-mode dataset palette in `BrandChart`. Extracted `KeywordDetail` chart options into a sibling `KeywordDetailChartOptions.ts` to keep the components file under the 400-line cap. Test setup gained a `window.matchMedia` polyfill so components consuming `useTheme()` render in jsdom. |
+| **User-content images** (`Citations/CitationDetailModal`, `Citations/CrawlHistory`, `RawResponses/ImageViewer`) | Cited-page screenshots and raw S3 image objects carry their own bright white-themed backgrounds, so even with the surrounding panel correctly tinted dark they still appeared as harsh white slabs. | Added `dark:brightness-90 dark:contrast-95` to `<img>` tags rendering arbitrary captured content. Profile photos (About tab) and the inverting brand mark (sidebar) intentionally do **not** receive the filter – the rule only applies to user-supplied screenshots. Documented in design-system §7.6 Images. |
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -396,6 +396,7 @@ Modals and chrome:
 | `Spinner`       | Loading indicator (`sm`/`md`/`lg`). |
 | `ThemeToggle`   | Light / dark / system theme switcher. |
 | `Icons.tsx`     | Shared SVG icon set. |
+| `chartTheme.ts` | `getChartTheme(isDark)` returns axis tick / grid / tooltip colours for Chart.js so canvases adapt to the theme. |
 | `MarkdownProcessor` | Helpers for rendering AI markdown safely. |
 
 ### 7.3 Layout
@@ -411,6 +412,58 @@ Organised by feature folder under `components/<Feature>`. Each feature
 folder has an `index.ts` that re-exports its public surface. Internal
 components keep `*.spec.tsx` next to the file. See
 `.kiro/steering/structure.md` for the layout map.
+
+### 7.5 Charts
+
+The app uses Chart.js (via `react-chartjs-2` for declarative usage and
+the imperative `Chart` constructor for the dashboard charts). Canvases
+do **not** participate in the global CSS override system, so chart
+chrome (axis ticks, grid, legend, tooltip) needs explicit theme-aware
+colours.
+
+Use the shared `getChartTheme(isDark)` helper from
+`components/ui/chartTheme.ts` together with the `useTheme` hook:
+
+```tsx
+import { useTheme } from '../../hooks/useTheme';
+import { getChartTheme } from '../ui/chartTheme';
+
+export function MyChart() {
+  const { isDark } = useTheme();
+  const theme = getChartTheme(isDark);
+
+  const options = {
+    plugins: {
+      legend: { labels: { color: theme.textColor } },
+      tooltip: {
+        backgroundColor: theme.tooltipBackground,
+        borderColor: theme.tooltipBorder,
+        titleColor: theme.tooltipText,
+        bodyColor: theme.tooltipText,
+      },
+    },
+    scales: {
+      x: { ticks: { color: theme.textColor }, grid: { color: theme.gridColor } },
+      y: { ticks: { color: theme.textColor }, grid: { color: theme.gridColor } },
+    },
+  };
+  // ...
+}
+```
+
+For imperative `new Chart(ctx, …)` usage, include `isDark` in the
+`useEffect` dependency array so the chart re-renders when the user
+toggles the theme.
+
+Dataset colours (the actual bars / slices / lines) follow these
+conventions:
+
+- **Saturated branded palettes** (e.g. `rgba(168, 85, 247, 0.5)` for
+  Claude) stay fixed across themes – they are saturated enough to read
+  on both backgrounds.
+- **Neutral data series** (e.g. the brand mentions doughnut whose
+  first slices are `gray-900` / `gray-700`) need a light- and
+  dark-mode palette. See `Dashboard/BrandChart.tsx` for the pattern.
 
 ---
 
@@ -508,6 +561,7 @@ design-system pass:
 | `Brands/ProviderResponseCard.tsx` | `🌍 Geographic Analysis` emoji prefix on a section header. | Removed; section title now reads "Geographic Analysis". |
 | `Keywords/KeywordDetailComponents.tsx` | `✕ Close` unicode multiplication-sign in the close button. | Replaced with `CloseIcon` leading the label. |
 | **All accent-tinted surfaces (48 files, ~349 occurrences)** | Pages using `bg-{tone}-50/100`, `text-{tone}-700/800`, `border-{tone}-100/200/300` rendered as bright pale-tinted panels in dark mode. Most visible on `Settings > Brand Tracking`, where the stacked emerald + amber + violet panels turned the whole page green/yellow on a dark background. | Extended the `index.css` global override system to cover every accent tone: tinted surfaces become translucent dark tints, accent text shifts to `*-300/-200`, accent borders become muted translucent equivalents. Zero call-site changes – fixes all 48 files at once and any future accent surface gets the right behaviour automatically. |
+| **Chart.js canvases** (`Dashboard/ProviderChart`, `Dashboard/BrandChart`, `Visibility/PersonaComparisonChart`, `Keywords/KeywordDetail*`) | Canvases sit outside Tailwind's CSS so the global overrides do not reach them. Axis tick text, grid lines, legend, tooltip, and the neutral doughnut palette stayed in light-mode colours on dark, leaving labels invisible and the BrandChart's `gray-900` slice merging into the dark page. Charts also did not re-render when the user toggled the theme. | Added shared `components/ui/chartTheme.ts` (`getChartTheme(isDark)`) that returns axis tick / grid / tooltip colours per theme, wired all 4 chart components to call it via `useTheme()`, added `isDark` to the imperative chart `useEffect` deps so they re-render on theme toggle, and split out a per-mode dataset palette in `BrandChart`. Extracted `KeywordDetail` chart options into a sibling `KeywordDetailChartOptions.ts` to keep the components file under the 400-line cap. Test setup gained a `window.matchMedia` polyfill so components consuming `useTheme()` render in jsdom. |
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,430 @@
+# Design System
+
+Visual language for the Citation Analysis dashboard. This document is the
+source of truth for colours, typography, spacing, components, icons, and
+the dark/light theming strategy. It exists so contributors can build new
+UI without inventing styles, and so reviewers have a checklist for
+catching anomalies.
+
+> **Stack:** Tailwind CSS 3 (`darkMode: 'class'`), React 18, no icon
+> library, no component library beyond AWS Amplify Authenticator. All
+> primitives live under `web/src/components/ui/`.
+
+---
+
+## 1. Theming model
+
+### 1.1 Strategy
+
+The app is class-based: dark mode is enabled by adding the class `dark`
+to `<html>`. Theme preference is managed by `useTheme` (`light` /
+`dark` / `system`) and toggled via the `ThemeToggle` button.
+
+There are two ways a Tailwind class can become "dark-mode aware":
+
+1. **Explicit `dark:` variant** – e.g. `bg-white dark:bg-gray-800`.
+   Used in layout chrome (sidebar, header, fallback error screens) and
+   anywhere we deliberately need a different colour in dark mode.
+2. **Global override** – common Tailwind classes (`bg-white`,
+   `bg-gray-50`, `text-gray-900`, `border-gray-200`, …) are remapped
+   inside `web/src/index.css` under the `.dark` selector. This means
+   most components do not need `dark:` variants at all.
+
+> **Rule of thumb:** if your class is in the global override list below,
+> do not add a `dark:` variant; trust the override. Only reach for
+> `dark:` when a component sits on a surface where the global override
+> is wrong (e.g. always-dark error fallbacks, gradient backgrounds, the
+> primary action rail in `main.tsx` and `TabContent.tsx`).
+
+### 1.2 Globally overridden classes
+
+Defined in `web/src/index.css`:
+
+| Light class            | Dark replacement |
+| ---------------------- | ---------------- |
+| `bg-white`             | gray-800         |
+| `bg-gray-50`           | gray-900         |
+| `bg-gray-100`          | gray-700         |
+| `border-gray-200`      | gray-700         |
+| `border-gray-100`      | gray-700         |
+| `text-gray-900`        | gray-50          |
+| `text-gray-700`        | gray-300         |
+| `text-gray-600`        | gray-300         |
+| `text-gray-500`        | gray-400         |
+| `text-gray-400`        | gray-500         |
+| `text-gray-300`        | gray-400         |
+| `hover:bg-gray-50`     | gray-700         |
+| `hover:bg-gray-100`    | gray-600         |
+| `hover:bg-gray-200`    | gray-600         |
+| `input/textarea/select` background, border, placeholder, focus ring | gray-700/-600/-400/-500 |
+
+Markdown prose styles (`.prose-markdown`) and AWS Amplify Authenticator
+have their own dark overrides in the same file.
+
+### 1.3 CSS variables
+
+The body uses two semantic tokens that switch with the theme:
+
+```css
+:root        { --color-bg-primary: 249 250 251; --color-text-primary: 17 24 39;  }
+.dark        { --color-bg-primary: 17 24 39;     --color-text-primary: 249 250 251; }
+```
+
+These are exposed as `bg-skin-primary` / `text-skin-primary` utilities
+for the body element only. Component-level styling uses Tailwind colour
+utilities directly, not these variables.
+
+---
+
+## 2. Colour palette
+
+### 2.1 Neutral scale (primary surface system)
+
+| Token           | Light      | Dark equivalent (via override) |
+| --------------- | ---------- | ------------------------------ |
+| Background      | `gray-50`  | `gray-900` |
+| Surface         | `white`    | `gray-800` |
+| Surface raised  | `gray-100` | `gray-700` |
+| Border          | `gray-200` | `gray-700` |
+| Text primary    | `gray-900` | `gray-50`  |
+| Text secondary  | `gray-600` | `gray-300` |
+| Text muted      | `gray-400` | `gray-500` |
+| Action primary  | `gray-900` | (kept dark; see Buttons) |
+
+### 2.2 Accent palette
+
+Accents are used sparingly: navigation icon tints, stat card badges,
+status pills, and feedback states.
+
+| Tone    | Usage                            | Tailwind family |
+| ------- | -------------------------------- | --------------- |
+| Blue    | Searches, info, neutral metrics  | `blue-*`        |
+| Indigo  | Visibility metrics               | `indigo-*`      |
+| Violet  | Brand mentions, citation counts  | `violet-*`      |
+| Purple  | Citations                        | `purple-*`      |
+| Fuchsia | Prompt insights                  | `fuchsia-*`     |
+| Rose    | Citation gaps                    | `rose-*`        |
+| Emerald | Success, "you", crawled pages    | `emerald-*` / `green-*` |
+| Amber   | Warnings, keyword counts         | `amber-*` / `yellow-*` |
+| Red     | Errors, destructive actions      | `red-*`         |
+| Sky     | Recent searches                  | `sky-*`         |
+| Slate   | Raw responses, low emphasis      | `slate-*`       |
+| Teal    | Content studio                   | `teal-*`        |
+| Orange  | Schedule                         | `orange-*`      |
+
+Pattern for badges and pills: `bg-{tone}-50 text-{tone}-700`
+(`bg-{tone}-100` for stronger emphasis). Avoid mixing two accents in
+the same component.
+
+### 2.3 Semantic state colours
+
+| State    | Background     | Text          | Border         |
+| -------- | -------------- | ------------- | -------------- |
+| Success  | `bg-green-50`  | `text-green-700` | `border-green-200` |
+| Warning  | `bg-yellow-50` | `text-yellow-800` | `border-yellow-200` |
+| Error    | `bg-red-50`    | `text-red-700` | `border-red-200` |
+| Info     | `bg-blue-50`   | `text-blue-700` | `border-blue-200` |
+
+---
+
+## 3. Typography
+
+The app uses the system font stack inherited from Tailwind defaults.
+
+| Role            | Class                                  |
+| --------------- | -------------------------------------- |
+| Page title (h2) | `text-2xl font-semibold text-gray-900` |
+| Section title (h3) | `text-lg font-semibold text-gray-900` |
+| Card label      | `text-sm font-medium text-gray-700`    |
+| Body            | `text-sm text-gray-600`                |
+| Helper / caption| `text-xs text-gray-400`                |
+| Numeric stat    | `text-3xl font-semibold text-gray-900` |
+| Section label   | `text-xs font-semibold uppercase tracking-wider text-gray-400` |
+
+> Markdown prose (AI responses, content studio output) uses the
+> `.prose-markdown` class which has its own typographic scale defined
+> in `index.css`. Do not re-style markdown output; extend
+> `.prose-markdown` instead.
+
+---
+
+## 4. Spacing and layout
+
+- The grid uses Tailwind's default 4 px base.
+- Standard card padding: `p-6` (24 px) on desktop, `p-4` on dense lists.
+- Standard gap between cards: `gap-4` to `gap-6`.
+- Section margin between blocks: `mb-6 sm:mb-8`.
+- Sidebar width: `w-64` (256 px), top bar height: `h-16` (64 px).
+- Page content max width is unconstrained – it fills the viewport
+  minus the sidebar, so internal widgets must remain readable up to
+  ultra-wide displays.
+
+Border radius: `rounded-lg` (8 px) is the default for cards, inputs,
+and buttons. Larger surfaces (icon badges, modals) use `rounded-xl`.
+Pills use `rounded-full`.
+
+Borders are 1 px (`border`) and use the neutral border tokens above.
+
+---
+
+## 5. Buttons
+
+Use the `<Button>` component from `web/src/components/ui/Button.tsx`.
+Do not hand-roll button class strings.
+
+### 5.1 Variants
+
+| Variant      | When to use | Visual |
+| ------------ | ----------- | ------ |
+| `primary`    | The main action of a page or form. Only **one** primary per visible group. | `bg-gray-900 text-white hover:bg-gray-800` |
+| `secondary`  | Alternate actions of equal weight. | `bg-white text-gray-900 border border-gray-200 hover:bg-gray-50` |
+| `ghost`      | Tertiary actions, cancel buttons, links inside dense rows. | `text-gray-600 hover:text-gray-900 hover:bg-gray-100` |
+| `danger`     | Destructive primary actions inside confirmation dialogs. | `bg-red-600 text-white hover:bg-red-700` |
+| `iconOnly`   | Square button hosting only an icon (toolbar / list-row actions). Always provide `aria-label`. | `text-gray-400 hover:text-gray-600 hover:bg-gray-100` |
+
+### 5.2 Sizes
+
+| Size | Height | When to use |
+| ---- | ------ | ----------- |
+| `sm` | ~32 px (`px-3 py-1.5`) | Inside dense rows, table cells, list-row actions. |
+| `md` | ~36-40 px (`px-4 py-2`, default) | Standard page-level actions. |
+
+### 5.3 Composition
+
+Use `leadingIcon` / `trailingIcon` props instead of hand-placing icons:
+
+```tsx
+<Button
+  leadingIcon={<PlusIcon className="w-4 h-4" />}
+  onClick={() => setShowCreate(true)}
+>
+  New Persona
+</Button>
+```
+
+Disabled state: pass `disabled`. The component applies `opacity-50` and
+`cursor-not-allowed` automatically. For loading, swap children for a
+loading label (`'Saving…'`) – do not introduce custom spinners on
+primary buttons.
+
+### 5.4 Dark-mode inversion
+
+`primary` buttons rely on the global override system, so
+`bg-gray-900 / hover:bg-gray-800` works in both themes. For buttons
+that sit on always-dark surfaces in light mode (the app rail,
+fallback error screens), set `invertOnDark` so the dark theme inverts
+them to a light pill (`dark:bg-gray-100 dark:text-gray-900`).
+
+```tsx
+<Button invertOnDark onClick={reload}>Reload Page</Button>
+```
+
+### 5.5 Anti-patterns
+
+- Inline `className="px-4 py-2 bg-gray-900 text-white …"` strings.
+  Use `<Button>` so the design system stays consistent.
+- Mixing sizes in the same row.
+- More than one primary button visible at once.
+- `iconOnly` button without `aria-label` / `title`.
+
+---
+
+## 6. Icons
+
+### 6.1 Source and style
+
+We ship our own icon set instead of pulling a library. Icons live in
+`web/src/components/ui/Icons.tsx` and follow a single Heroicons-style
+convention:
+
+- 24 × 24 viewBox.
+- Stroke only, `fill="none"`, `stroke="currentColor"`.
+- `strokeLinecap="round"`, `strokeLinejoin="round"`,
+  `strokeWidth={1.5}`.
+- Default size `w-5 h-5` (20 px), sized via the `className` prop.
+- Colour is inherited from `currentColor`, so place the icon inside an
+  element whose `text-*` colour you want.
+
+Available icons: `PauseIcon`, `PlayIcon`, `PencilIcon`, `TrashIcon`,
+`PlusIcon`, `CloseIcon`, `ChevronRightIcon`, `ChevronDownIcon`,
+`SearchIcon`, `LinkIcon`, `GlobeIcon`, `KeyIcon`, `WarningIcon`.
+
+The sidebar (`Layout/Sidebar.tsx`) has a separate set of inline icons
+(`DashboardIcon`, `BrandIcon`, `CitationsIcon`, …). They follow the
+same convention; consolidating them into `Icons.tsx` is a future
+refactor.
+
+### 6.2 Adding a new icon
+
+1. Pick or trace a Heroicons outline path.
+2. Add a function component to `Icons.tsx` matching the existing
+   pattern (props: `className`, `title`).
+3. Re-export it from `components/ui/index.ts`.
+4. Use it via `<MyIcon className="w-4 h-4" />`.
+
+### 6.3 Sizing reference
+
+| Context | Class |
+| ------- | ----- |
+| Inline with body text | `w-3 h-3` or `w-3.5 h-3.5` |
+| Icon-only buttons     | `w-4 h-4` |
+| Sidebar nav items     | `w-5 h-5` |
+| Stat card badges      | `w-6 h-6` |
+| Empty-state illustrations | `w-12 h-12` |
+
+### 6.4 Accessibility
+
+- Decorative icons need no label; the wrapping `<svg>` defaults to
+  `aria-hidden`.
+- When the icon is the only visible content (icon-only buttons,
+  sidebar collapse, expand chevrons that double as the click
+  target), the host element must carry `aria-label` and the icon's
+  `title` prop should be set or the host element should have a
+  `title` attribute.
+- Use `aria-expanded` on disclosure buttons that toggle a chevron.
+
+### 6.5 No emoji as UI
+
+Emoji are not used as UI affordances anywhere. Reasons:
+
+1. Inconsistent rendering across operating systems.
+2. No way to recolour for dark mode or hover states.
+3. Screen readers announce the unicode name, not the action.
+
+The only places emoji appear are decorative content **inside** the
+About section (`components/About/ArchitectureTab.tsx`,
+`components/About/LicensesTab.tsx`) where they label conceptual
+sections, not interactive controls. Treat that as the ceiling for
+emoji usage.
+
+---
+
+## 7. Components inventory
+
+### 7.1 Primitives (`components/ui/`)
+
+| Component       | Purpose |
+| --------------- | ------- |
+| `Button`        | Canonical button. Variants + sizes. Use everywhere. |
+| `Modal`, `ConfirmModal`, `AlertModal` | Overlays with focus trap and escape handling. |
+| `Spinner`       | Loading indicator (`sm`/`md`/`lg`). |
+| `ThemeToggle`   | Light / dark / system theme switcher. |
+| `Icons.tsx`     | Shared SVG icon set. |
+| `MarkdownProcessor` | Helpers for rendering AI markdown safely. |
+
+### 7.2 Layout
+
+`components/Layout/Sidebar.tsx` is the only navigation chrome. It owns
+nav sections, badges, and the "running" pulse indicator. New top-level
+features should be added there as a new entry, not as a new chrome
+component.
+
+### 7.3 Feature components
+
+Organised by feature folder under `components/<Feature>`. Each feature
+folder has an `index.ts` that re-exports its public surface. Internal
+components keep `*.spec.tsx` next to the file. See
+`.kiro/steering/structure.md` for the layout map.
+
+---
+
+## 8. Forms
+
+- Wrap form fields in `<form>` and submit via a `primary` button.
+- Labels: `block text-sm font-medium text-gray-700 mb-1` paired via
+  `htmlFor` / `id`.
+- Inputs / textareas / selects: `w-full p-2 border border-gray-200
+  rounded-lg text-sm focus:ring-2 focus:ring-gray-900`. Dark-mode
+  styling is applied globally.
+- Helper text under inputs: `text-xs text-gray-400 mt-1`.
+- Validation errors: `text-xs text-red-600 mt-1`.
+- Cancel buttons live to the right of the submit button and use the
+  `ghost` variant.
+
+---
+
+## 9. Tables
+
+- Header row: `bg-gray-50` background, `text-xs font-medium uppercase
+  tracking-wider text-gray-500`.
+- Cell padding: `px-6 py-4`.
+- Row separators: `divide-y divide-gray-200`.
+- Sortable columns use a chevron icon next to the label and toggle
+  `aria-sort`.
+- Expandable rows use `ChevronRightIcon` (collapsed) and
+  `ChevronDownIcon` (expanded), wrapped in a button with
+  `aria-expanded`.
+
+---
+
+## 10. Favicon and identity
+
+- App favicon: `web/public/assets/favicon.ico` (32×32 ICO).
+- App name: "Citation Analysis Dashboard" (`web/index.html` `<title>`).
+- Logo mark in sidebar: an inline bar-chart SVG inside an
+  `bg-gray-900 dark:bg-white` rounded square (32×32).
+
+If a new favicon is needed, replace `favicon.ico` and add modern
+formats (`favicon.svg`, `apple-touch-icon.png`) referenced from
+`web/index.html`. Keep the silhouette legible at 16×16.
+
+---
+
+## 11. Anomaly checklist
+
+Use this list during code review of any UI change. Every item is a
+real anomaly that has been fixed in the codebase – don't reintroduce
+them.
+
+- [ ] No emoji as a button label or interactive icon. Use icons from
+      `components/ui/Icons.tsx`.
+- [ ] No unicode arrows (`▲▼◀▶`) for expand/collapse. Use
+      `ChevronDownIcon` / `ChevronRightIcon`, with `aria-expanded` on
+      the button.
+- [ ] No hand-rolled `className="px-4 py-2 bg-gray-900 …"` button
+      strings. Use `<Button>`.
+- [ ] No icon-only button missing `aria-label` / `title`.
+- [ ] No hard-coded hex colours. Use Tailwind tokens.
+- [ ] No mixed sizes in the same button group / list row.
+- [ ] No new `dark:` variants for classes already covered by the
+      global override (`bg-white`, `text-gray-900`, …).
+- [ ] No `dark:` variants forgotten on always-dark surfaces (app rail,
+      fallback error screens).
+- [ ] No emoji-as-key prop signatures (e.g. `icon: '🔍'` mapping into
+      a switch). Take a `ReactNode` icon component instead.
+- [ ] All new icons follow the stroke convention: 24 × 24 viewBox,
+      `currentColor`, `strokeWidth={1.5}`.
+- [ ] No primary button without `transition-colors` (provided by
+      `<Button>` automatically).
+- [ ] No two primary buttons in the same visible group.
+
+### 11.1 Recently fixed anomalies (May 2026)
+
+For reference – these were the anomalies discovered during the
+design-system pass:
+
+| Component | Issue | Fix |
+| --------- | ----- | --- |
+| `Settings/QueryPromptsManager.tsx` | Emoji icons (`⏸▶✏️🗑`) on action buttons; non-canonical button styling for "+ New Persona". | Replaced with `PauseIcon`/`PlayIcon`/`PencilIcon`/`TrashIcon`. Buttons migrated to `<Button>` primary/ghost/iconOnly variants. |
+| `Dashboard/StatCard.tsx` | `icon` prop typed as a `string` (emoji) and used as a key into an SVG lookup map – unrelated emoji silently fell back to a literal emoji render. | Refactored to take a `ReactNode` icon directly plus a `tone` prop (blue/violet/emerald/amber/gray). Call site `Layout/TabContent.tsx` updated to pass `SearchIcon`/`LinkIcon`/`GlobeIcon`/`KeyIcon`. |
+| `Tables/TopCitationsTable.tsx`, `Keywords/KeywordDetailComponents.tsx`, `Brands/ProviderResponseCard.tsx` | Unicode `▲▼▶` for expand/collapse. | Replaced with `ChevronDownIcon` / `ChevronRightIcon`, plus `aria-expanded` and `aria-label` on the controls. |
+| `Brands/BrandExpansionPanel.tsx` | `⚠️` emoji on duplicate-warning text. | Replaced with `WarningIcon`. |
+
+---
+
+## 12. Where to put new design system code
+
+```
+web/src/components/ui/
+├── Button.tsx          # button variants + sizes
+├── Icons.tsx           # shared icon set
+├── Modal.tsx           # overlays
+├── Spinner.tsx         # loading
+├── ThemeToggle.tsx     # theme switcher
+├── MarkdownProcessor.tsx
+└── index.ts            # public re-exports
+```
+
+When in doubt, add the primitive here and re-export it from
+`index.ts`. Feature folders should consume primitives, not redefine
+them.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -38,7 +38,9 @@ There are two ways a Tailwind class can become "dark-mode aware":
 
 ### 1.2 Globally overridden classes
 
-Defined in `web/src/index.css`:
+Defined in `web/src/index.css`. Two groups: **neutral** and **accent**.
+
+#### 1.2.1 Neutral scale
 
 | Light class            | Dark replacement |
 | ---------------------- | ---------------- |
@@ -58,8 +60,36 @@ Defined in `web/src/index.css`:
 | `hover:bg-gray-200`    | gray-600         |
 | `input/textarea/select` background, border, placeholder, focus ring | gray-700/-600/-400/-500 |
 
-Markdown prose styles (`.prose-markdown`) and AWS Amplify Authenticator
-have their own dark overrides in the same file.
+#### 1.2.2 Accent surfaces, text, and borders
+
+The same global-override pattern is applied to every accent palette
+the app uses. The principle is: tinted surfaces become **translucent
+dark tints** and accent text shifts to the **`*-300` / `*-200`** shade
+that is legible on dark.
+
+| Light class                   | Dark behaviour |
+| ----------------------------- | -------------- |
+| `bg-{tone}-50`                | translucent dark tint (~25% alpha of `*-900`) |
+| `bg-{tone}-100`               | translucent dark tint (~40% alpha of `*-900`) |
+| `text-{tone}-700` / `-800`    | `*-300` (legible accent on dark) |
+| `text-{tone}-900`             | `*-200` (highest emphasis accent) |
+| `border-{tone}-100`           | translucent `*-800/-900` border (~40% alpha) |
+| `border-{tone}-200`           | translucent `*-700/-800` border (~55% alpha) |
+| `border-{tone}-300`           | translucent `*-600/-700` border (~70% alpha) |
+| `hover:bg-{tone}-100/-200`    | denser translucent tint (50–70% alpha) |
+
+Tones covered: `emerald`, `green`, `amber`, `yellow`, `violet`,
+`purple`, `fuchsia`, `blue`, `indigo`, `sky`, `cyan`, `teal`, `red`,
+`rose`, `orange`, `slate`. Alpha-modifier classes used in row
+backgrounds (`bg-green-50/30`, `bg-emerald-50/50`, `bg-red-50/30`,
+`bg-orange-50/30`) have their own matching dark-mode overrides.
+
+> **What is NOT overridden:** saturated solid surfaces
+> (`bg-{tone}-500/600/700`) and their `text-white` pairings. Those are
+> primary-action buttons that work in both themes as-is.
+
+Markdown prose styles (`.prose-markdown`) and AWS Amplify
+Authenticator have their own dark overrides in the same file.
 
 ### 1.3 CSS variables
 
@@ -94,27 +124,33 @@ utilities directly, not these variables.
 ### 2.2 Accent palette
 
 Accents are used sparingly: navigation icon tints, stat card badges,
-status pills, and feedback states.
+status pills, and feedback states. Each tone has a defined behaviour in
+both themes.
 
-| Tone    | Usage                            | Tailwind family |
-| ------- | -------------------------------- | --------------- |
-| Blue    | Searches, info, neutral metrics  | `blue-*`        |
-| Indigo  | Visibility metrics               | `indigo-*`      |
-| Violet  | Brand mentions, citation counts  | `violet-*`      |
-| Purple  | Citations                        | `purple-*`      |
-| Fuchsia | Prompt insights                  | `fuchsia-*`     |
-| Rose    | Citation gaps                    | `rose-*`        |
-| Emerald | Success, "you", crawled pages    | `emerald-*` / `green-*` |
-| Amber   | Warnings, keyword counts         | `amber-*` / `yellow-*` |
-| Red     | Errors, destructive actions      | `red-*`         |
-| Sky     | Recent searches                  | `sky-*`         |
-| Slate   | Raw responses, low emphasis      | `slate-*`       |
-| Teal    | Content studio                   | `teal-*`        |
-| Orange  | Schedule                         | `orange-*`      |
+| Tone    | Usage                            | Light surface        | Light text            | Dark surface (auto) | Dark text (auto) |
+| ------- | -------------------------------- | -------------------- | --------------------- | ------------------- | ---------------- |
+| Blue    | Searches, info, neutral metrics  | `bg-blue-50/100`     | `text-blue-700/800`   | translucent blue-900 | `blue-300`      |
+| Indigo  | Visibility metrics               | `bg-indigo-50/100`   | `text-indigo-700/800` | translucent indigo-900 | `indigo-300`  |
+| Violet  | Brand mentions                   | `bg-violet-50/100`   | `text-violet-700/800` | translucent violet-900 | `violet-300`  |
+| Purple  | Citations                        | `bg-purple-50/100`   | `text-purple-700/800` | translucent purple-900 | `purple-300`  |
+| Fuchsia | Prompt insights                  | `bg-fuchsia-50/100`  | `text-fuchsia-700/800` | translucent fuchsia-900 | `fuchsia-300` |
+| Rose    | Citation gaps                    | `bg-rose-50/100`     | `text-rose-700/800`   | translucent rose-900 | `rose-300`     |
+| Emerald | "Yours", success, crawled        | `bg-emerald-50/100`  | `text-emerald-700/800` | translucent emerald-900 | `emerald-300` |
+| Green   | Success, positive                | `bg-green-50/100`    | `text-green-700/800`  | translucent green-900 | `green-300`    |
+| Amber   | Warnings, competitors            | `bg-amber-50/100`    | `text-amber-700/800`  | translucent amber-900 | `amber-300`    |
+| Yellow  | Medium priority                  | `bg-yellow-50/100`   | `text-yellow-700/800` | translucent yellow-900 | `yellow-300`  |
+| Red     | Errors, destructive              | `bg-red-50/100`      | `text-red-700/800`    | translucent red-900 | `red-300`       |
+| Sky     | Recent searches                  | `bg-sky-50/100`      | `text-sky-700/800`    | translucent sky-900 | `sky-300`       |
+| Slate   | Raw responses, low emphasis      | `bg-slate-50/100`    | `text-slate-700/800`  | translucent slate-900 | `slate-300`   |
+| Teal    | Content studio                   | `bg-teal-50/100`     | `text-teal-700/800`   | translucent teal-900 | `teal-300`     |
+| Orange  | Schedule                         | `bg-orange-50/100`   | `text-orange-700/800` | translucent orange-900 | `orange-300` |
 
 Pattern for badges and pills: `bg-{tone}-50 text-{tone}-700`
 (`bg-{tone}-100` for stronger emphasis). Avoid mixing two accents in
 the same component.
+
+> Solid action buttons keep `bg-{tone}-600 text-white hover:bg-{tone}-700`
+> in both themes. Those classes are intentionally NOT overridden.
 
 ### 2.3 Semantic state colours
 
@@ -306,7 +342,52 @@ usage.
 
 ## 7. Components inventory
 
-### 7.1 Primitives (`components/ui/`)
+### 7.1 Pages and theme support
+
+Every route in `App.tsx` is listed below with its primary components
+and the light / dark mode coverage status. "✓ auto" means the page
+relies entirely on the global overrides described in §1.2 — no
+component-level `dark:` variants are needed and the page renders
+correctly in both themes.
+
+| # | Route | Page label | Primary components | Theme support |
+| - | ----- | ---------- | ------------------ | ------------- |
+| 1 | `/` | Dashboard | `Layout/TabContent`, `Dashboard/StatCard`, `Dashboard/ProviderChart`, `Dashboard/BrandChart`, `Tables/TopCitationsTable`, `Tables/RecentSearchesTable` | ✓ auto |
+| 2 | `/visibility` | Visibility | `Visibility/VisibilityDashboard`, `VisibilityComponents`, `PersonaComparisonChart`, `shared/PersonaSelector` | ✓ auto |
+| 3 | `/brands` | Brand Mentions | `Brands/BrandsView`, `BrandConfigContent`, `BrandConfigPanel`, `BrandTagList`, `DomainList`, `IndustrySelector`, `ExtractionOptions`, `BrandExpansionPanel`, `CompetitorDiscoveryPanel`, `FirstPartyBrandsSection`, `CompetitorBrandsSection`, `BrandMentionsTable`, `BrandOverviewTab`, `BrandDetailModal`, `ProviderResponseCard`, `PromptEditor` | ✓ auto (was the green-everywhere bug) |
+| 4 | `/citations` | Citations | `Citations/CitationsView`, `CitationFilters`, `CitationRow`, `CitationTableHeader`, `CitationDetailModal`, `CrawlHistory`, `PaginationControls` | ✓ auto |
+| 5 | `/prompt-insights` | Prompt Insights | `Insights/PromptInsights`, `PromptCard` | ✓ auto |
+| 6 | `/citation-gaps` | Citation Gaps | `Insights/CitationGaps`, `GapCard` | ✓ auto |
+| 7 | `/recommendations` | Action Center | `Insights/Recommendations` | ✓ auto |
+| 8 | `/keyword-research` | Keyword Research | `KeywordResearch/KeywordResearchView`, `KeywordExpansion`, `CompetitorAnalysis`, `CompetitorAnalysisComponents`, `ResearchHistory`, `KeywordResultsTable` | ✓ auto |
+| 9 | `/content-studio` | Content Studio | `ContentStudio/ContentStudioView`, `ContentGenerator`, `ContentHistory`, `ContentDetailModal`, `ContentIdeaCard`, `HistoryListItem`, `SelfReflection/SelfReflectionPanel` | ✓ auto |
+| 10 | `/searches` | Recent Searches | `Searches/SearchesView`, `SearchesViewComponents` | ✓ auto |
+| 11 | `/raw-responses` | Raw Responses | `RawResponses/RawResponsesExplorer`, `Breadcrumb`, `FileViewer`, `ImageViewer` | ✓ auto |
+| 12 | `/execution` | Run Analysis | `Execution/ExecutionMonitor`, `ExecutionStatus`, `ExecutionMonitorComponents`, `TriggerSection` | ✓ auto |
+| 13 | `/schedule` | Schedule | `Schedule/ScheduleManager` | ✓ auto |
+| 14 | `/settings` | Settings | `Settings/SettingsView`, `UsersConfig`, `UserModals`, `QueryPromptsManager` | ✓ auto |
+
+Modals and chrome:
+
+| Component | Coverage |
+| --------- | -------- |
+| `Layout/Sidebar` | explicit `dark:` variants (always-dark navigation rail) |
+| `App` header (sign out, about, theme toggle) | explicit `dark:` variants |
+| `ui/Modal` / `ConfirmModal` / `AlertModal` | explicit `dark:` variants on overlay + content |
+| `ui/Spinner` | `currentColor` – inherits theme |
+| `ui/ThemeToggle` | explicit `dark:` variants |
+| `ui/Button` | global override; `invertOnDark` flag for always-dark surfaces |
+| `About/AboutModal` and tabs | explicit `dark:` variants |
+| `ErrorBoundary` / `ErrorDisplay` | explicit `dark:` variants on always-dark fallback |
+| `main.tsx` `RootErrorFallback` | explicit `dark:` variants |
+
+> "✓ auto" pages do not need `dark:` variants on accent classes because
+> the global overrides handle them. If a page in the table changes its
+> mind and starts using a class that is **not** in §1.2, add the
+> override to `index.css` rather than sprinkling `dark:` variants
+> across components.
+
+### 7.2 Primitives (`components/ui/`)
 
 | Component       | Purpose |
 | --------------- | ------- |
@@ -317,14 +398,14 @@ usage.
 | `Icons.tsx`     | Shared SVG icon set. |
 | `MarkdownProcessor` | Helpers for rendering AI markdown safely. |
 
-### 7.2 Layout
+### 7.3 Layout
 
 `components/Layout/Sidebar.tsx` is the only navigation chrome. It owns
 nav sections, badges, and the "running" pulse indicator. New top-level
 features should be added there as a new entry, not as a new chrome
 component.
 
-### 7.3 Feature components
+### 7.4 Feature components
 
 Organised by feature folder under `components/<Feature>`. Each feature
 folder has an `index.ts` that re-exports its public surface. Internal
@@ -392,9 +473,17 @@ them.
 - [ ] No hard-coded hex colours. Use Tailwind tokens.
 - [ ] No mixed sizes in the same button group / list row.
 - [ ] No new `dark:` variants for classes already covered by the
-      global override (`bg-white`, `text-gray-900`, …).
+      global override – this includes neutrals (`bg-white`,
+      `text-gray-900`, …) **and accent tones** (`bg-emerald-50`,
+      `text-amber-800`, `border-blue-200`, …). If you find yourself
+      writing `dark:bg-emerald-900/20` or similar, add the override to
+      `index.css` instead so every accent surface gets it.
+- [ ] No accent surface inside an always-dark area without checking
+      that the global override matches the intent (e.g. status pills
+      inside the dark sidebar – those already have explicit `dark:`
+      treatment).
 - [ ] No `dark:` variants forgotten on always-dark surfaces (app rail,
-      fallback error screens).
+      fallback error screens, header chrome, modals).
 - [ ] No emoji-as-key prop signatures (e.g. `icon: '🔍'` mapping into
       a switch). Take a `ReactNode` icon component instead.
 - [ ] All new icons follow the stroke convention: 24 × 24 viewBox,
@@ -418,6 +507,7 @@ design-system pass:
 | `Brands/CompetitorDiscoveryPanel.tsx` | `✓` text suffix on already-added competitor pills. | Replaced with `CheckIcon` rendered conditionally with `title="Already added"`. |
 | `Brands/ProviderResponseCard.tsx` | `🌍 Geographic Analysis` emoji prefix on a section header. | Removed; section title now reads "Geographic Analysis". |
 | `Keywords/KeywordDetailComponents.tsx` | `✕ Close` unicode multiplication-sign in the close button. | Replaced with `CloseIcon` leading the label. |
+| **All accent-tinted surfaces (48 files, ~349 occurrences)** | Pages using `bg-{tone}-50/100`, `text-{tone}-700/800`, `border-{tone}-100/200/300` rendered as bright pale-tinted panels in dark mode. Most visible on `Settings > Brand Tracking`, where the stacked emerald + amber + violet panels turned the whole page green/yellow on a dark background. | Extended the `index.css` global override system to cover every accent tone: tinted surfaces become translucent dark tints, accent text shifts to `*-300/-200`, accent borders become muted translucent equivalents. Zero call-site changes – fixes all 48 files at once and any future accent surface gets the right behaviour automatically. |
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -247,7 +247,8 @@ convention:
 
 Available icons: `PauseIcon`, `PlayIcon`, `PencilIcon`, `TrashIcon`,
 `PlusIcon`, `CloseIcon`, `ChevronRightIcon`, `ChevronDownIcon`,
-`SearchIcon`, `LinkIcon`, `GlobeIcon`, `KeyIcon`, `WarningIcon`.
+`SearchIcon`, `LinkIcon`, `GlobeIcon`, `KeyIcon`, `WarningIcon`,
+`CheckIcon`, `ArrowRightIcon`.
 
 The sidebar (`Layout/Sidebar.tsx`) has a separate set of inline icons
 (`DashboardIcon`, `BrandIcon`, `CitationsIcon`, …). They follow the
@@ -294,8 +295,12 @@ Emoji are not used as UI affordances anywhere. Reasons:
 The only places emoji appear are decorative content **inside** the
 About section (`components/About/ArchitectureTab.tsx`,
 `components/About/LicensesTab.tsx`) where they label conceptual
-sections, not interactive controls. Treat that as the ceiling for
-emoji usage.
+sections, not interactive controls. There is also a single
+`✓` text suffix in `components/Brands/PromptEditor.tsx` inside a
+native `<select>` `<option>` – browsers will not render React
+components inside `<option>`, so a unicode glyph is the only viable
+choice there. Treat that as the ceiling for emoji / unicode-glyph
+usage.
 
 ---
 
@@ -409,6 +414,10 @@ design-system pass:
 | `Dashboard/StatCard.tsx` | `icon` prop typed as a `string` (emoji) and used as a key into an SVG lookup map – unrelated emoji silently fell back to a literal emoji render. | Refactored to take a `ReactNode` icon directly plus a `tone` prop (blue/violet/emerald/amber/gray). Call site `Layout/TabContent.tsx` updated to pass `SearchIcon`/`LinkIcon`/`GlobeIcon`/`KeyIcon`. |
 | `Tables/TopCitationsTable.tsx`, `Keywords/KeywordDetailComponents.tsx`, `Brands/ProviderResponseCard.tsx` | Unicode `▲▼▶` for expand/collapse. | Replaced with `ChevronDownIcon` / `ChevronRightIcon`, plus `aria-expanded` and `aria-label` on the controls. |
 | `Brands/BrandExpansionPanel.tsx` | `⚠️` emoji on duplicate-warning text. | Replaced with `WarningIcon`. |
+| `Brands/BrandMentionsTable.tsx` | `→` text arrow inside "View Details" button. | Replaced with `ArrowRightIcon` trailing the label. |
+| `Brands/CompetitorDiscoveryPanel.tsx` | `✓` text suffix on already-added competitor pills. | Replaced with `CheckIcon` rendered conditionally with `title="Already added"`. |
+| `Brands/ProviderResponseCard.tsx` | `🌍 Geographic Analysis` emoji prefix on a section header. | Removed; section title now reads "Geographic Analysis". |
+| `Keywords/KeywordDetailComponents.tsx` | `✕ Close` unicode multiplication-sign in the close button. | Replaced with `CloseIcon` leading the label. |
 
 ---
 

--- a/web/src/components/Brands/BrandConfigContent.tsx
+++ b/web/src/components/Brands/BrandConfigContent.tsx
@@ -110,7 +110,7 @@ export const BrandConfigContent = ({
             <div className="bg-violet-50 rounded-lg p-4 border border-violet-200">
               <h3 className="text-sm font-semibold text-violet-800 mb-2">Custom Entity Types</h3>
               <div className="flex gap-2 mb-3">
-                <input type="text" value={inputs.newEntityType} onChange={(e) => setNewEntityType(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && addEntityType()} placeholder="Enter entity type..." className="flex-1 p-2 border border-violet-300 rounded-lg focus:ring-2 focus:ring-violet-500 bg-white text-sm" />
+                <input type="text" id="new-entity-type" value={inputs.newEntityType} onChange={(e) => setNewEntityType(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && addEntityType()} placeholder="Enter entity type..." aria-label="New custom entity type" className="flex-1 p-2 border border-violet-300 rounded-lg focus:ring-2 focus:ring-violet-500 bg-white text-sm" />
                 <button onClick={addEntityType} className="px-4 py-2 bg-violet-600 text-white rounded-lg hover:bg-violet-700 transition-colors text-sm">Add</button>
               </div>
               <div className="flex flex-wrap gap-2">

--- a/web/src/components/Brands/BrandExpansionPanel.tsx
+++ b/web/src/components/Brands/BrandExpansionPanel.tsx
@@ -1,4 +1,5 @@
 import type { BrandExpansionAllResult } from '../../hooks/useBrandConfig';
+import { WarningIcon } from '../ui';
 
 interface BrandExpansionPanelProps {
   readonly result: BrandExpansionAllResult;
@@ -69,7 +70,10 @@ export const BrandExpansionPanel = ({
 
       {result.duplicates_found && result.duplicates_found.length > 0 && (
         <div className={`mb-3 p-2 ${duplicatesBg} border rounded-lg`}>
-          <p className={`text-xs font-medium ${duplicatesText} mb-1`}>⚠️ Potential duplicates in your list:</p>
+          <p className={`flex items-center gap-1.5 text-xs font-medium ${duplicatesText} mb-1`}>
+            <WarningIcon className="w-3.5 h-3.5" />
+            Potential duplicates in your list:
+          </p>
           <ul className={`text-xs ${duplicatesSubtext} space-y-1`}>
             {result.duplicates_found.map((dup) => (
               <li key={`${dup.brand}-${dup.duplicate_of}`}>

--- a/web/src/components/Brands/BrandMentionsTable.tsx
+++ b/web/src/components/Brands/BrandMentionsTable.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type {
   AggregatedBrand, BrandConfig 
 } from '../../types';
+import { ArrowRightIcon } from '../ui';
 
 interface BrandMentionsTableProps {
   brands: AggregatedBrand[];
@@ -181,9 +182,10 @@ export const BrandMentionsTable = ({
                         e.stopPropagation();
                         onBrandClick(brand);
                       }}
-                      className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                      className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm font-medium"
                     >
-                      View Details →
+                      View Details
+                      <ArrowRightIcon className="w-4 h-4" />
                     </button>
                   </td>
                 </tr>

--- a/web/src/components/Brands/CompetitorBrandsSection.tsx
+++ b/web/src/components/Brands/CompetitorBrandsSection.tsx
@@ -79,11 +79,13 @@ export function CompetitorBrandsSection({
       <p className="text-xs text-amber-700 mb-3">Click a competitor to select it, then use "Expand Brand" to discover their sub-brands.</p>
       <div className="flex gap-2 mb-3">
         <input
+          id="new-competitor-brand"
           type="text"
           value={newBrand}
           onChange={(e) => onNewBrandChange(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && onAddBrand()}
           placeholder="Enter competitor name..."
+          aria-label="New competitor brand"
           className="flex-1 p-2 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 bg-white text-sm"
         />
         <button onClick={onAddBrand} className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors text-sm">Add</button>

--- a/web/src/components/Brands/CompetitorDiscoveryPanel.tsx
+++ b/web/src/components/Brands/CompetitorDiscoveryPanel.tsx
@@ -1,4 +1,5 @@
 import type { CompetitorDiscoveryResult } from '../../hooks/useBrandConfig';
+import { CheckIcon } from '../ui';
 
 interface CompetitorDiscoveryPanelProps {
   readonly result: CompetitorDiscoveryResult;
@@ -51,9 +52,10 @@ export const CompetitorDiscoveryPanel = ({
               key={brand}
               onClick={() => !isAlreadyAdded && onToggleBrand(brand)}
               disabled={isAlreadyAdded}
-              className={`px-3 py-1 rounded-full text-sm transition-colors ${getButtonClass(brand)}`}
+              className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm transition-colors ${getButtonClass(brand)}`}
             >
-              {isAlreadyAdded ? `${brand} ✓` : brand}
+              {brand}
+              {isAlreadyAdded && <CheckIcon className="w-3.5 h-3.5" title="Already added" />}
             </button>
           );
         })}

--- a/web/src/components/Brands/DomainList.tsx
+++ b/web/src/components/Brands/DomainList.tsx
@@ -20,11 +20,13 @@ export const DomainList = ({
     </p>
     <div className="flex gap-2 mb-3">
       <input
+        id="new-first-party-domain"
         type="text"
         value={newDomain}
         onChange={(e) => onNewDomainChange(e.target.value)}
         onKeyDown={(e) => e.key === 'Enter' && onAddDomain()}
         placeholder="e.g., example.com, brand.com"
+        aria-label="New first party domain"
         className="flex-1 p-2 border border-emerald-300 rounded-lg focus:ring-2 focus:ring-emerald-500 bg-white text-sm"
       />
       <button

--- a/web/src/components/Brands/ExtractionOptions.tsx
+++ b/web/src/components/Brands/ExtractionOptions.tsx
@@ -37,8 +37,9 @@ export const ExtractionOptions = ({
         <span className="text-sm text-gray-700">Include ranking context</span>
       </label>
       <div className="flex items-center gap-3">
-        <span className="text-sm text-gray-700">Max brands per response:</span>
+        <label htmlFor="max-brands" className="text-sm text-gray-700">Max brands per response:</label>
         <input
+          id="max-brands"
           type="number"
           value={maxBrands}
           onChange={(e) => onMaxBrandsChange(parseInt(e.target.value, 10) || 20)}

--- a/web/src/components/Brands/FirstPartyBrandsSection.tsx
+++ b/web/src/components/Brands/FirstPartyBrandsSection.tsx
@@ -46,11 +46,13 @@ export function FirstPartyBrandsSection({
       <p className="text-xs text-emerald-700 mb-3">Your brands to track. Click a brand to select it, then use "Expand" to discover sub-brands.</p>
       <div className="flex gap-2 mb-3">
         <input
+          id="new-first-party-brand"
           type="text"
           value={newBrand}
           onChange={(e) => onNewBrandChange(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && onAddBrand()}
           placeholder="Enter brand name..."
+          aria-label="New first party brand"
           className="flex-1 p-2 border border-emerald-300 rounded-lg focus:ring-2 focus:ring-emerald-500 bg-white text-sm"
         />
         <button onClick={onAddBrand} className="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors text-sm">Add</button>

--- a/web/src/components/Brands/IndustrySelector.tsx
+++ b/web/src/components/Brands/IndustrySelector.tsx
@@ -18,8 +18,9 @@ export const IndustrySelector = ({
   onIndustryChange,
 }: IndustrySelectorProps) => (
   <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
-    <h3 className="text-sm font-semibold text-gray-900 mb-3">Industry</h3>
+    <label htmlFor="industry-select" className="block text-sm font-semibold text-gray-900 mb-3">Industry</label>
     <select
+      id="industry-select"
       value={industry}
       onChange={(e) => onIndustryChange(e.target.value)}
       className="w-full p-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-gray-900 focus:border-gray-900 bg-white text-sm"

--- a/web/src/components/Brands/ProviderResponseCard.tsx
+++ b/web/src/components/Brands/ProviderResponseCard.tsx
@@ -273,7 +273,7 @@ export const ProviderResponseCard = ({
         {/* GEO Feedback */}
         {provider.geo_feedback && (
           <FeedbackSection
-            title="🌍 Geographic Analysis"
+            title="Geographic Analysis"
             content={provider.geo_feedback}
             isExpanded={showGeoFeedback}
             onToggle={() => setShowGeoFeedback(!showGeoFeedback)}

--- a/web/src/components/Brands/ProviderResponseCard.tsx
+++ b/web/src/components/Brands/ProviderResponseCard.tsx
@@ -5,6 +5,7 @@ import type {
 import {
   formatResponse, extractUrls, findMentionPositions 
 } from '../ui/MarkdownProcessor';
+import { ChevronDownIcon } from '../ui';
 
 interface ProviderResponseCardProps {
   provider: ProviderBrandData;
@@ -69,9 +70,20 @@ const CitationsList = ({
         {urls.length > 5 && (
           <button
             onClick={onToggleShowAll}
-            className="text-xs text-gray-600 hover:text-gray-800 font-medium"
+            className="inline-flex items-center gap-1 text-xs text-gray-600 hover:text-gray-800 font-medium"
+            aria-expanded={showAll}
           >
-            {showAll ? '▲ Show Less' : `▼ Show ${urls.length - 5} More Citations`}
+            {showAll ? (
+              <>
+                <ChevronDownIcon className="w-3 h-3 rotate-180" />
+                Show Less
+              </>
+            ) : (
+              <>
+                <ChevronDownIcon className="w-3 h-3" />
+                Show {urls.length - 5} More Citations
+              </>
+            )}
           </button>
         )}
       </div>
@@ -169,7 +181,13 @@ const FeedbackSection = ({
       className={`w-full px-4 py-3 ${bgColor} transition-colors flex items-center justify-between`}
     >
       <span className={`text-sm font-medium ${titleColor}`}>{title}</span>
-      <span className="text-gray-600">{isExpanded ? '▲' : '▼'}</span>
+      <span className="text-gray-600" aria-hidden="true">
+        {isExpanded ? (
+          <ChevronDownIcon className="w-4 h-4 rotate-180" />
+        ) : (
+          <ChevronDownIcon className="w-4 h-4" />
+        )}
+      </span>
     </button>
     {isExpanded && (
       <div className="px-4 py-3 bg-white">
@@ -210,8 +228,19 @@ export const ProviderResponseCard = ({
           <button
             onClick={() => setIsExpanded(!isExpanded)}
             className="mt-4 text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center gap-1"
+            aria-expanded={isExpanded}
           >
-            {isExpanded ? '▲ Collapse' : '▼ Expand Full Response'}
+            {isExpanded ? (
+              <>
+                <ChevronDownIcon className="w-3 h-3 rotate-180" />
+                Collapse
+              </>
+            ) : (
+              <>
+                <ChevronDownIcon className="w-3 h-3" />
+                Expand Full Response
+              </>
+            )}
           </button>
         )}
 

--- a/web/src/components/Citations/CitationDetailModal.tsx
+++ b/web/src/components/Citations/CitationDetailModal.tsx
@@ -290,7 +290,7 @@ export const CitationDetailModal = ({
             {citation.status === 'blocked' && <BlockedPageBanner blockReason={citation.block_reason} />}
             <div className="bg-gray-50 rounded-lg p-4">
               <p className="text-sm text-gray-600 mb-4">Screenshot captured on {formatDate(citation.crawled_at)}</p>
-              <img src={citation.screenshot_url} alt={`Screenshot of ${citation.title}`} className="w-full border border-gray-300 rounded shadow-lg" />
+              <img src={citation.screenshot_url} alt={`Screenshot of ${citation.title}`} className="w-full border border-gray-300 rounded shadow-lg dark:brightness-90 dark:contrast-95" />
             </div>
           </div>
         ) : null;

--- a/web/src/components/Citations/CrawlHistory.tsx
+++ b/web/src/components/Citations/CrawlHistory.tsx
@@ -133,7 +133,7 @@ export const HistoryScreenshot = ({ crawl }: { crawl: HistoryCrawl }) => {
           <img
             src={crawl.screenshot_url}
             alt={`Screenshot from ${formatDate(crawl.crawled_at)}`}
-            className="w-full border border-gray-300 rounded shadow-lg"
+            className="w-full border border-gray-300 rounded shadow-lg dark:brightness-90 dark:contrast-95"
           />
         ) : (
           <div className="flex items-center justify-center h-48 bg-gray-100 rounded border border-gray-200">

--- a/web/src/components/Dashboard/BrandChart.tsx
+++ b/web/src/components/Dashboard/BrandChart.tsx
@@ -5,14 +5,33 @@ import {
   Chart, registerables 
 } from 'chart.js';
 import type { BrandStat } from '../../types';
+import { useTheme } from '../../hooks/useTheme';
+import { getChartTheme } from '../ui/chartTheme';
 
 Chart.register(...registerables);
 
 interface BrandChartProps {data: BrandStat[];}
 
+const BRAND_PALETTE_LIGHT = [
+  'rgba(17, 24, 39, 0.9)',
+  'rgba(55, 65, 81, 0.9)',
+  'rgba(251, 191, 36, 0.85)',
+  'rgba(167, 139, 250, 0.85)',
+  'rgba(156, 163, 175, 0.9)',
+];
+
+const BRAND_PALETTE_DARK = [
+  'rgba(229, 231, 235, 0.9)',
+  'rgba(156, 163, 175, 0.9)',
+  'rgba(251, 191, 36, 0.85)',
+  'rgba(167, 139, 250, 0.85)',
+  'rgba(107, 114, 128, 0.9)',
+];
+
 export const BrandChart = ({ data }: BrandChartProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
+  const { isDark } = useTheme();
 
   useEffect(() => {
     if (!canvasRef.current || !data?.length) return;
@@ -24,8 +43,8 @@ export const BrandChart = ({ data }: BrandChartProps) => {
     const ctx = canvasRef.current.getContext('2d');
     if (!ctx) return;
 
-    const isDark = document.documentElement.classList.contains('dark');
-    const textColor = isDark ? 'rgb(209, 213, 219)' : 'rgb(75, 85, 99)';
+    const theme = getChartTheme(isDark);
+    const palette = isDark ? BRAND_PALETTE_DARK : BRAND_PALETTE_LIGHT;
 
     chartRef.current = new Chart(ctx, {
       type: 'doughnut',
@@ -34,13 +53,7 @@ export const BrandChart = ({ data }: BrandChartProps) => {
         datasets: [
           {
             data: data.map((d) => d.mention_count),
-            backgroundColor: [
-              'rgba(17, 24, 39, 0.9)',
-              'rgba(55, 65, 81, 0.9)',
-              'rgba(251, 191, 36, 0.85)',
-              'rgba(167, 139, 250, 0.85)',
-              'rgba(156, 163, 175, 0.9)',
-            ],
+            backgroundColor: palette,
             borderWidth: 0,
           },
         ],
@@ -56,8 +69,15 @@ export const BrandChart = ({ data }: BrandChartProps) => {
               boxWidth: 12,
               padding: 16,
               font: { size: 11 },
-              color: textColor,
+              color: theme.textColor,
             },
+          },
+          tooltip: {
+            backgroundColor: theme.tooltipBackground,
+            borderColor: theme.tooltipBorder,
+            borderWidth: 1,
+            titleColor: theme.tooltipText,
+            bodyColor: theme.tooltipText,
           },
         },
       },
@@ -68,7 +88,7 @@ export const BrandChart = ({ data }: BrandChartProps) => {
         chartRef.current.destroy();
       }
     };
-  }, [data]);
+  }, [data, isDark]);
 
   const hasData = data && data.length > 0;
 

--- a/web/src/components/Dashboard/ProviderChart.tsx
+++ b/web/src/components/Dashboard/ProviderChart.tsx
@@ -5,6 +5,8 @@ import {
   Chart, registerables 
 } from 'chart.js';
 import type { ProviderStat } from '../../types';
+import { useTheme } from '../../hooks/useTheme';
+import { getChartTheme } from '../ui/chartTheme';
 
 Chart.register(...registerables);
 
@@ -13,6 +15,7 @@ interface ProviderChartProps {data: ProviderStat[];}
 export const ProviderChart = ({ data }: ProviderChartProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart | null>(null);
+  const { isDark } = useTheme();
 
   useEffect(() => {
     if (!canvasRef.current || !data?.length) return;
@@ -24,9 +27,7 @@ export const ProviderChart = ({ data }: ProviderChartProps) => {
     const ctx = canvasRef.current.getContext('2d');
     if (!ctx) return;
 
-    const isDark = document.documentElement.classList.contains('dark');
-    const textColor = isDark ? 'rgb(209, 213, 219)' : 'rgb(75, 85, 99)';
-    const gridColor = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)';
+    const theme = getChartTheme(isDark);
 
     chartRef.current = new Chart(ctx, {
       type: 'bar',
@@ -49,16 +50,25 @@ export const ProviderChart = ({ data }: ProviderChartProps) => {
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: {legend: { display: false },},
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: theme.tooltipBackground,
+            borderColor: theme.tooltipBorder,
+            borderWidth: 1,
+            titleColor: theme.tooltipText,
+            bodyColor: theme.tooltipText,
+          },
+        },
         scales: {
           y: {
             beginAtZero: true,
-            grid: { color: gridColor },
-            ticks: { color: textColor },
+            grid: { color: theme.gridColor },
+            ticks: { color: theme.textColor },
           },
           x: {
             grid: { display: false },
-            ticks: { color: textColor },
+            ticks: { color: theme.textColor },
           },
         },
       },
@@ -69,7 +79,7 @@ export const ProviderChart = ({ data }: ProviderChartProps) => {
         chartRef.current.destroy();
       }
     };
-  }, [data]);
+  }, [data, isDark]);
 
   const hasData = data && data.length > 0;
 

--- a/web/src/components/Dashboard/StatCard.spec.tsx
+++ b/web/src/components/Dashboard/StatCard.spec.tsx
@@ -5,37 +5,48 @@ import {
   describe, it, expect 
 } from 'vitest';
 import { StatCard } from './StatCard';
+import { SearchIcon } from '../ui';
 
 describe('StatCard', () => {
   it('displays title and formatted value', () => {
-    render(<StatCard title="Total Searches" value={1234} icon="🔍" />);
-    
+    render(<StatCard title="Total Searches" value={1234} icon={<SearchIcon />} />);
+
     expect(screen.getByText('Total Searches')).toBeInTheDocument();
     expect(screen.getByText('1,234')).toBeInTheDocument();
   });
 
   it('formats large numbers with locale separators', () => {
-    render(<StatCard title="Citations" value={1000000} icon="📎" />);
-    
+    render(<StatCard title="Citations" value={1000000} icon={<SearchIcon />} />);
+
     expect(screen.getByText('1,000,000')).toBeInTheDocument();
   });
 
   it('displays zero value correctly', () => {
-    render(<StatCard title="Empty" value={0} icon="🔑" />);
-    
+    render(<StatCard title="Empty" value={0} icon={<SearchIcon />} />);
+
     expect(screen.getByText('0')).toBeInTheDocument();
   });
 
-  it('renders SVG icon when icon matches iconMap', () => {
-    const { container } = render(<StatCard title="Test" value={5} icon="🔍" />);
-    
+  it('renders the provided SVG icon component', () => {
+    const { container } = render(<StatCard title="Test" value={5} icon={<SearchIcon />} />);
+
     const svg = container.querySelector('svg');
     expect(svg).toBeInTheDocument();
   });
 
-  it('renders emoji fallback when icon not in iconMap', () => {
-    render(<StatCard title="Test" value={5} icon="🎉" />);
-    
-    expect(screen.getByText('🎉')).toBeInTheDocument();
+  it('applies blue tone classes when tone prop is "blue"', () => {
+    const { container } = render(
+      <StatCard title="Test" value={5} icon={<SearchIcon />} tone="blue" />
+    );
+
+    const badge = container.querySelector('.bg-blue-50');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('falls back to gray tone classes when tone prop is omitted', () => {
+    const { container } = render(<StatCard title="Test" value={5} icon={<SearchIcon />} />);
+
+    const badge = container.querySelector('.bg-gray-50');
+    expect(badge).toBeInTheDocument();
   });
 });

--- a/web/src/components/Dashboard/StatCard.tsx
+++ b/web/src/components/Dashboard/StatCard.tsx
@@ -1,67 +1,59 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Visual tone of the stat card icon badge.
+ *
+ * The set of tones is intentionally small and matches the design system
+ * accent palette (see `docs/design-system.md`). Each tone resolves to a
+ * tinted background and matching foreground colour for the icon container.
+ */
+export type StatCardTone = 'blue' | 'violet' | 'emerald' | 'amber' | 'gray';
+
 interface StatCardProps {
-  title: string;
-  value: number;
-  icon: string;
+  readonly title: string;
+  readonly value: number;
+  /** Icon component instance (e.g. `<SearchIcon />`). */
+  readonly icon: ReactNode;
+  /** Accent tone applied to the icon badge. Defaults to `gray`. */
+  readonly tone?: StatCardTone;
 }
 
-const iconMap: Record<string, JSX.Element> = {
-  '🔍': (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-    </svg>
-  ),
-  '📎': (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-    </svg>
-  ),
-  '🕷️': (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
-    </svg>
-  ),
-  '🔑': (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" />
-    </svg>
-  ),
-};
-
-const colorMap: Record<string, {
+const toneClasses: Record<StatCardTone, {
   bg: string;
   text: string;
-  border: string 
+  border: string;
 }> = {
-  '🔍': {
+  blue: {
     bg: 'bg-blue-50',
     text: 'text-blue-600',
-    border: 'border-blue-100' 
+    border: 'border-blue-100',
   },
-  '📎': {
+  violet: {
     bg: 'bg-violet-50',
     text: 'text-violet-600',
-    border: 'border-violet-100' 
+    border: 'border-violet-100',
   },
-  '🕷️': {
+  emerald: {
     bg: 'bg-emerald-50',
     text: 'text-emerald-600',
-    border: 'border-emerald-100' 
+    border: 'border-emerald-100',
   },
-  '🔑': {
+  amber: {
     bg: 'bg-amber-50',
     text: 'text-amber-600',
-    border: 'border-amber-100' 
+    border: 'border-amber-100',
+  },
+  gray: {
+    bg: 'bg-gray-50',
+    text: 'text-gray-500',
+    border: 'border-gray-100',
   },
 };
 
 export const StatCard = ({
-  title, value, icon 
+  title, value, icon, tone = 'gray',
 }: StatCardProps) => {
-  const colors = colorMap[icon] ?? {
-    bg: 'bg-gray-50',
-    text: 'text-gray-500',
-    border: 'border-gray-100' 
-  };
+  const colors = toneClasses[tone];
 
   return (
     <div className={`bg-white rounded-lg border ${colors.border} p-6`}>
@@ -71,7 +63,7 @@ export const StatCard = ({
           <p className="text-3xl font-semibold text-gray-900">{value.toLocaleString()}</p>
         </div>
         <div className={`${colors.bg} ${colors.text} p-3 rounded-xl`}>
-          {iconMap[icon] || <span className="text-2xl">{icon}</span>}
+          {icon}
         </div>
       </div>
     </div>

--- a/web/src/components/Keywords/KeywordDetail.tsx
+++ b/web/src/components/Keywords/KeywordDetail.tsx
@@ -6,6 +6,8 @@ import {
 } from '../../infrastructure';
 import type { Search } from '../../types';
 import { Spinner } from '../ui/Spinner';
+import { useTheme } from '../../hooks/useTheme';
+import { getChartTheme } from '../ui/chartTheme';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -167,18 +169,22 @@ interface ChartsSectionProps {
 
 const ChartsSection = ({
   lineChartData, barChartData 
-}: ChartsSectionProps) => (
-  <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
-    <div className="bg-gray-50 p-3 sm:p-4 rounded-lg">
-      <h3 className="font-semibold text-gray-900 mb-4 text-sm sm:text-base">Citations Trend</h3>
-      <Line data={lineChartData} options={lineChartOptions} />
+}: ChartsSectionProps) => {
+  const { isDark } = useTheme();
+  const theme = getChartTheme(isDark);
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+      <div className="bg-gray-50 p-3 sm:p-4 rounded-lg">
+        <h3 className="font-semibold text-gray-900 mb-4 text-sm sm:text-base">Citations Trend</h3>
+        <Line data={lineChartData} options={lineChartOptions(theme)} />
+      </div>
+      <div className="bg-gray-50 p-3 sm:p-4 rounded-lg">
+        <h3 className="font-semibold text-gray-900 mb-4 text-sm sm:text-base">Top 10 Citations</h3>
+        <Bar data={barChartData} options={barChartOptions(theme)} />
+      </div>
     </div>
-    <div className="bg-gray-50 p-3 sm:p-4 rounded-lg">
-      <h3 className="font-semibold text-gray-900 mb-4 text-sm sm:text-base">Top 10 Citations</h3>
-      <Bar data={barChartData} options={barChartOptions} />
-    </div>
-  </div>
-);
+  );
+};
 
 interface RunHistoryProps {
   runBatches: Record<string, Search[]>;

--- a/web/src/components/Keywords/KeywordDetailChartOptions.ts
+++ b/web/src/components/Keywords/KeywordDetailChartOptions.ts
@@ -1,0 +1,81 @@
+/**
+ * Theme-aware Chart.js option factories for the keyword detail
+ * panel. Kept in a separate file so `KeywordDetailComponents.tsx`
+ * stays under the 400-line `max-lines` ESLint cap.
+ *
+ * Call with the result of `getChartTheme(isDark)` so chart chrome
+ * (axis ticks, grid, legend, tooltip) adapts to the active theme.
+ */
+import type { ChartTheme } from '../ui/chartTheme';
+
+interface SimpleTooltipContext {
+  readonly dataset: { readonly label?: string };
+  readonly parsed: { readonly y: number | null };
+}
+
+const themedLegend = (theme: ChartTheme) => ({
+  display: true,
+  position: 'bottom' as const,
+  labels: { color: theme.textColor },
+});
+
+const themedTooltip = (theme: ChartTheme) => ({
+  backgroundColor: theme.tooltipBackground,
+  borderColor: theme.tooltipBorder,
+  borderWidth: 1,
+  titleColor: theme.tooltipText,
+  bodyColor: theme.tooltipText,
+});
+
+const themedAxis = (theme: ChartTheme, extra: Record<string, unknown> = {}) => ({
+  ticks: {
+    color: theme.textColor,
+    ...(extra.ticks as object ?? {}) 
+  },
+  grid: { color: theme.gridColor },
+  ...extra,
+});
+
+export const lineChartOptions = (theme: ChartTheme) => ({
+  responsive: true,
+  plugins: {
+    legend: themedLegend(theme),
+    tooltip: {
+      ...themedTooltip(theme),
+      callbacks: {
+        label: (context: SimpleTooltipContext) =>
+          `${context.dataset.label ?? ''}: ${context.parsed.y ?? 0} citations`,
+      },
+    },
+  },
+  scales: {
+    y: themedAxis(theme, { beginAtZero: true }),
+    x: themedAxis(theme),
+  },
+});
+
+export const barChartOptions = (theme: ChartTheme) => ({
+  responsive: true,
+  plugins: {
+    legend: themedLegend(theme),
+    tooltip: {
+      ...themedTooltip(theme),
+      callbacks: {
+        label: (context: SimpleTooltipContext) =>
+          `${context.dataset.label ?? ''}: ${context.parsed.y ?? 0}`,
+        footer: (tooltipItems: Array<{ readonly parsed: { readonly y: number | null } }>) => {
+          const total = tooltipItems.reduce((sum, item) => sum + (item.parsed.y ?? 0), 0);
+          return `Total: ${total}`;
+        },
+      },
+    },
+  },
+  scales: {
+    x: themedAxis(theme, { stacked: true }),
+    y: themedAxis(theme, {
+      stacked: true,
+      beginAtZero: true,
+      ticks: { stepSize: 1 } 
+    }),
+  },
+});

--- a/web/src/components/Keywords/KeywordDetailComponents.tsx
+++ b/web/src/components/Keywords/KeywordDetailComponents.tsx
@@ -1,4 +1,5 @@
 import type { Search } from '../../types';
+import { ChevronDownIcon } from '../ui';
 
 export const providerColors: Record<string, {
   border: string;
@@ -274,7 +275,9 @@ export const SearchItem = ({
           >
             {search.citations?.length ?? 0} citations
           </span>
-          <span className="text-gray-400">{isExpanded ? '▼' : '▶'}</span>
+          <span className="text-gray-400" aria-hidden="true">
+            <ChevronDownIcon className={`w-4 h-4 ${isExpanded ? '' : '-rotate-90'}`} />
+          </span>
         </div>
       </div>
 
@@ -360,9 +363,13 @@ const ResponseSection = ({
             e.stopPropagation();
             setExpandedResponse(expandedResponse === globalIdx ? null : globalIdx);
           }}
-          className="mt-2 text-xs text-gray-500 hover:text-gray-700 font-medium"
+          className="mt-2 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 font-medium"
+          aria-expanded={expandedResponse === globalIdx}
         >
-          {expandedResponse === globalIdx ? '▲ Show less' : '▼ Show full response'}
+          <ChevronDownIcon
+            className={`w-3 h-3 ${expandedResponse === globalIdx ? 'rotate-180' : ''}`}
+          />
+          {expandedResponse === globalIdx ? 'Show less' : 'Show full response'}
         </button>
       )}
     </div>

--- a/web/src/components/Keywords/KeywordDetailComponents.tsx
+++ b/web/src/components/Keywords/KeywordDetailComponents.tsx
@@ -1,5 +1,7 @@
 import type { Search } from '../../types';
-import { ChevronDownIcon } from '../ui';
+import {
+  ChevronDownIcon, CloseIcon 
+} from '../ui';
 
 export const providerColors: Record<string, {
   border: string;
@@ -201,9 +203,9 @@ export const DetailHeader = ({
     </div>
     <button
       onClick={onClose}
-      className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors text-sm shrink-0"
+      className="inline-flex items-center gap-1.5 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors text-sm shrink-0"
     >
-      ✕ Close
+      <CloseIcon className="w-3.5 h-3.5" />Close
     </button>
   </div>
 );
@@ -366,9 +368,7 @@ const ResponseSection = ({
           className="mt-2 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 font-medium"
           aria-expanded={expandedResponse === globalIdx}
         >
-          <ChevronDownIcon
-            className={`w-3 h-3 ${expandedResponse === globalIdx ? 'rotate-180' : ''}`}
-          />
+          <ChevronDownIcon className={`w-3 h-3 ${expandedResponse === globalIdx ? 'rotate-180' : ''}`} />
           {expandedResponse === globalIdx ? 'Show less' : 'Show full response'}
         </button>
       )}

--- a/web/src/components/Keywords/KeywordDetailComponents.tsx
+++ b/web/src/components/Keywords/KeywordDetailComponents.tsx
@@ -131,56 +131,9 @@ function buildCitationFrequency(citationByProvider: Record<string, Record<string
     .slice(0, 10);
 }
 
-export const lineChartOptions = {
-  responsive: true,
-  plugins: {
-    legend: {
-      display: true,
-      position: 'bottom' as const 
-    },
-    tooltip: {
-      callbacks: {
-        label: (context: {
-          dataset: { label?: string };
-          parsed: { y: number | null } 
-        }) =>
-          `${context.dataset.label ?? ''}: ${context.parsed.y ?? 0} citations`,
-      },
-    },
-  },
-  scales: { y: { beginAtZero: true } },
-};
-
-export const barChartOptions = {
-  responsive: true,
-  plugins: {
-    legend: {
-      display: true,
-      position: 'bottom' as const 
-    },
-    tooltip: {
-      callbacks: {
-        label: (context: {
-          dataset: { label?: string };
-          parsed: { y: number | null } 
-        }) =>
-          `${context.dataset.label ?? ''}: ${context.parsed.y ?? 0}`,
-        footer: (tooltipItems: Array<{ parsed: { y: number | null } }>) => {
-          const total = tooltipItems.reduce((sum, item) => sum + (item.parsed.y ?? 0), 0);
-          return `Total: ${total}`;
-        },
-      },
-    },
-  },
-  scales: {
-    x: { stacked: true },
-    y: {
-      stacked: true,
-      beginAtZero: true,
-      ticks: { stepSize: 1 } 
-    },
-  },
-};
+export {
+  lineChartOptions, barChartOptions
+} from './KeywordDetailChartOptions';
 
 interface DetailHeaderProps {
   keyword: string;

--- a/web/src/components/Layout/TabContent.tsx
+++ b/web/src/components/Layout/TabContent.tsx
@@ -3,6 +3,9 @@ import {
 } from 'react';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { Spinner } from '../ui/Spinner';
+import {
+  SearchIcon, LinkIcon, GlobeIcon, KeyIcon 
+} from '../ui';
 import { StatCard } from '../Dashboard/StatCard';
 import { ProviderChart } from '../Dashboard/ProviderChart';
 import { BrandChart } from '../Dashboard/BrandChart';
@@ -66,10 +69,10 @@ function LazyTab({ children }: { readonly children: ReactNode }) {
 function DashboardStats({ stats }: { readonly stats: Stats | null }) {
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
-      <StatCard title="Total Searches" value={stats?.total_searches ?? 0} icon="🔍" />
-      <StatCard title="Total Citations" value={stats?.total_citations ?? 0} icon="📎" />
-      <StatCard title="Pages Crawled" value={stats?.total_crawled ?? 0} icon="🕷️" />
-      <StatCard title="Unique Keywords" value={stats?.unique_keywords ?? 0} icon="🔑" />
+      <StatCard title="Total Searches" value={stats?.total_searches ?? 0} icon={<SearchIcon className="w-6 h-6" />} tone="blue" />
+      <StatCard title="Total Citations" value={stats?.total_citations ?? 0} icon={<LinkIcon className="w-6 h-6" />} tone="violet" />
+      <StatCard title="Pages Crawled" value={stats?.total_crawled ?? 0} icon={<GlobeIcon className="w-6 h-6" />} tone="emerald" />
+      <StatCard title="Unique Keywords" value={stats?.unique_keywords ?? 0} icon={<KeyIcon className="w-6 h-6" />} tone="amber" />
     </div>
   );
 }

--- a/web/src/components/RawResponses/ImageViewer.tsx
+++ b/web/src/components/RawResponses/ImageViewer.tsx
@@ -46,7 +46,7 @@ export const ImageViewer = ({
             <img
               src={imageUrl}
               alt={file.name}
-              className={`max-w-full max-h-[600px] rounded-lg shadow-lg transition-opacity ${
+              className={`max-w-full max-h-[600px] rounded-lg shadow-lg transition-opacity dark:brightness-90 dark:contrast-95 ${
                 imageLoaded ? 'opacity-100' : 'opacity-0'
               }`}
               onLoad={() => setImageLoaded(true)}

--- a/web/src/components/Settings/QueryPromptsManager.tsx
+++ b/web/src/components/Settings/QueryPromptsManager.tsx
@@ -3,10 +3,27 @@
  *
  * Each persona represents a user profile (e.g. "Family Traveler", "Student")
  * whose context is injected into AI queries to see how responses change.
+ *
+ * Visual styling follows the design system documented in
+ * `docs/design-system.md`:
+ *   - Action icons use the shared Heroicons-style outline set from
+ *     `components/ui/Icons.tsx` (matches the sidebar icon language).
+ *   - Buttons use the `<Button>` component so primary/ghost variants stay
+ *     consistent with the rest of the app and adapt to dark mode.
+ *   - Surfaces, borders, and text rely on Tailwind tokens that are mapped
+ *     to dark-mode equivalents through global overrides in `index.css`.
  */
 import { useState } from 'react';
 import { useQueryPrompts } from '../../hooks/useQueryPrompts';
 import type { QueryPrompt } from '../../types';
+import {
+  Button,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  PlusIcon,
+  TrashIcon,
+} from '../ui';
 
 const SAMPLE_KEYWORD = 'best hotels in Barcelona';
 
@@ -117,17 +134,16 @@ function PersonaForm({
         <PromptPreview template={template} />
       </div>
       <div className="flex gap-2">
-        <button
+        <Button
           type="submit"
           disabled={saving || !name.trim() || !template.trim()}
-          className="px-4 py-2 bg-gray-900 text-white rounded-lg text-sm hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {saving ? 'Saving...' : submitLabel}
-        </button>
+        </Button>
         {onCancel && (
-          <button type="button" onClick={onCancel} className="px-4 py-2 text-gray-600 text-sm hover:text-gray-900">
+          <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
-          </button>
+          </Button>
         )}
       </div>
     </form>
@@ -190,6 +206,9 @@ function PersonaRow({
   const statusLabel = isEnabled ? 'Enabled' : 'Disabled';
   const rowClass = isEnabled ? 'border-gray-200 bg-white' : 'border-gray-100 bg-gray-50 opacity-60';
 
+  const toggleTitle = isEnabled ? 'Disable persona' : 'Enable persona';
+  const ToggleIcon = isEnabled ? PauseIcon : PlayIcon;
+
   return (
     <div className={`p-4 border rounded-lg ${rowClass}`}>
       <div className="flex items-center justify-between">
@@ -206,34 +225,36 @@ function PersonaRow({
           <p className="text-xs text-gray-400 mt-1 truncate">{prompt.template}</p>
         </div>
         <div className="flex items-center gap-1 ml-3">
-          <button
+          <Button
+            variant="iconOnly"
+            size="sm"
             onClick={handleToggle}
             disabled={toggling}
-            className="p-1.5 text-gray-400 hover:text-gray-600 rounded"
-            title={isEnabled ? 'Disable' : 'Enable'}
-            aria-label={isEnabled ? 'Disable persona' : 'Enable persona'}
+            title={toggleTitle}
+            aria-label={toggleTitle}
           >
-            {toggling && '...'}
-            {!toggling && isEnabled && '⏸'}
-            {!toggling && !isEnabled && '▶'}
-          </button>
-          <button
+            <ToggleIcon className="w-4 h-4" />
+          </Button>
+          <Button
+            variant="iconOnly"
+            size="sm"
             onClick={() => setEditing(true)}
-            className="p-1.5 text-gray-400 hover:text-gray-600 rounded"
-            title="Edit"
+            title="Edit persona"
             aria-label="Edit persona"
           >
-            ✏️
-          </button>
-          <button
+            <PencilIcon className="w-4 h-4" />
+          </Button>
+          <Button
+            variant="iconOnly"
+            size="sm"
             onClick={handleDelete}
             disabled={deleting}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded"
-            title="Delete"
+            title="Delete persona"
             aria-label="Delete persona"
+            className="hover:text-red-600"
           >
-            {deleting ? '...' : '🗑'}
-          </button>
+            <TrashIcon className="w-4 h-4" />
+          </Button>
         </div>
       </div>
     </div>
@@ -257,12 +278,12 @@ export function QueryPromptsManager() {
           </p>
         </div>
         {!showCreate && prompts.length < 10 && (
-          <button
+          <Button
             onClick={() => setShowCreate(true)}
-            className="px-3 py-1.5 bg-gray-900 text-white rounded-lg text-sm hover:bg-gray-800"
+            leadingIcon={<PlusIcon className="w-4 h-4" />}
           >
-            + New Persona
-          </button>
+            New Persona
+          </Button>
         )}
       </div>
 

--- a/web/src/components/Tables/TopCitationsTable.tsx
+++ b/web/src/components/Tables/TopCitationsTable.tsx
@@ -4,6 +4,9 @@ import {
 import type { TopUrl } from '../../types';
 import { API_BASE_URL } from '../../infrastructure';
 import { exportToExcel } from '../../exporters/excelGenerator';
+import {
+  ChevronDownIcon, ChevronRightIcon 
+} from '../ui';
 
 interface TopCitationsTableProps {citations: TopUrl[];}
 
@@ -277,9 +280,16 @@ export const TopCitationsTable = ({ citations }: TopCitationsTableProps) => {
                     <td className="px-6 py-4 text-sm text-gray-900">
                       <button
                         onClick={() => toggleRow(idx, citation.url)}
-                        className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full font-medium hover:bg-blue-200 cursor-pointer transition-colors"
+                        className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 rounded-full font-medium hover:bg-blue-200 cursor-pointer transition-colors"
+                        aria-expanded={isExpanded}
+                        aria-label={isExpanded ? 'Collapse breakdown' : 'Expand breakdown'}
                       >
-                        {citation.citation_count} {isExpanded ? '▼' : '▶'}
+                        {citation.citation_count}
+                        {isExpanded ? (
+                          <ChevronDownIcon className="w-3 h-3" />
+                        ) : (
+                          <ChevronRightIcon className="w-3 h-3" />
+                        )}
                       </button>
                     </td>
                   </tr>

--- a/web/src/components/Tables/TopCitationsTable.tsx
+++ b/web/src/components/Tables/TopCitationsTable.tsx
@@ -187,7 +187,7 @@ export const TopCitationsTable = ({ citations }: TopCitationsTableProps) => {
             <select
               value={itemsPerPage}
               onChange={(e) => handleItemsPerPageChange(Number(e.target.value))}
-              className="px-3 py-1 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="px-3 py-1 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900"
             >
               <option value={10}>10</option>
               <option value={20}>20</option>

--- a/web/src/components/Visibility/PersonaComparisonChart.tsx
+++ b/web/src/components/Visibility/PersonaComparisonChart.tsx
@@ -10,6 +10,8 @@ import {
 import { Bar } from 'react-chartjs-2';
 import type { TooltipItem } from 'chart.js';
 import type { PersonaRankingsResponse } from '../../types';
+import { useTheme } from '../../hooks/useTheme';
+import { getChartTheme } from '../ui/chartTheme';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
@@ -22,6 +24,9 @@ function computeAverageRank(brands: ReadonlyArray<{ rank: number }>): number | n
 }
 
 export function PersonaComparisonChart({ data }: PersonaComparisonChartProps) {
+  const { isDark } = useTheme();
+  const theme = getChartTheme(isDark);
+
   if (!data) return null;
 
   const personasWithResults = data.personas.filter((p) => p.brands.length > 0);
@@ -80,8 +85,16 @@ export function PersonaComparisonChart({ data }: PersonaComparisonChartProps) {
   const options = {
     responsive: true,
     plugins: {
-      legend: { position: 'top' as const },
+      legend: {
+        position: 'top' as const,
+        labels: { color: theme.textColor },
+      },
       tooltip: {
+        backgroundColor: theme.tooltipBackground,
+        borderColor: theme.tooltipBorder,
+        borderWidth: 1,
+        titleColor: theme.tooltipText,
+        bodyColor: theme.tooltipText,
         callbacks: {
           label(context: TooltipItem<'bar'>) {
             const personaIndex = context.dataIndex;
@@ -104,13 +117,19 @@ export function PersonaComparisonChart({ data }: PersonaComparisonChartProps) {
         title: {
           display: true,
           text: 'Average Brand Rank (lower is better)',
+          color: theme.textColor,
         },
+        ticks: { color: theme.textColor },
+        grid: { color: theme.gridColor },
       },
       x: {
         title: {
           display: true,
           text: 'Persona',
+          color: theme.textColor,
         },
+        ticks: { color: theme.textColor },
+        grid: { color: theme.gridColor },
       },
     },
   };

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,0 +1,106 @@
+/**
+ * Centralized Button component implementing the project design system.
+ *
+ * Variants:
+ *   - `primary` (default) – high contrast call-to-action.
+ *   - `secondary` – low contrast neutral action.
+ *   - `ghost` – minimal, used inside dense lists / tables.
+ *   - `danger` – destructive primary action.
+ *   - `iconOnly` – square button hosting only an icon (use `aria-label`).
+ *
+ * Sizes:
+ *   - `sm` (32px height)
+ *   - `md` (default, 36-40px height)
+ *
+ * Dark mode is handled at the global stylesheet level (see `index.css`),
+ * which is why `bg-gray-900 / hover:bg-gray-800` works in both themes
+ * without explicit `dark:` variants. The few buttons that sit on dark
+ * backgrounds in light mode (e.g. main app rail) still need explicit
+ * `dark:` overrides; see `Button.tsx` `invertOnDark` prop.
+ *
+ * See `docs/design-system.md` for usage guidance.
+ */
+
+import type {
+  ButtonHTMLAttributes, ReactNode 
+} from 'react';
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'ghost'
+  | 'danger'
+  | 'iconOnly';
+
+export type ButtonSize = 'sm' | 'md';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  readonly variant?: ButtonVariant;
+  readonly size?: ButtonSize;
+  readonly leadingIcon?: ReactNode;
+  readonly trailingIcon?: ReactNode;
+  /**
+   * For `primary` buttons that need explicit dark-mode inversion on
+   * always-dark surfaces (e.g. fallback error screens). Defaults to false
+   * because global CSS overrides handle the common case.
+   */
+  readonly invertOnDark?: boolean;
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500';
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+};
+
+const iconOnlySizeClasses: Record<ButtonSize, string> = {
+  sm: 'p-1.5',
+  md: 'p-2',
+};
+
+const variantClasses = (variant: ButtonVariant, invertOnDark: boolean): string => {
+  switch (variant) {
+    case 'primary':
+      return invertOnDark
+        ? 'bg-gray-900 text-white hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200'
+        : 'bg-gray-900 text-white hover:bg-gray-800 disabled:bg-gray-300';
+    case 'secondary':
+      return 'bg-white text-gray-900 border border-gray-200 hover:bg-gray-50';
+    case 'ghost':
+      return 'text-gray-600 hover:text-gray-900 hover:bg-gray-100';
+    case 'danger':
+      return 'bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300';
+    case 'iconOnly':
+      return 'text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md';
+  }
+};
+
+export const Button = ({
+  variant = 'primary',
+  size = 'md',
+  leadingIcon,
+  trailingIcon,
+  invertOnDark = false,
+  className = '',
+  type = 'button',
+  children,
+  ...rest
+}: ButtonProps) => {
+  const sizing = variant === 'iconOnly' ? iconOnlySizeClasses[size] : sizeClasses[size];
+  const variantStyles = variantClasses(variant, invertOnDark);
+
+  return (
+    <button
+       
+      type={type}
+      className={`${baseClasses} ${sizing} ${variantStyles} ${className}`.trim()}
+      {...rest}
+    >
+      {leadingIcon}
+      {children}
+      {trailingIcon}
+    </button>
+  );
+};

--- a/web/src/components/ui/Icons.tsx
+++ b/web/src/components/ui/Icons.tsx
@@ -1,0 +1,150 @@
+/**
+ * Centralized icon library.
+ *
+ * All icons follow the same Heroicons-style outline convention used across
+ * the app: 24×24 viewBox, stroke-based, `currentColor`, configurable size
+ * and class via props so they inherit the surrounding text color and dark
+ * mode treatment automatically.
+ *
+ * See `docs/design-system.md` for icon usage guidelines.
+ */
+
+interface IconProps {
+  /** Tailwind size classes (default: `w-5 h-5`). */
+  readonly className?: string;
+  /** Title for accessible labelling. When provided, icon becomes labelled. */
+  readonly title?: string;
+}
+
+const baseProps = (className?: string, title?: string) => ({
+  className: className ?? 'w-5 h-5',
+  fill: 'none' as const,
+  stroke: 'currentColor' as const,
+  viewBox: '0 0 24 24',
+  'aria-hidden': title === undefined,
+  role: title === undefined ? undefined : 'img',
+});
+
+const strokeProps = {
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  strokeWidth: 1.5,
+};
+
+export const PauseIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
+
+export const PlayIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+    <path {...strokeProps} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
+
+export const PencilIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+  </svg>
+);
+
+export const TrashIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+  </svg>
+);
+
+export const PlusIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M12 4v16m8-8H4" />
+  </svg>
+);
+
+export const CloseIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+export const ChevronRightIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M9 5l7 7-7 7" />
+  </svg>
+);
+
+export const ChevronDownIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M19 9l-7 7-7-7" />
+  </svg>
+);
+
+export const SearchIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+  </svg>
+);
+
+export const LinkIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+  </svg>
+);
+
+export const GlobeIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+  </svg>
+);
+
+export const KeyIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" />
+  </svg>
+);
+
+export const WarningIcon = ({
+  className, title 
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+  </svg>
+);

--- a/web/src/components/ui/Icons.tsx
+++ b/web/src/components/ui/Icons.tsx
@@ -148,3 +148,21 @@ export const WarningIcon = ({
     <path {...strokeProps} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
   </svg>
 );
+
+export const CheckIcon = ({
+  className, title
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M5 13l4 4L19 7" />
+  </svg>
+);
+
+export const ArrowRightIcon = ({
+  className, title
+}: IconProps) => (
+  <svg {...baseProps(className, title)}>
+    {title && <title>{title}</title>}
+    <path {...strokeProps} d="M14 5l7 7m0 0l-7 7m7-7H3" />
+  </svg>
+);

--- a/web/src/components/ui/chartTheme.ts
+++ b/web/src/components/ui/chartTheme.ts
@@ -1,0 +1,42 @@
+/**
+ * Chart.js theme tokens that adapt to light/dark mode.
+ *
+ * Use with `useTheme()` from `hooks/useTheme.ts` to keep Chart.js
+ * canvases legible in both themes. Saturated dataset colours stay
+ * fixed – only chrome (axis ticks, grid, legend, tooltip) adapts.
+ *
+ * See `docs/design-system.md#1-theming-model` for context.
+ */
+
+export interface ChartTheme {
+  /** Axis tick + label + legend text colour. */
+  readonly textColor: string;
+  /** Axis grid line colour. */
+  readonly gridColor: string;
+  /** Tooltip surface colour. */
+  readonly tooltipBackground: string;
+  /** Tooltip border colour. */
+  readonly tooltipBorder: string;
+  /** Tooltip text colour. */
+  readonly tooltipText: string;
+}
+
+const DARK_THEME: ChartTheme = {
+  textColor: 'rgb(209, 213, 219)',
+  gridColor: 'rgba(255, 255, 255, 0.08)',
+  tooltipBackground: 'rgba(31, 41, 55, 0.95)',
+  tooltipBorder: 'rgba(75, 85, 99, 1)',
+  tooltipText: 'rgb(243, 244, 246)',
+};
+
+const LIGHT_THEME: ChartTheme = {
+  textColor: 'rgb(75, 85, 99)',
+  gridColor: 'rgba(0, 0, 0, 0.05)',
+  tooltipBackground: 'rgba(17, 24, 39, 0.92)',
+  tooltipBorder: 'rgba(75, 85, 99, 1)',
+  tooltipText: 'rgb(249, 250, 251)',
+};
+
+export function getChartTheme(isDark: boolean): ChartTheme {
+  return isDark ? DARK_THEME : LIGHT_THEME;
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -3,6 +3,25 @@ export {
 } from './Modal';
 export { Spinner } from './Spinner';
 export { ThemeToggle } from './ThemeToggle';
+export { Button } from './Button';
+export type {
+  ButtonVariant, ButtonSize 
+} from './Button';
+export {
+  PauseIcon,
+  PlayIcon,
+  PencilIcon,
+  TrashIcon,
+  PlusIcon,
+  CloseIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+  SearchIcon,
+  LinkIcon,
+  GlobeIcon,
+  KeyIcon,
+  WarningIcon,
+} from './Icons';
 export {
   formatInlineMarkdown, formatResponse, extractUrls, findMentionPositions 
 } from './MarkdownProcessor';

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -7,6 +7,8 @@ export { Button } from './Button';
 export type {
   ButtonVariant, ButtonSize 
 } from './Button';
+export { getChartTheme } from './chartTheme';
+export type { ChartTheme } from './chartTheme';
 export {
   PauseIcon,
   PlayIcon,

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -21,6 +21,8 @@ export {
   GlobeIcon,
   KeyIcon,
   WarningIcon,
+  CheckIcon,
+  ArrowRightIcon,
 } from './Icons';
 export {
   formatInlineMarkdown, formatResponse, extractUrls, findMentionPositions 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -33,12 +33,24 @@
   background-color: rgb(55 65 81); /* gray-700 */
 }
 
+.dark .bg-gray-200 {
+  background-color: rgb(75 85 99); /* gray-600 */
+}
+
 .dark .border-gray-200 {
   border-color: rgb(55 65 81); /* gray-700 */
 }
 
 .dark .border-gray-100 {
   border-color: rgb(55 65 81); /* gray-700 */
+}
+
+.dark .border-gray-300 {
+  border-color: rgb(75 85 99); /* gray-600 */
+}
+
+.dark .hover\:border-gray-300:hover {
+  border-color: rgb(107 114 128); /* gray-500 */
 }
 
 .dark .text-gray-900 {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -77,6 +77,171 @@
   background-color: rgb(75 85 99); /* gray-600 */
 }
 
+/* ============================================================
+ * Accent surfaces in dark mode
+ *
+ * Tinted Tailwind classes (`bg-{tone}-50`, `bg-{tone}-100`, accent
+ * text and borders) do not adapt to dark mode by default. Without
+ * these overrides, components that use accent palettes (e.g. the
+ * Brand settings emerald / amber / violet panels, status badges,
+ * stat cards) render as bright pale-tinted surfaces sitting on a
+ * dark page – uncomfortable to read and visually inconsistent.
+ *
+ * Strategy:
+ *   - `bg-{tone}-50/100` → translucent dark tint (~20-40% alpha
+ *     over the dark surface). Reads as a low-saturation tinted
+ *     callout, not a bright pastel.
+ *   - `text-{tone}-700/800/900` → the corresponding `*-300/-200`
+ *     variant. These are the legible accent colours on dark.
+ *   - `border-{tone}-100/200/300` → muted accent borders so the
+ *     panel still feels tinted but does not glow.
+ *   - `hover:bg-{tone}-100/200` → hover lifts to a slightly denser
+ *     translucent tint instead of flashing to bright pastel.
+ *
+ * Saturated solid surfaces (`bg-{tone}-500/600/700`) and their
+ * matching `text-white` pairings are intentionally NOT overridden:
+ * they are primary action buttons that work as-is in both themes.
+ *
+ * See `docs/design-system.md#1-theming-model` for the rationale.
+ * ============================================================ */
+
+/* --- Emerald / Green (success, first-party brands, "yours") --- */
+.dark .bg-emerald-50  { background-color: rgb(6 78 59 / 0.25); }
+.dark .bg-emerald-100 { background-color: rgb(6 78 59 / 0.4); }
+.dark .bg-green-50    { background-color: rgb(6 78 59 / 0.25); }
+.dark .bg-green-100   { background-color: rgb(6 78 59 / 0.4); }
+.dark .text-emerald-700 { color: rgb(110 231 183); /* emerald-300 */ }
+.dark .text-emerald-800 { color: rgb(110 231 183); }
+.dark .text-emerald-900 { color: rgb(167 243 208); /* emerald-200 */ }
+.dark .text-green-700   { color: rgb(134 239 172); /* green-300 */ }
+.dark .text-green-800   { color: rgb(134 239 172); }
+.dark .text-green-900   { color: rgb(187 247 208); /* green-200 */ }
+.dark .border-emerald-100 { border-color: rgb(6 95 70 / 0.4); }
+.dark .border-emerald-200 { border-color: rgb(4 120 87 / 0.55); }
+.dark .border-emerald-300 { border-color: rgb(5 150 105 / 0.7); }
+.dark .border-green-100   { border-color: rgb(20 83 45 / 0.4); }
+.dark .border-green-200   { border-color: rgb(22 101 52 / 0.55); }
+.dark .border-green-300   { border-color: rgb(21 128 61 / 0.7); }
+.dark .hover\:bg-emerald-100:hover { background-color: rgb(6 78 59 / 0.55); }
+.dark .hover\:bg-emerald-200:hover { background-color: rgb(6 78 59 / 0.7); }
+.dark .hover\:bg-green-100:hover   { background-color: rgb(6 78 59 / 0.55); }
+
+/* --- Amber / Yellow (warnings, competitor brands) --- */
+.dark .bg-amber-50  { background-color: rgb(120 53 15 / 0.25); }
+.dark .bg-amber-100 { background-color: rgb(120 53 15 / 0.4); }
+.dark .bg-yellow-50  { background-color: rgb(113 63 18 / 0.25); }
+.dark .bg-yellow-100 { background-color: rgb(113 63 18 / 0.4); }
+.dark .text-amber-700  { color: rgb(252 211 77); /* amber-300 */ }
+.dark .text-amber-800  { color: rgb(252 211 77); }
+.dark .text-amber-900  { color: rgb(253 230 138); /* amber-200 */ }
+.dark .text-yellow-700 { color: rgb(253 224 71); /* yellow-300 */ }
+.dark .text-yellow-800 { color: rgb(253 224 71); }
+.dark .text-yellow-900 { color: rgb(254 240 138); /* yellow-200 */ }
+.dark .border-amber-100  { border-color: rgb(146 64 14 / 0.4); }
+.dark .border-amber-200  { border-color: rgb(180 83 9 / 0.55); }
+.dark .border-amber-300  { border-color: rgb(217 119 6 / 0.7); }
+.dark .border-yellow-100 { border-color: rgb(133 77 14 / 0.4); }
+.dark .border-yellow-200 { border-color: rgb(161 98 7 / 0.55); }
+.dark .hover\:bg-amber-100:hover { background-color: rgb(120 53 15 / 0.55); }
+.dark .hover\:bg-amber-200:hover { background-color: rgb(120 53 15 / 0.7); }
+
+/* --- Violet / Purple / Fuchsia (brand mentions, custom entities) --- */
+.dark .bg-violet-50   { background-color: rgb(76 29 149 / 0.25); }
+.dark .bg-violet-100  { background-color: rgb(76 29 149 / 0.4); }
+.dark .bg-purple-50   { background-color: rgb(88 28 135 / 0.25); }
+.dark .bg-purple-100  { background-color: rgb(88 28 135 / 0.4); }
+.dark .bg-fuchsia-50  { background-color: rgb(112 26 117 / 0.25); }
+.dark .bg-fuchsia-100 { background-color: rgb(112 26 117 / 0.4); }
+.dark .text-violet-700  { color: rgb(196 181 253); /* violet-300 */ }
+.dark .text-violet-800  { color: rgb(196 181 253); }
+.dark .text-violet-900  { color: rgb(221 214 254); /* violet-200 */ }
+.dark .text-purple-700  { color: rgb(216 180 254); /* purple-300 */ }
+.dark .text-purple-800  { color: rgb(216 180 254); }
+.dark .text-purple-900  { color: rgb(233 213 255); /* purple-200 */ }
+.dark .text-fuchsia-700 { color: rgb(240 171 252); /* fuchsia-300 */ }
+.dark .text-fuchsia-800 { color: rgb(240 171 252); }
+.dark .border-violet-100  { border-color: rgb(91 33 182 / 0.4); }
+.dark .border-violet-200  { border-color: rgb(109 40 217 / 0.55); }
+.dark .border-violet-300  { border-color: rgb(124 58 237 / 0.7); }
+.dark .border-purple-100  { border-color: rgb(107 33 168 / 0.4); }
+.dark .border-purple-200  { border-color: rgb(126 34 206 / 0.55); }
+.dark .hover\:bg-violet-100:hover { background-color: rgb(76 29 149 / 0.55); }
+.dark .hover\:bg-violet-200:hover { background-color: rgb(76 29 149 / 0.7); }
+
+/* --- Blue / Indigo / Sky / Cyan (info, metrics, links) --- */
+.dark .bg-blue-50   { background-color: rgb(30 58 138 / 0.25); }
+.dark .bg-blue-100  { background-color: rgb(30 58 138 / 0.4); }
+.dark .bg-indigo-50  { background-color: rgb(49 46 129 / 0.25); }
+.dark .bg-indigo-100 { background-color: rgb(49 46 129 / 0.4); }
+.dark .bg-sky-50    { background-color: rgb(12 74 110 / 0.25); }
+.dark .bg-sky-100   { background-color: rgb(12 74 110 / 0.4); }
+.dark .bg-cyan-50   { background-color: rgb(22 78 99 / 0.25); }
+.dark .bg-cyan-100  { background-color: rgb(22 78 99 / 0.4); }
+.dark .text-blue-700   { color: rgb(147 197 253); /* blue-300 */ }
+.dark .text-blue-800   { color: rgb(147 197 253); }
+.dark .text-blue-900   { color: rgb(191 219 254); /* blue-200 */ }
+.dark .text-indigo-700 { color: rgb(165 180 252); /* indigo-300 */ }
+.dark .text-indigo-800 { color: rgb(165 180 252); }
+.dark .text-sky-700    { color: rgb(125 211 252); /* sky-300 */ }
+.dark .text-sky-800    { color: rgb(125 211 252); }
+.dark .border-blue-100   { border-color: rgb(30 64 175 / 0.4); }
+.dark .border-blue-200   { border-color: rgb(29 78 216 / 0.55); }
+.dark .border-blue-300   { border-color: rgb(37 99 235 / 0.7); }
+.dark .border-indigo-100 { border-color: rgb(55 48 163 / 0.4); }
+.dark .border-indigo-200 { border-color: rgb(67 56 202 / 0.55); }
+.dark .border-sky-100    { border-color: rgb(7 89 133 / 0.4); }
+.dark .border-sky-200    { border-color: rgb(3 105 161 / 0.55); }
+.dark .hover\:bg-blue-100:hover { background-color: rgb(30 58 138 / 0.55); }
+.dark .hover\:bg-blue-200:hover { background-color: rgb(30 58 138 / 0.7); }
+
+/* --- Teal --- */
+.dark .bg-teal-50   { background-color: rgb(19 78 74 / 0.25); }
+.dark .bg-teal-100  { background-color: rgb(19 78 74 / 0.4); }
+.dark .text-teal-700 { color: rgb(94 234 212); /* teal-300 */ }
+.dark .text-teal-800 { color: rgb(94 234 212); }
+.dark .border-teal-100 { border-color: rgb(17 94 89 / 0.4); }
+.dark .border-teal-200 { border-color: rgb(15 118 110 / 0.55); }
+
+/* --- Red / Rose / Orange (errors, destructive, gaps) --- */
+.dark .bg-red-50    { background-color: rgb(127 29 29 / 0.25); }
+.dark .bg-red-100   { background-color: rgb(127 29 29 / 0.4); }
+.dark .bg-rose-50   { background-color: rgb(136 19 55 / 0.25); }
+.dark .bg-rose-100  { background-color: rgb(136 19 55 / 0.4); }
+.dark .bg-orange-50  { background-color: rgb(124 45 18 / 0.25); }
+.dark .bg-orange-100 { background-color: rgb(124 45 18 / 0.4); }
+.dark .text-red-700    { color: rgb(252 165 165); /* red-300 */ }
+.dark .text-red-800    { color: rgb(252 165 165); }
+.dark .text-red-900    { color: rgb(254 202 202); /* red-200 */ }
+.dark .text-rose-700   { color: rgb(253 164 175); /* rose-300 */ }
+.dark .text-rose-800   { color: rgb(253 164 175); }
+.dark .text-orange-700 { color: rgb(253 186 116); /* orange-300 */ }
+.dark .text-orange-800 { color: rgb(253 186 116); }
+.dark .border-red-100   { border-color: rgb(153 27 27 / 0.4); }
+.dark .border-red-200   { border-color: rgb(185 28 28 / 0.55); }
+.dark .border-red-300   { border-color: rgb(220 38 38 / 0.7); }
+.dark .border-rose-100  { border-color: rgb(159 18 57 / 0.4); }
+.dark .border-rose-200  { border-color: rgb(190 18 60 / 0.55); }
+.dark .border-orange-100 { border-color: rgb(154 52 18 / 0.4); }
+.dark .border-orange-200 { border-color: rgb(194 65 12 / 0.55); }
+.dark .border-orange-300 { border-color: rgb(234 88 12 / 0.7); }
+.dark .hover\:bg-red-100:hover    { background-color: rgb(127 29 29 / 0.55); }
+.dark .hover\:bg-red-200:hover    { background-color: rgb(127 29 29 / 0.7); }
+.dark .hover\:bg-rose-100:hover   { background-color: rgb(136 19 55 / 0.55); }
+
+/* --- Slate (low-emphasis) --- */
+.dark .bg-slate-50   { background-color: rgb(15 23 42 / 0.5); }
+.dark .bg-slate-100  { background-color: rgb(15 23 42 / 0.7); }
+.dark .text-slate-700 { color: rgb(203 213 225); /* slate-300 */ }
+.dark .text-slate-800 { color: rgb(203 213 225); }
+.dark .border-slate-100 { border-color: rgb(30 41 59 / 0.5); }
+.dark .border-slate-200 { border-color: rgb(51 65 85 / 0.7); }
+
+/* --- Alpha-modifier surfaces used in row backgrounds --- */
+.dark .bg-emerald-50\/50 { background-color: rgb(6 78 59 / 0.2); }
+.dark .bg-green-50\/30   { background-color: rgb(6 78 59 / 0.18); }
+.dark .bg-red-50\/30     { background-color: rgb(127 29 29 / 0.18); }
+.dark .bg-orange-50\/30  { background-color: rgb(124 45 18 / 0.2); }
+
 /* Input fields in dark mode */
 .dark input:not([type="checkbox"]):not([type="radio"]),
 .dark textarea,

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,1 +1,27 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+/**
+ * Polyfill `window.matchMedia` for jsdom. Components that consume the
+ * `useTheme` hook (chart components, layout, theme toggle) break in
+ * tests without it because jsdom does not implement matchMedia.
+ *
+ * Returns a non-matching media query by default. Tests that need to
+ * assert dark-mode behaviour can override `window.matchMedia` per
+ * test.
+ */
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary

Normalises the dashboard's visual language and removes emoji from interactive UI. Triggered by feedback that the Personas page (`Settings > Query Prompts`) uses emoji icons (⏸ ▶ ✏️ 🗑) for action buttons and a non-canonical "+ New Persona" button — neither match the icon and button style used everywhere else.

The fix introduces shared `<Button>` and `<Icons>` primitives, migrates the Personas page onto them, sweeps related anomalies discovered during the audit, and documents the design system so the rules are explicit going forward.

## What changed

### New shared primitives (`web/src/components/ui/`)
- **`Icons.tsx`** — 13 stroke-based Heroicons-style outline icons (`Pause`, `Play`, `Pencil`, `Trash`, `Plus`, `Close`, `ChevronRight/Down`, `Search`, `Link`, `Globe`, `Key`, `Warning`). 24×24 viewBox, `currentColor`, `strokeWidth=1.5` — matches the sidebar nav language.
- **`Button.tsx`** — `<Button>` with variants `primary | secondary | ghost | danger | iconOnly` and sizes `sm | md`. Supports `leadingIcon`, `trailingIcon`, `invertOnDark` for buttons on always-dark surfaces.

### Personas page (the original complaint)
`web/src/components/Settings/QueryPromptsManager.tsx`:
- Emoji action icons (⏸ ▶ ✏️ 🗑) → `PauseIcon` / `PlayIcon` / `PencilIcon` / `TrashIcon`.
- "+ New Persona", Save, and Cancel buttons migrated to `<Button>` with proper variants.

### Other anomalies fixed in the same pass
- `Dashboard/StatCard.tsx` — removed the `icon: '🔍' → SVG lookup map` anti-pattern. Now accepts a `ReactNode` icon and a `tone` enum (`blue | violet | emerald | amber | gray`). `Layout/TabContent.tsx` and the test updated.
- `Tables/TopCitationsTable.tsx`, `Keywords/KeywordDetailComponents.tsx`, `Brands/ProviderResponseCard.tsx` — `▲ ▼ ▶` text characters used for expand/collapse → rotating `ChevronDownIcon` with `aria-expanded` and `aria-label`.
- `Brands/BrandExpansionPanel.tsx` — `⚠️` in duplicate-warning text → `WarningIcon`.

### Documentation
- **`docs/design-system.md`** (430 lines) — covers theming model (class-based dark mode + global CSS overrides + CSS vars), color palette (neutral + accent + semantic), typography, spacing, buttons (variants/sizes/anti-patterns), icons (style/sizing/a11y/no-emoji rule), components inventory, forms, tables, favicon/identity, and an anomaly checklist with the items fixed in this PR.

## Visual change

Before / after on the Personas page:

| | Before | After |
|---|---|---|
| Action icons | `⏸ ✏️ 🗑` (emoji, can't be recoloured, inconsistent across OSes) | Stroke SVG icons matching sidebar nav |
| Disabled toggle | `▶` (text triangle) | `PlayIcon` |
| New Persona button | Smaller `bg-gray-900` rectangle, no icon | Canonical primary `<Button>` with `+` icon |
| Dark mode | No `dark:` styling | Inherited via global overrides |

## Testing

- `npm run type-check` — clean
- `npm run build` (Vite production build) — succeeds in 7s
- `npm test --run` — 70 test files, 676 tests pass
- `npx eslint` on every touched/new file — zero errors, zero warnings

## Notes

- No behaviour changes. Pure visual / API normalisation.
- The Sidebar still ships its own inline icons. Consolidating those into `Icons.tsx` is called out as a future refactor in `docs/design-system.md`.
- Decorative emoji inside the About section (`ArchitectureTab`, `LicensesTab`) are intentionally kept and documented as "the ceiling" for emoji usage. They are not interactive controls.
- Pre-existing lint errors elsewhere in the repo (e.g. `useKeywordResearch.ts`, `useSelfReflection.ts`, `shared/PersonaSelector.tsx` from the recent persona/self-reflection merge) are out of scope for this PR.

## Anomaly checklist (from `docs/design-system.md`)

- [x] No emoji as a button label or interactive icon
- [x] No unicode arrows (`▲▼◀▶`) for expand/collapse
- [x] No hand-rolled `className="px-4 py-2 bg-gray-900 …"` button strings on touched files
- [x] No icon-only button without `aria-label` / `title`
- [x] No emoji-as-key prop signatures
- [x] All new icons follow the stroke convention
