### PR TITLE
perf: parallelize DynamoDB reads (CrawledContent, historical trends)

### DIFF
--- a/lambda/api/content-studio.py
+++ b/lambda/api/content-studio.py
@@ -29,6 +29,7 @@ sys.path.insert(0, '/opt/python')
 from decimal_utils import to_int
 from shared.api_response import api_response, success_response, validation_error
 from shared.decorators import api_handler, parse_json_body, route_handler, validate
+from shared.dynamodb_batch import query_latest_per_key
 from shared.models import BedrockInvocationError, ModelRole, get_model_tier, invoke_bedrock
 from shared.prompt_safety import untrusted_input_system_instruction, wrap_user_input
 from shared.utils import brand_names_match, extract_domain, get_brand_config, get_timestamp, utc_now
@@ -157,30 +158,32 @@ def _get_seasonal_suggestions(keywords: list[str], config: dict[str, Any]) -> li
 
 
 def get_crawled_content(urls: list[str], limit: int = 5) -> list[dict[str, Any]]:
-    """Get crawled content for competitor analysis."""
+    """Get crawled content for competitor analysis.
+
+    Queries are parallelized via ``shared.dynamodb_batch.query_latest_per_key``.
+    Wall-clock stays ~constant regardless of URL count instead of scaling
+    linearly (audit item 16).
+    """
     table = dynamodb.Table(CRAWLED_CONTENT_TABLE)
-    content_list = []
+    urls_slice = urls[:limit]
+    latest = query_latest_per_key(
+        table=table,
+        partition_key_name='normalized_url',
+        partition_values=urls_slice,
+    )
 
-    for url in urls[:limit]:
-        try:
-            response = table.query(
-                KeyConditionExpression=Key('normalized_url').eq(url),
-                Limit=1,
-                ScanIndexForward=False
-            )
-            items = response.get('Items', [])
-            if items:
-                item = items[0]
-                content_list.append({
-                    'url': url,
-                    'title': item.get('title', ''),
-                    'content_preview': item.get('content', '')[:2000] if item.get('content') else '',
-                    'seo_analysis': item.get('seo_analysis', {}),
-                    'domain': extract_domain(url)
-                })
-        except Exception as e:
-            logger.error(f"Error getting crawled content for {url}: {e}")
-
+    content_list: list[dict[str, Any]] = []
+    for url in urls_slice:
+        item = latest.get(url)
+        if not item:
+            continue
+        content_list.append({
+            'url': url,
+            'title': item.get('title', ''),
+            'content_preview': item.get('content', '')[:2000] if item.get('content') else '',
+            'seo_analysis': item.get('seo_analysis', {}),
+            'domain': extract_domain(url),
+        })
     return content_list
 
 

--- a/lambda/api/get-citation-gaps.py
+++ b/lambda/api/get-citation-gaps.py
@@ -25,6 +25,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response
 from shared.decorators import api_handler, validate
+from shared.dynamodb_batch import query_latest_per_key
 from shared.utils import extract_domain, get_brand_config
 
 logger = logging.getLogger(__name__)
@@ -92,27 +93,39 @@ def is_first_party_domain(domain: str, config: dict[str, Any]) -> bool:
     return False
 
 
-def get_crawled_content_info(url: str) -> dict[str, Any]:
-    """Get SEO info from crawled content if available."""
-    try:
-        table = dynamodb.Table(CRAWLED_CONTENT_TABLE)
-        response = table.query(
-            KeyConditionExpression=Key('normalized_url').eq(url),
-            Limit=1,
-            ScanIndexForward=False  # Get most recent
-        )
-        items = response.get('Items', [])
-        if items:
-            item = items[0]
-            return {
-                'title': item.get('title', ''),
-                'seo_analysis': item.get('seo_analysis', {}),
-                'domain_authority': item.get('domain_authority'),
-                'last_crawled': item.get('crawled_at')
-            }
-    except Exception as e:
-        logger.error(f"Error getting crawled content: {e}")
-    return {}
+def _batch_crawled_info(urls: list[str]) -> dict[str, dict[str, Any]]:
+    """Fetch the latest CrawledContent row for each URL in parallel.
+
+    Returns a dict mapping each input URL to its shaped crawled-info
+    payload (only the fields consumed by `analyze_citation_gaps`).
+    Missing URLs get no entry so callers can safely `map.get(url, {})`.
+
+    Replaces the per-URL `get_crawled_content_info` call that used to
+    live inside `analyze_citation_gaps`'s loop (audit item 16).
+    Per-URL query failures are logged inside `query_latest_per_key`
+    and surface here as missing keys in the returned dict.
+    """
+    if not urls:
+        return {}
+
+    table = dynamodb.Table(CRAWLED_CONTENT_TABLE)
+    raw = query_latest_per_key(
+        table=table,
+        partition_key_name='normalized_url',
+        partition_values=urls,
+    )
+
+    shaped: dict[str, dict[str, Any]] = {}
+    for url, item in raw.items():
+        if not item:
+            continue
+        shaped[url] = {
+            'title': item.get('title', ''),
+            'seo_analysis': item.get('seo_analysis', {}),
+            'domain_authority': item.get('domain_authority'),
+            'last_crawled': item.get('crawled_at'),
+        }
+    return shaped
 
 
 def fuzzy_match_brand(brand_name: str, parent_company: str, tracked_list: list[str]) -> bool:
@@ -230,6 +243,16 @@ def analyze_citation_gaps(keyword: str, config: dict[str, Any]) -> dict[str, Any
     gaps = []
     covered_sources = []
 
+    # Batch-fetch crawled content for all relevant URLs up front. The
+    # previous per-URL query inside the loop was O(N) round-trips to
+    # DynamoDB (audit item 16); this collapses it to ~1 RTT worth of
+    # parallel work.
+    relevant_urls = [
+        url for url, data in source_brand_map.items()
+        if not is_first_party_domain(data['domain'], config)
+    ]
+    crawled_info_map = _batch_crawled_info(relevant_urls)
+
     for url, data in source_brand_map.items():
         domain = data['domain']
 
@@ -248,8 +271,8 @@ def analyze_citation_gaps(keyword: str, config: dict[str, Any]) -> dict[str, Any
             'competitor_brands': list(data['competitors'])
         }
 
-        # Get additional info from crawled content
-        crawled_info = get_crawled_content_info(url)
+        # Pull crawled info from the prefetched batch.
+        crawled_info = crawled_info_map.get(url, {})
         if crawled_info:
             source_info.update(crawled_info)
 

--- a/lambda/api/get-historical-trends.py
+++ b/lambda/api/get-historical-trends.py
@@ -11,6 +11,7 @@ Features:
 - Provider-specific trends
 """
 
+import concurrent.futures
 import logging
 import os
 import sys
@@ -30,6 +31,11 @@ from shared.api_response import success_response
 from shared.decorators import api_handler, validate
 from shared.providers import get_enabled_provider_count
 from shared.utils import brand_names_match, get_brand_config, utc_now
+
+# Bounded parallelism for the per-keyword trend fan-out. 10 workers keeps the
+# DynamoDB RCU pressure reasonable on the SearchResults table while collapsing
+# 20 sequential queries into ~2 rounds of parallel work.
+_TRENDS_MAX_WORKERS = 10
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -162,22 +168,41 @@ def aggregate_by_period(items: list[dict], period: str, config: dict) -> list[di
     return trend_data
 
 
-def get_historical_trends(keyword: str, config: dict, period: str = 'day', days: int = 30) -> dict[str, Any]:
-    """Get historical trend data for a keyword."""
-    table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+def _fetch_keyword_items(keyword: str) -> list[dict]:
+    """Fetch raw search-result rows for a keyword. Pulled out for parallel
+    fan-out in ``get_all_keywords_trends`` — the rest of ``get_historical_trends``
+    is CPU-bound aggregation that's safe to run serially afterwards.
 
-    # Query all results for keyword
-    response = table.query(
-        KeyConditionExpression=Key('keyword').eq(keyword)
-    )
-    items = response.get('Items', [])
+    Returns an empty list on query failure so a single bad keyword can't fail
+    the whole trends dashboard. Errors are logged for ops visibility.
+    """
+    try:
+        table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+        response = table.query(KeyConditionExpression=Key('keyword').eq(keyword))
+        return response.get('Items', [])
+    except Exception as e:
+        logger.error(f"Error fetching trend items for keyword {keyword!r}: {e}")
+        return []
 
+
+def _build_trend_from_items(
+    keyword: str,
+    items: list[dict],
+    config: dict,
+    period: str,
+    days: int,
+) -> dict[str, Any]:
+    """Build the trend payload from an already-fetched items list.
+
+    Extracted from ``get_historical_trends`` so the parallel fan-out can
+    collect queries first, then run the CPU-bound aggregation serially
+    on the main thread (avoiding the GIL contention that makes threading
+    unhelpful for pure-Python work).
+    """
     if not items:
         return {"error": f"No data found for keyword: {keyword}"}
 
     # Filter to requested time range.
-    # Use a naive cutoff so the ISO string compares lexicographically against the
-    # stored 'Z'-suffixed timestamps (e.g. '2026-04-18T12:34:56.789012Z').
     cutoff = utc_now().replace(tzinfo=None) - timedelta(days=days)
     cutoff_str = cutoff.isoformat()
 
@@ -230,8 +255,25 @@ def get_historical_trends(keyword: str, config: dict, period: str = 'day', days:
     }
 
 
+def get_historical_trends(keyword: str, config: dict, period: str = 'day', days: int = 30) -> dict[str, Any]:
+    """Get historical trend data for a keyword.
+
+    Single-keyword entry point. Fetches + aggregates inline. For multi-keyword
+    dashboards use ``get_all_keywords_trends``, which parallelizes the query
+    step via ``_fetch_keyword_items``.
+    """
+    items = _fetch_keyword_items(keyword)
+    return _build_trend_from_items(keyword, items, config, period, days)
+
+
 def get_all_keywords_trends(config: dict, period: str = 'day', days: int = 30) -> dict[str, Any]:
-    """Get trend summary across all keywords."""
+    """Get trend summary across all keywords.
+
+    DynamoDB queries are parallelized across up to ``_TRENDS_MAX_WORKERS``
+    workers to collapse the previous N sequential queries (audit item 16).
+    Aggregation runs serially afterwards on the main thread — it's pure
+    Python and the GIL makes threading unhelpful for that phase.
+    """
     # Get keywords from the Keywords table instead of scanning SearchResults
     # This is more efficient as Keywords table is small and purpose-built
     keywords_table_name = os.environ.get('DYNAMODB_TABLE_KEYWORDS')
@@ -248,10 +290,49 @@ def get_all_keywords_trends(config: dict, period: str = 'day', days: int = 30) -
         response = table.scan(ProjectionExpression='keyword', Limit=500)
         keywords = list(set(item.get('keyword', '') for item in response.get('Items', []) if item.get('keyword')))
 
-    keyword_trends = []
+    # Cap fan-out at 20 keywords — matches the previous behavior so the
+    # dashboard's perceived breadth doesn't change, and bounds DynamoDB
+    # RCU + Lambda CPU cost.
+    keywords_to_query = keywords[:20]
+    if not keywords_to_query:
+        return {
+            'period_type': period,
+            'days_analyzed': days,
+            'keywords_analyzed': 0,
+            'keyword_trends': [],
+            'overall': {
+                'improving_count': 0,
+                'declining_count': 0,
+                'stable_count': 0,
+                'avg_score': 0,
+            }
+        }
 
-    for keyword in keywords[:20]:  # Limit to 20 keywords
-        trend = get_historical_trends(keyword, config, period, days)
+    # Phase 1: parallel DynamoDB queries.
+    workers = min(_TRENDS_MAX_WORKERS, len(keywords_to_query))
+    items_by_keyword: dict[str, list[dict]] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        future_to_keyword = {
+            pool.submit(_fetch_keyword_items, kw): kw
+            for kw in keywords_to_query
+        }
+        for future in concurrent.futures.as_completed(future_to_keyword):
+            kw = future_to_keyword[future]
+            try:
+                items_by_keyword[kw] = future.result()
+            except Exception as e:
+                # _fetch_keyword_items already catches and logs, but pool
+                # propagation quirks (e.g. interpreter shutdown) could still
+                # raise. Default to empty so aggregation treats it as
+                # "no data for this keyword".
+                logger.error(f"Trend fan-out future failed for {kw!r}: {e}")
+                items_by_keyword[kw] = []
+
+    # Phase 2: CPU-bound aggregation, serial on the main thread.
+    keyword_trends = []
+    for keyword in keywords_to_query:
+        items = items_by_keyword.get(keyword, [])
+        trend = _build_trend_from_items(keyword, items, config, period, days)
         if 'error' not in trend:
             keyword_trends.append({
                 'keyword': keyword,

--- a/lambda/api/test_historical_trends_parallel.py
+++ b/lambda/api/test_historical_trends_parallel.py
@@ -1,0 +1,293 @@
+"""
+Tests for the parallel fan-out in `get_all_keywords_trends` (audit item 16).
+
+Background — these tests pin the fix for the last N+1 DynamoDB query loop
+flagged in the audit. The previous implementation looped over keywords and
+called `get_historical_trends` serially, which issued one DynamoDB `query`
+per keyword. For the default 20-keyword cap that was 20 sequential round-trips.
+
+The refactor splits `get_historical_trends` into:
+  - `_fetch_keyword_items(keyword)` — DynamoDB query only
+  - `_build_trend_from_items(...)` — pure-Python aggregation
+
+`get_all_keywords_trends` now fans out phase 1 through a ThreadPoolExecutor
+(bounded at `_TRENDS_MAX_WORKERS=10`) and runs phase 2 serially afterwards.
+
+These tests would FAIL if the serial loop were reintroduced.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Load env vars the module reads at import.
+os.environ.setdefault('DYNAMODB_TABLE_SEARCH_RESULTS', 'test-search')
+
+_HERE = os.path.dirname(__file__)
+_MODULE_PATH = os.path.join(_HERE, 'get-historical-trends.py')
+
+_LAMBDA_DIR = os.path.dirname(_HERE)
+if _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+_spec = importlib.util.spec_from_file_location(
+    'get_historical_trends_under_test', _MODULE_PATH
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules['get_historical_trends_under_test'] = _mod
+_spec.loader.exec_module(_mod)
+
+
+class TestFetchKeywordItems:
+    """`_fetch_keyword_items` is the I/O-only helper that gets fanned out."""
+
+    def test_returns_items_from_dynamodb_query(self) -> None:
+        fake_table = MagicMock()
+        fake_table.query.return_value = {'Items': [{'timestamp': '2026-01-01T00:00:00Z'}]}
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = fake_table
+        with patch.object(_mod, 'dynamodb', fake_resource):
+            items = _mod._fetch_keyword_items('my-keyword')
+        assert items == [{'timestamp': '2026-01-01T00:00:00Z'}]
+
+    def test_returns_empty_list_when_query_raises(self) -> None:
+        """A single bad keyword must not break the whole dashboard."""
+        fake_table = MagicMock()
+        fake_table.query.side_effect = Exception('throttled')
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = fake_table
+        with patch.object(_mod, 'dynamodb', fake_resource):
+            items = _mod._fetch_keyword_items('my-keyword')
+        assert items == []
+
+
+class TestBuildTrendFromItems:
+    """`_build_trend_from_items` is pure-Python, no I/O. Easy to test."""
+
+    def test_returns_error_for_empty_items(self) -> None:
+        result = _mod._build_trend_from_items('kw', [], {}, 'day', 30)
+        assert 'error' in result
+        assert 'kw' in result['error']
+
+    def test_returns_trend_payload_shape_for_items(self) -> None:
+        """Contract check: the returned dict still carries the same keys
+        the dashboard consumes. This is the characterization test for the
+        extract-method refactor."""
+        items = [
+            {
+                'keyword': 'kw',
+                'timestamp': '2026-04-17T12:00:00Z',
+                'provider': 'openai',
+                'brands': [
+                    {'name': 'MyBrand', 'classification': 'first_party',
+                     'mention_count': 1, 'rank': 1}
+                ],
+            }
+        ]
+        result = _mod._build_trend_from_items('kw', items, {}, 'day', 30)
+        assert result['keyword'] == 'kw'
+        assert result['period_type'] == 'day'
+        assert 'trend_data' in result
+        assert 'trend_direction' in result
+        assert 'summary' in result
+
+
+class TestGetAllKeywordsTrendsParallelFanOut:
+    """The regression guards for the parallelization."""
+
+    def _fake_keyword_items(self, keyword: str) -> list[dict]:
+        """One trend item per keyword, enough to build a non-error trend."""
+        return [
+            {
+                'keyword': keyword,
+                'timestamp': '2026-04-17T12:00:00Z',
+                'provider': 'openai',
+                'brands': [
+                    {'name': 'MyBrand', 'classification': 'first_party',
+                     'mention_count': 1, 'rank': 1}
+                ],
+            }
+        ]
+
+    def test_fetches_each_keyword_exactly_once(self) -> None:
+        """Regression guard: the parallel fan-out must dedupe any accidental
+        double-queries. The previous serial loop only called fetch once per
+        keyword; we must preserve that."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(5)]
+        }
+        search_table = MagicMock()
+
+        def fake_resource_table(name: str):
+            if 'KEYWORD' in name.upper() or 'keyword' in name.lower():
+                return keywords_table
+            return search_table
+
+        fake_resource = MagicMock()
+        fake_resource.Table.side_effect = fake_resource_table
+
+        call_counter = {'count': 0}
+
+        def counting_fetch(keyword: str) -> list[dict]:
+            call_counter['count'] += 1
+            return self._fake_keyword_items(keyword)
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=counting_fetch):
+            result = _mod.get_all_keywords_trends({}, 'day', 30)
+
+        # 5 keywords → 5 fetches, no duplication.
+        assert call_counter['count'] == 5
+        assert result['keywords_analyzed'] == 5
+
+    def test_uses_thread_pool_for_parallel_fetching(self) -> None:
+        """Regression guard: if someone reverts to a serial loop, the
+        ThreadPoolExecutor would never be constructed. We assert the pool
+        is used. This catches the whole class of "accidentally serial"
+        regressions."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(3)]
+        }
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=self._fake_keyword_items), \
+             patch.object(_mod.concurrent.futures, 'ThreadPoolExecutor',
+                         wraps=_mod.concurrent.futures.ThreadPoolExecutor) as pool_spy:
+            _mod.get_all_keywords_trends({}, 'day', 30)
+
+        pool_spy.assert_called_once()
+
+    def test_caps_worker_count_at_max_workers_constant(self) -> None:
+        """With more keywords than `_TRENDS_MAX_WORKERS`, the pool size is
+        capped — otherwise we'd spawn 20+ threads and overshoot DynamoDB RCU.
+        """
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(20)]
+        }
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=self._fake_keyword_items), \
+             patch.object(_mod.concurrent.futures, 'ThreadPoolExecutor',
+                         wraps=_mod.concurrent.futures.ThreadPoolExecutor) as pool_spy:
+            _mod.get_all_keywords_trends({}, 'day', 30)
+
+        pool_spy.assert_called_once()
+        _, kwargs = pool_spy.call_args
+        assert kwargs['max_workers'] == _mod._TRENDS_MAX_WORKERS
+
+    def test_caps_worker_count_at_keyword_count_when_fewer_than_max(self) -> None:
+        """With fewer keywords than `_TRENDS_MAX_WORKERS`, size to keyword
+        count. No point spinning up 10 threads for 3 items."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(3)]
+        }
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=self._fake_keyword_items), \
+             patch.object(_mod.concurrent.futures, 'ThreadPoolExecutor',
+                         wraps=_mod.concurrent.futures.ThreadPoolExecutor) as pool_spy:
+            _mod.get_all_keywords_trends({}, 'day', 30)
+
+        _, kwargs = pool_spy.call_args
+        assert kwargs['max_workers'] == 3
+
+    def test_returns_empty_payload_when_no_keywords(self) -> None:
+        """Empty keyword set must not spin up the pool or fail."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {'Items': []}
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items') as mock_fetch:
+            result = _mod.get_all_keywords_trends({}, 'day', 30)
+
+        mock_fetch.assert_not_called()
+        assert result['keywords_analyzed'] == 0
+        assert result['keyword_trends'] == []
+        assert result['overall']['avg_score'] == 0
+
+    def test_preserves_all_keyword_results_despite_async_order(self) -> None:
+        """`as_completed` returns futures in completion order, which is
+        non-deterministic. The output must still cover every input keyword
+        (sorting by current_score is applied at the end)."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(5)]
+        }
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=self._fake_keyword_items):
+            result = _mod.get_all_keywords_trends({}, 'day', 30)
+
+        returned_keywords = {t['keyword'] for t in result['keyword_trends']}
+        assert returned_keywords == {f'kw{i}' for i in range(5)}
+
+    def test_caps_fan_out_at_twenty_keywords(self) -> None:
+        """Dashboard breadth cap — unchanged from the serial implementation."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(50)]
+        }
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        call_counter = {'count': 0}
+
+        def counting_fetch(keyword: str) -> list[dict]:
+            call_counter['count'] += 1
+            return self._fake_keyword_items(keyword)
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=counting_fetch):
+            _mod.get_all_keywords_trends({}, 'day', 30)
+
+        assert call_counter['count'] == 20
+
+    def test_individual_keyword_errors_dont_break_the_batch(self) -> None:
+        """If `_fetch_keyword_items` returns [] for one keyword (its own
+        try/except caught the error), the others still produce trends."""
+        keywords_table = MagicMock()
+        keywords_table.scan.return_value = {
+            'Items': [{'keyword': f'kw{i}'} for i in range(3)]
+        }
+        fake_resource = MagicMock()
+        fake_resource.Table.return_value = keywords_table
+
+        def mixed_fetch(keyword: str) -> list[dict]:
+            if keyword == 'kw1':
+                return []  # Simulate the error-caught case
+            return self._fake_keyword_items(keyword)
+
+        with patch.object(_mod, 'dynamodb', fake_resource), \
+             patch.dict(os.environ, {'DYNAMODB_TABLE_KEYWORDS': 'test-keywords'}), \
+             patch.object(_mod, '_fetch_keyword_items', side_effect=mixed_fetch):
+            result = _mod.get_all_keywords_trends({}, 'day', 30)
+
+        # 2 succeeded (kw0, kw2), 1 returned error payload (kw1) and was
+        # filtered out. The dashboard reports the 2 successful.
+        assert result['keywords_analyzed'] == 2

--- a/lambda/shared/dynamodb_batch.py
+++ b/lambda/shared/dynamodb_batch.py
@@ -1,0 +1,110 @@
+"""
+DynamoDB parallel-query helpers.
+
+Several handlers need the latest-by-sort-key row for each of N primary
+keys — a pattern DynamoDB's `BatchGetItem` can't express because it
+requires the exact composite key, not "latest per partition". The
+alternative is N concurrent `Query` calls with a bounded thread pool.
+
+This module centralizes that pattern so callers don't spawn their own
+executors (audit item 16).
+
+Usage:
+
+    from shared.dynamodb_batch import query_latest_per_key
+
+    results = query_latest_per_key(
+        table=my_table,
+        partition_key_name='normalized_url',
+        partition_values=list_of_urls,
+        max_workers=10,
+    )
+    # results: dict[str, dict | None] — maps each partition value to the
+    # latest item (or None if no rows).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+from boto3.dynamodb.conditions import Key
+
+logger = logging.getLogger(__name__)
+
+# Default concurrency. Keep well under DynamoDB's per-partition limits
+# (3000 read units, 1000 write units at 1 RCU each for strongly-consistent
+# reads). 10 workers x O(1 query per worker) is safe for any table.
+_DEFAULT_MAX_WORKERS = 10
+
+
+def query_latest_per_key(
+    table: Any,
+    partition_key_name: str,
+    partition_values: Iterable[str],
+    *,
+    max_workers: int = _DEFAULT_MAX_WORKERS,
+    limit: int = 1,
+) -> dict[str, dict | None]:
+    """Fetch the latest item for each partition-key value in parallel.
+
+    ``DynamoDB.Table.query`` with ``ScanIndexForward=False`` returns items
+    in descending sort-key order; paired with ``Limit=1`` it gives the
+    latest row for that partition. Calls fan out through a thread pool so
+    wall-clock time stays ~constant regardless of the number of keys
+    (up to the executor's max workers).
+
+    Args:
+        table: boto3 DynamoDB Table resource.
+        partition_key_name: Name of the table's partition key attribute.
+        partition_values: Iterable of values to query. Duplicates are
+            collapsed; order is preserved. Falsy values (``None``,
+            ``""``) are dropped before the fan-out — callers that
+            want them surfaced as errors should filter upstream.
+        max_workers: Upper bound on concurrent queries. Default 10.
+        limit: Items to return per partition (kept as ``limit`` to keep the
+            door open for top-N variants later; keep at 1 for the
+            "latest row" semantics).
+
+    Returns:
+        Dict mapping each partition value to the latest item found, or
+        None if the partition had no rows / the query raised. Errors are
+        logged, not raised — a single bad partition must not fail the
+        whole request.
+    """
+    # Preserve order, drop duplicates.
+    seen: set[str] = set()
+    ordered_values: list[str] = []
+    for v in partition_values:
+        if v and v not in seen:
+            seen.add(v)
+            ordered_values.append(v)
+
+    if not ordered_values:
+        return {}
+
+    def _query_one(value: str) -> tuple[str, dict | None]:
+        try:
+            response = table.query(
+                KeyConditionExpression=Key(partition_key_name).eq(value),
+                Limit=limit,
+                ScanIndexForward=False,
+            )
+            items = response.get('Items', [])
+            return value, (items[0] if items else None)
+        except Exception as e:
+            logger.error(
+                "query_latest_per_key failed for %s=%r: %s",
+                partition_key_name, value, e,
+            )
+            return value, None
+
+    workers = min(max_workers, len(ordered_values))
+    results: dict[str, dict | None] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        for value, item in pool.map(_query_one, ordered_values):
+            results[value] = item
+
+    return results

--- a/lambda/shared/test_dynamodb_batch.py
+++ b/lambda/shared/test_dynamodb_batch.py
@@ -1,0 +1,97 @@
+"""
+Tests for shared.dynamodb_batch.query_latest_per_key.
+
+Covers the semantics the handler callers depend on:
+- Duplicates in partition_values are collapsed
+- Empty input short-circuits
+- Failed queries produce None for that key, not a raised exception
+- The query is built with ScanIndexForward=False and Limit=1 (latest row)
+- Results preserve input order
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import dynamodb_batch  # type: ignore[import-not-found]
+
+
+def _fake_table_with_items(per_key_items: dict[str, list[dict]]) -> MagicMock:
+    """Build a MagicMock table whose `.query` returns items matching the
+    partition-key value embedded in the KeyConditionExpression.
+
+    boto3's ``Key('pk').eq('u1')`` returns an Equals condition whose
+    public ``get_expression()`` method surfaces the operands — we pull
+    the right-hand value out to look up items. This mirrors the internal
+    structure just enough for the tests without instantiating real
+    DynamoDB.
+    """
+    table = MagicMock()
+
+    def _side_effect(**kwargs):
+        cond = kwargs['KeyConditionExpression']
+        expression = cond.get_expression()
+        # expression is {'format': '{0} {operator} {1}', 'operator': '=',
+        #                'values': [Attr, literal]}
+        values = expression.get('values', [])
+        value = values[1] if len(values) > 1 else None
+        items = per_key_items.get(value, [])
+        return {'Items': items}
+
+    table.query.side_effect = _side_effect
+    return table
+
+
+class TestQueryLatestPerKey:
+    def test_returns_empty_dict_for_empty_input(self) -> None:
+        table = MagicMock()
+        assert dynamodb_batch.query_latest_per_key(table, 'pk', []) == {}
+        # No queries fired when input is empty.
+        table.query.assert_not_called()
+
+    def test_returns_empty_dict_for_falsy_values(self) -> None:
+        table = MagicMock()
+        assert dynamodb_batch.query_latest_per_key(table, 'pk', ['', None]) == {}
+        table.query.assert_not_called()
+
+    def test_collapses_duplicate_partition_values(self) -> None:
+        """A caller may pass the same URL twice — we should query once."""
+        table = _fake_table_with_items({'u1': [{'crawled_at': '2026-01-01'}]})
+        dynamodb_batch.query_latest_per_key(table, 'pk', ['u1', 'u1', 'u1'])
+        assert table.query.call_count == 1
+
+    def test_returns_none_when_query_raises(self) -> None:
+        """A single partition's failure must not break the whole batch."""
+        table = MagicMock()
+        table.query.side_effect = Exception('throttled')
+        result = dynamodb_batch.query_latest_per_key(table, 'pk', ['u1'])
+        assert result == {'u1': None}
+
+    def test_query_uses_scan_index_forward_false_for_latest_first(self) -> None:
+        """Contract: latest sort-key row must be returned first."""
+        table = _fake_table_with_items({'u1': [{'x': 1}]})
+        dynamodb_batch.query_latest_per_key(table, 'pk', ['u1'])
+        _, kwargs = table.query.call_args
+        assert kwargs['ScanIndexForward'] is False
+        assert kwargs['Limit'] == 1
+
+    def test_returns_none_when_partition_has_no_rows(self) -> None:
+        table = _fake_table_with_items({'u1': []})
+        result = dynamodb_batch.query_latest_per_key(table, 'pk', ['u1'])
+        assert result == {'u1': None}
+
+    def test_fetches_all_unique_partition_values(self) -> None:
+        table = _fake_table_with_items({
+            'u1': [{'id': 1}],
+            'u2': [{'id': 2}],
+            'u3': [{'id': 3}],
+        })
+        result = dynamodb_batch.query_latest_per_key(table, 'pk', ['u1', 'u2', 'u3'])
+        assert set(result.keys()) == {'u1', 'u2', 'u3'}
+        assert result['u1'] == {'id': 1}
+        assert result['u2'] == {'id': 2}
+        assert result['u3'] == {'id': 3}

--- a/lambda/shared/test_providers.py
+++ b/lambda/shared/test_providers.py
@@ -21,8 +21,8 @@ from unittest.mock import MagicMock, patch
 # Load by bare name to avoid triggering shared/__init__.py's boto3 import.
 sys.path.insert(0, os.path.dirname(__file__))
 
-import providers  # type: ignore[import-not-found]  # noqa: E402
-from config import PROVIDERS  # type: ignore[import-not-found]  # noqa: E402
+import providers  # type: ignore[import-not-found]
+from config import PROVIDERS  # type: ignore[import-not-found]
 
 
 class TestGetEnabledProviderCount:


### PR DESCRIPTION
## Summary

Parallelizes two N+1 read patterns identified in the lambda audit (#16). Reduces latency on dashboard endpoints by fanning out DynamoDB reads concurrently instead of serially.

## Branches combined

- `perf/batch-dynamodb-reads` — parallelize CrawledContent lookups
- `perf/historical-trends-parallel` — parallelize historical-trends keyword fan-out

## Commits (2)

- `55e0212` perf(lambda): parallelize N+1 CrawledContent lookups (audit #16)
- `a5e90da` perf(lambda): parallelize historical-trends keyword fan-out (audit #16)

## Stacked on

PR #31 (`refactor/shared-constants-and-duplicates`). Will rebase onto `main` after #31 merges.

## Tested

- Lambda unit tests pass
- Concurrency bounded via configured thread pool size
