### PR TITLE
refactor + fixes: shared constants, industry presets, content-studio idempotency

### DIFF
--- a/lambda/api/content-studio.py
+++ b/lambda/api/content-studio.py
@@ -11,6 +11,7 @@ Endpoints:
 - DELETE /content-studio/{id} - Delete generated content
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ from typing import Any
 
 import boto3
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 
 # Add shared module to path
 sys.path.insert(0, '/opt/python')
@@ -759,10 +761,63 @@ def parse_generated_content(text: str) -> dict[str, Any]:
     return result
 
 
-def create_pending_content(idea: dict[str, Any]) -> dict[str, Any]:
-    """Create a pending content record for async generation."""
+def _compute_idempotency_key(idea: dict[str, Any], window_minutes: int = 5) -> str:
+    """Compute a deterministic idempotency key for a generation request.
+
+    Same idea payload submitted within the same `window_minutes` bucket
+    produces the same key. Different windows produce different keys so a
+    user intentionally re-triggering hours later still gets a fresh run.
+
+    Bucketing to 5 minutes strikes a balance:
+    - Long enough to absorb API Gateway's default retries (which use short
+      exponential backoff, typically <1 minute apart) and accidental
+      client double-clicks.
+    - Short enough that a user who genuinely wants to regenerate doesn't
+      have to wait an inordinate time for a fresh `id`.
+
+    Inputs contributing to the hash:
+    - idea_id: uniquely identifies which idea card was clicked
+    - keyword: the business keyword (different keywords → different results)
+    - content_angle: the variant (comprehensive_guide vs reputation_management
+      etc.) — same idea + different angle legitimately needs a fresh id
+    - output_language: same rationale (different language → different output)
+    - Rounded timestamp bucket
+
+    Returns a 32-char hex string used as the DynamoDB primary key.
+    """
+    window_seconds = window_minutes * 60
+    now_ts = utc_now().timestamp()
+    bucket = int(now_ts // window_seconds)
+
+    payload = "|".join([
+        str(idea.get("id", "")),
+        str(idea.get("keyword", "")),
+        str(idea.get("content_angle", "")),
+        str(idea.get("output_language", "English")),
+        str(bucket),
+    ])
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return digest[:32]
+
+
+def create_pending_content(idea: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Create a pending content record for async generation.
+
+    Idempotent via a deterministic primary key derived from the idea payload
+    plus a short time bucket (see `_compute_idempotency_key`). API Gateway
+    retries and accidental client double-clicks within the window resolve
+    to the same row instead of spawning duplicate generations (audit #23).
+
+    Returns:
+        Tuple of ``(item, created)`` where ``created`` is True when this
+        call wrote a fresh row and False when an existing row already
+        satisfied the idempotency key. Callers use ``created`` to decide
+        whether to kick off the async generation — retries must NOT
+        re-invoke, otherwise the "fix" still leaves duplicate generations
+        running.
+    """
     table = dynamodb.Table(CONTENT_STUDIO_TABLE)
-    content_id = str(uuid.uuid4())
+    content_id = _compute_idempotency_key(idea)
     timestamp = get_timestamp()
 
     item = {
@@ -783,8 +838,33 @@ def create_pending_content(idea: dict[str, Any]) -> dict[str, Any]:
         'updated_at': timestamp
     }
 
-    table.put_item(Item=item)
-    return item
+    try:
+        # Conditional write — only create if this idempotency key is new.
+        table.put_item(
+            Item=item,
+            ConditionExpression='attribute_not_exists(id)',
+        )
+        return item, True
+    except ClientError as e:
+        if e.response.get('Error', {}).get('Code') != 'ConditionalCheckFailedException':
+            raise
+        # A row already exists for this key. This is the retry/duplicate
+        # case — return the existing row so the caller hands the user the
+        # same content_id and skips the second async generation.
+        logger.info(
+            f"Idempotent hit for content_id={content_id}; "
+            "returning existing record instead of creating duplicate"
+        )
+        existing = table.get_item(Key={'id': content_id}).get('Item')
+        if existing is None:
+            # Extremely unlikely: someone deleted the row between put and get.
+            # Safer to re-raise so the client sees the error rather than
+            # silently producing a surprise new UUID.
+            raise RuntimeError(
+                f"Idempotent conflict on content_id={content_id} but item "
+                "disappeared on read"
+            )
+        return existing, False
 
 
 def update_content_status(content_id: str, status: str, generation_result: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -955,9 +1035,27 @@ def _generate_content(event: dict[str, Any], context: Any, body: dict, idea: dic
     if len(idea.get('keyword', '')) > 500:
         return validation_error('Keyword too long (max 500 characters)', event, 'keyword')
 
-    # Create pending record immediately
-    pending_content = create_pending_content(idea)
+    # Create pending record immediately. If an idempotency-key hit occurs
+    # (API Gateway retry or client double-click within the window), `created`
+    # is False and we must skip the async invocation — otherwise the
+    # generation still runs twice, defeating the idempotency fix.
+    pending_content, created = create_pending_content(idea)
     content_id = pending_content['id']
+
+    if not created:
+        existing_status = pending_content.get('status', 'pending')
+        logger.info(
+            f"Returning existing content_id={content_id} "
+            f"(status={existing_status}) without re-invoking generation"
+        )
+        return success_response({
+            'success': True,
+            'id': content_id,
+            'status': existing_status,
+            'message': 'Content generation already in progress. Poll /status/{id} for updates.',
+            'keyword': idea.get('keyword'),
+            'idempotent_hit': True,
+        }, event)
 
     # Get the current function name for async invocation
     function_name = os.environ.get('AWS_LAMBDA_FUNCTION_NAME', '')

--- a/lambda/api/get-historical-trends.py
+++ b/lambda/api/get-historical-trends.py
@@ -28,6 +28,17 @@ from decimal_utils import to_int
 sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response
+from shared.constants import (
+    TREND_DIRECTION_DECLINING_SLOPE,
+    TREND_DIRECTION_IMPROVING_SLOPE,
+    UNRANKED_SENTINEL,
+    VISIBILITY_MENTION_LOG_BASE,
+    VISIBILITY_MENTION_WEIGHT,
+    VISIBILITY_PROVIDER_WEIGHT,
+    VISIBILITY_RANK_CAP,
+    VISIBILITY_RANK_INVERSE_BASE,
+    VISIBILITY_RANK_WEIGHT,
+)
 from shared.decorators import api_handler, validate
 from shared.providers import get_enabled_provider_count
 from shared.utils import brand_names_match, get_brand_config, utc_now
@@ -48,18 +59,37 @@ KEYWORDS_TABLE = os.environ.get('DYNAMODB_TABLE_KEYWORDS')  # Optional for fallb
 
 
 def calculate_visibility_score(provider_count: int, total_mentions: int, best_rank: int, total_providers: int | None = None) -> float:
-    """Calculate visibility score (0-100)."""
+    """Calculate visibility score (0-100).
+
+    This variant is sentiment-agnostic (historical-trends doesn't carry
+    per-period sentiment aggregation); the sentiment weight is folded
+    into the other three weights proportionally:
+        provider: 40, rank: 30, mentions: 20, total = 90 (out of 100).
+    See `get-visibility-metrics.py::calculate_visibility_score` for the
+    full 4-factor version. Constants are shared in `shared.constants`.
+    """
     import math
     if total_providers is None:
         total_providers = get_enabled_provider_count()
-    provider_score = (provider_count / total_providers) * 40 if total_providers > 0 else 0
-    rank_score = max(0, (11 - min(best_rank, 10)) / 10) * 30
-    mention_score = min(math.log(total_mentions + 1) / math.log(51), 1) * 20
+    provider_score = (
+        (provider_count / total_providers) * VISIBILITY_PROVIDER_WEIGHT
+        if total_providers > 0 else 0
+    )
+    capped_rank = min(best_rank, VISIBILITY_RANK_CAP)
+    rank_score = max(0, (VISIBILITY_RANK_INVERSE_BASE - capped_rank) / VISIBILITY_RANK_CAP) * VISIBILITY_RANK_WEIGHT
+    mention_score = (
+        min(math.log(total_mentions + 1) / math.log(VISIBILITY_MENTION_LOG_BASE), 1)
+        * VISIBILITY_MENTION_WEIGHT
+    )
     return round(provider_score + rank_score + mention_score, 1)
 
 
 def get_trend_direction(values: list[float]) -> str:
-    """Determine trend direction from a series of values."""
+    """Determine trend direction from a series of values.
+
+    Slope thresholds are tuned for the 0-100 visibility range. See
+    `shared.constants.TREND_DIRECTION_{IMPROVING,DECLINING}_SLOPE`.
+    """
     if len(values) < 2:
         return 'stable'
 
@@ -76,10 +106,9 @@ def get_trend_direction(values: list[float]) -> str:
 
     slope = numerator / denominator
 
-    # Determine direction based on slope magnitude
-    if slope > 2:
+    if slope > TREND_DIRECTION_IMPROVING_SLOPE:
         return 'improving'
-    elif slope < -2:
+    elif slope < TREND_DIRECTION_DECLINING_SLOPE:
         return 'declining'
     return 'stable'
 
@@ -131,7 +160,7 @@ def aggregate_by_period(items: list[dict], period: str, config: dict) -> list[di
         # Aggregate first-party brand metrics
         fp_mentions = 0
         fp_providers = set()
-        fp_best_rank = 999
+        fp_best_rank = UNRANKED_SENTINEL
         total_searches = len(timestamps)
 
         for item in items_in_period:
@@ -150,7 +179,7 @@ def aggregate_by_period(items: list[dict], period: str, config: dict) -> list[di
                 if is_first_party:
                     fp_mentions += to_int(brand.get('mention_count'), 1)
                     fp_providers.add(provider)
-                    fp_best_rank = min(fp_best_rank, to_int(brand.get('rank'), 999))
+                    fp_best_rank = min(fp_best_rank, to_int(brand.get('rank'), UNRANKED_SENTINEL))
 
         visibility_score = calculate_visibility_score(
             len(fp_providers), fp_mentions, fp_best_rank
@@ -161,7 +190,7 @@ def aggregate_by_period(items: list[dict], period: str, config: dict) -> list[di
             'visibility_score': visibility_score,
             'total_mentions': fp_mentions,
             'provider_count': len(fp_providers),
-            'best_rank': fp_best_rank if fp_best_rank < 999 else None,
+            'best_rank': fp_best_rank if fp_best_rank < UNRANKED_SENTINEL else None,
             'analysis_runs': total_searches
         })
 

--- a/lambda/api/get-visibility-metrics.py
+++ b/lambda/api/get-visibility-metrics.py
@@ -26,6 +26,16 @@ from shared.decorators import api_handler, validate, require_keyword
 from shared.api_response import success_response
 from shared.utils import get_brand_config
 from shared.config import PROVIDERS
+from shared.constants import (
+    UNRANKED_SENTINEL,
+    VISIBILITY_MENTION_LOG_BASE,
+    VISIBILITY_MENTION_WEIGHT,
+    VISIBILITY_PROVIDER_WEIGHT,
+    VISIBILITY_RANK_CAP,
+    VISIBILITY_RANK_INVERSE_BASE,
+    VISIBILITY_RANK_WEIGHT,
+    VISIBILITY_SENTIMENT_WEIGHT,
+)
 from shared.providers import get_enabled_provider_count
 from decimal_utils import to_int
 
@@ -47,25 +57,31 @@ def calculate_visibility_score(
 ) -> float:
     """
     Calculate visibility score (0-100) based on multiple factors.
-    
-    Factors:
-    - Provider coverage (40%): How many AI engines mention the brand
-    - Ranking position (30%): Best rank across providers (1=best)
-    - Mention frequency (20%): Total number of mentions
-    - Sentiment (10%): Average sentiment score
+    Factors (weights sum to 100; see shared.constants for the source of truth):
+    - Provider coverage: VISIBILITY_PROVIDER_WEIGHT
+    - Ranking position: VISIBILITY_RANK_WEIGHT
+    - Mention frequency: VISIBILITY_MENTION_WEIGHT
+    - Sentiment: VISIBILITY_SENTIMENT_WEIGHT
     """
-    # Provider coverage score (0-40)
-    provider_score = (provider_count / total_providers) * 40 if total_providers > 0 else 0
-    
-    # Ranking score (0-30) - inverse of rank, capped at rank 10
-    rank_score = max(0, (11 - min(best_rank, 10)) / 10) * 30
-    
-    # Mention score (0-20) - logarithmic scale, capped at 50 mentions
-    mention_score = min(math.log(total_mentions + 1) / math.log(51), 1) * 20
-    
-    # Sentiment score (0-10) - convert -1 to 1 scale to 0-10
-    sentiment_score = ((avg_sentiment_score + 1) / 2) * 10
-    
+    # Provider coverage score
+    provider_score = (
+        (provider_count / total_providers) * VISIBILITY_PROVIDER_WEIGHT
+        if total_providers > 0 else 0
+    )
+
+    # Ranking score — inverse of rank, capped at VISIBILITY_RANK_CAP
+    capped_rank = min(best_rank, VISIBILITY_RANK_CAP)
+    rank_score = max(0, (VISIBILITY_RANK_INVERSE_BASE - capped_rank) / VISIBILITY_RANK_CAP) * VISIBILITY_RANK_WEIGHT
+
+    # Mention score — logarithmic saturation at VISIBILITY_MENTION_SATURATION_COUNT mentions
+    mention_score = (
+        min(math.log(total_mentions + 1) / math.log(VISIBILITY_MENTION_LOG_BASE), 1)
+        * VISIBILITY_MENTION_WEIGHT
+    )
+
+    # Sentiment score — convert -1..1 scale to 0..VISIBILITY_SENTIMENT_WEIGHT
+    sentiment_score = ((avg_sentiment_score + 1) / 2) * VISIBILITY_SENTIMENT_WEIGHT
+
     return round(provider_score + rank_score + mention_score + sentiment_score, 1)
 
 
@@ -145,7 +161,7 @@ def get_visibility_metrics(keyword: str, config: Dict[str, Any], query_prompt_id
             brand_data[name]['providers'].add(provider)
             mention_count = to_int(brand.get('mention_count'), 1)
             brand_data[name]['mentions'] += mention_count
-            brand_data[name]['ranks'].append(to_int(brand.get('rank'), 999))
+            brand_data[name]['ranks'].append(to_int(brand.get('rank'), UNRANKED_SENTINEL))
             if brand.get('sentiment'):
                 brand_data[name]['sentiments'].append(sentiment_to_score(brand.get('sentiment')))
             
@@ -158,7 +174,7 @@ def get_visibility_metrics(keyword: str, config: Dict[str, Any], query_prompt_id
     brand_metrics = []
     for name, data in brand_data.items():
         provider_count = len(data['providers'])
-        best_rank = min(data['ranks']) if data['ranks'] else 999
+        best_rank = min(data['ranks']) if data['ranks'] else UNRANKED_SENTINEL
         avg_sentiment = sum(data['sentiments']) / len(data['sentiments']) if data['sentiments'] else 0.0
         
         # Ensure all values are native Python types

--- a/lambda/api/manage-brand-config.py
+++ b/lambda/api/manage-brand-config.py
@@ -19,6 +19,8 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response, validation_error
 from shared.decorators import api_handler, cors_preflight, parse_json_body, route_handler, validate
+from shared.industry_presets import INDUSTRY_PRESETS as _BASE_PRESETS
+from shared.industry_presets import get_preset as get_shared_preset
 from shared.llm_json import parse_llm_json
 from shared.prompt_safety import untrusted_input_system_instruction, wrap_user_input
 from shared.utils import get_timestamp
@@ -84,117 +86,37 @@ TEXT TO ANALYZE:
 JSON OUTPUT:"""
 
 
-# Industry presets with default prompts
-INDUSTRY_PRESETS = {
-    "hotels": {
-        "name": "Hotels & Hospitality",
-        "description": "Track hotel brands, chains, and individual properties",
-        "entity_types": ["hotel chains", "hotel brands", "individual properties", "resorts", "boutique hotels"],
-        "example_brands": ["Marriott", "Hilton", "Hyatt", "InterContinental", "Four Seasons"],
-        "extraction_focus": "hotel and accommodation recommendations",
+# Industry preset structural data is owned by shared.industry_presets. The
+# dashboard API returns the same base fields plus a derived `default_prompt`
+# computed at request time via `_preset_with_prompt`, avoiding drift between
+# this file's copy and the extraction Lambda's.
+
+
+def _preset_with_prompt(preset: dict) -> dict:
+    """Decorate a shared preset with a `default_prompt` string.
+
+    Dashboard clients consume both the structural fields and a ready-to-use
+    prompt. Computing the prompt here keeps the shared module free of
+    API-specific concerns and lets us change the prompt template without
+    touching the extraction Lambda.
+    """
+    return {
+        **preset,
         "default_prompt": generate_default_prompt(
-            "Hotels & Hospitality",
-            "hotel and accommodation recommendations",
-            ["hotel chains", "hotel brands", "individual properties", "resorts", "boutique hotels"]
-        )
-    },
-    "restaurants": {
-        "name": "Restaurants & Food Service",
-        "description": "Track restaurant chains, fast food, and dining brands",
-        "entity_types": ["restaurant chains", "fast food brands", "casual dining", "fine dining", "coffee shops"],
-        "example_brands": ["McDonald's", "Starbucks", "Chipotle", "Olive Garden", "Domino's"],
-        "extraction_focus": "restaurant and dining recommendations",
-        "default_prompt": generate_default_prompt(
-            "Restaurants & Food Service",
-            "restaurant and dining recommendations",
-            ["restaurant chains", "fast food brands", "casual dining", "fine dining", "coffee shops"]
-        )
-    },
-    "airlines": {
-        "name": "Airlines & Aviation",
-        "description": "Track airline brands and aviation companies",
-        "entity_types": ["airlines", "aviation companies", "low-cost carriers", "premium airlines"],
-        "example_brands": ["Delta", "United", "American Airlines", "Southwest", "JetBlue", "Ryanair"],
-        "extraction_focus": "airline and flight recommendations",
-        "default_prompt": generate_default_prompt(
-            "Airlines & Aviation",
-            "airline and flight recommendations",
-            ["airlines", "aviation companies", "low-cost carriers", "premium airlines"]
-        )
-    },
-    "retail": {
-        "name": "Retail & Consumer Brands",
-        "description": "Track retail stores and consumer product brands",
-        "entity_types": ["retail stores", "e-commerce brands", "consumer products", "fashion brands"],
-        "example_brands": ["Amazon", "Walmart", "Target", "Nike", "Adidas", "Apple"],
-        "extraction_focus": "product and retail recommendations",
-        "default_prompt": generate_default_prompt(
-            "Retail & Consumer Brands",
-            "product and retail recommendations",
-            ["retail stores", "e-commerce brands", "consumer products", "fashion brands"]
-        )
-    },
-    "fashion": {
-        "name": "Fashion & Apparel",
-        "description": "Track fashion brands, clothing, and footwear",
-        "entity_types": ["fashion brands", "clothing brands", "footwear brands", "luxury brands", "sportswear"],
-        "example_brands": ["Nike", "Adidas", "Zara", "H&M", "Gucci", "Louis Vuitton", "Puma"],
-        "extraction_focus": "fashion and apparel recommendations",
-        "default_prompt": generate_default_prompt(
-            "Fashion & Apparel",
-            "fashion and apparel recommendations",
-            ["fashion brands", "clothing brands", "footwear brands", "luxury brands", "sportswear"]
-        )
-    },
-    "automotive": {
-        "name": "Automotive",
-        "description": "Track car brands and automotive companies",
-        "entity_types": ["car manufacturers", "automotive brands", "EV companies", "luxury car brands"],
-        "example_brands": ["Toyota", "Ford", "Tesla", "BMW", "Mercedes-Benz", "Honda"],
-        "extraction_focus": "vehicle and automotive recommendations",
-        "default_prompt": generate_default_prompt(
-            "Automotive",
-            "vehicle and automotive recommendations",
-            ["car manufacturers", "automotive brands", "EV companies", "luxury car brands"]
-        )
-    },
-    "technology": {
-        "name": "Technology & Software",
-        "description": "Track tech companies and software brands",
-        "entity_types": ["tech companies", "software brands", "SaaS products", "hardware brands"],
-        "example_brands": ["Apple", "Google", "Microsoft", "Amazon", "Meta", "Salesforce"],
-        "extraction_focus": "technology and software recommendations",
-        "default_prompt": generate_default_prompt(
-            "Technology & Software",
-            "technology and software recommendations",
-            ["tech companies", "software brands", "SaaS products", "hardware brands"]
-        )
-    },
-    "finance": {
-        "name": "Finance & Banking",
-        "description": "Track banks, financial services, and fintech",
-        "entity_types": ["banks", "credit card companies", "fintech", "insurance companies", "investment firms"],
-        "example_brands": ["Chase", "Bank of America", "PayPal", "Visa", "Mastercard", "Goldman Sachs"],
-        "extraction_focus": "financial service recommendations",
-        "default_prompt": generate_default_prompt(
-            "Finance & Banking",
-            "financial service recommendations",
-            ["banks", "credit card companies", "fintech", "insurance companies", "investment firms"]
-        )
-    },
-    "custom": {
-        "name": "Custom Industry",
-        "description": "Define your own industry and brand types",
-        "entity_types": [],
-        "example_brands": [],
-        "extraction_focus": "brand and company recommendations",
-        "default_prompt": generate_default_prompt(
-            "Custom Industry",
-            "brand and company recommendations",
-            ["brand names", "company names"]
-        )
+            preset["name"],
+            preset["extraction_focus"],
+            preset.get("entity_types", []),
+        ),
     }
-}
+
+
+def get_preset_with_prompt(industry_id: str) -> dict:
+    """Look up an industry preset and decorate it with its default prompt.
+
+    Uses `shared.industry_presets.get_preset` for the base lookup (which
+    falls back to ``custom`` on unknown ids).
+    """
+    return _preset_with_prompt(get_shared_preset(industry_id))
 
 
 def normalize_brand(name: str) -> str:
@@ -242,7 +164,7 @@ def expand_brands(existing_brands: list, industry: str = "hotels", brand_type: s
             "error": "Please add at least one brand first"
         }
 
-    industry_preset = INDUSTRY_PRESETS.get(industry, INDUSTRY_PRESETS.get("custom", {}))
+    industry_preset = get_shared_preset(industry)
     industry_name = industry_preset.get("name", "General")
     entity_types = industry_preset.get("entity_types", ["brands", "companies"])
 
@@ -353,7 +275,7 @@ def expand_brand(brand_name: str, industry: str = "hotels", existing_brands: lis
     if existing_brands is None:
         existing_brands = []
 
-    industry_preset = INDUSTRY_PRESETS.get(industry, INDUSTRY_PRESETS.get("custom", {}))
+    industry_preset = get_shared_preset(industry)
     industry_name = industry_preset.get("name", "General")
     entity_types = industry_preset.get("entity_types", ["brands", "companies"])
     example_brands = industry_preset.get("example_brands", [])
@@ -452,7 +374,7 @@ def find_competitors(first_party_brands: list, industry: str = "hotels", existin
     if existing_competitors is None:
         existing_competitors = []
 
-    industry_preset = INDUSTRY_PRESETS.get(industry, INDUSTRY_PRESETS.get("custom", {}))
+    industry_preset = get_shared_preset(industry)
     industry_name = industry_preset.get("name", "General")
     entity_types = industry_preset.get("entity_types", ["brands", "companies"])
     example_brands = industry_preset.get("example_brands", [])
@@ -564,8 +486,13 @@ def save_config(config: dict[str, Any]) -> dict[str, Any]:
 # --- Route Handlers ---
 
 def _get_presets(event: dict[str, Any], context: Any) -> dict[str, Any]:
-    """GET /brand-config/presets - Return industry presets."""
-    return success_response({'presets': INDUSTRY_PRESETS}, event)
+    """GET /brand-config/presets - Return industry presets decorated
+    with derived default prompts for the dashboard."""
+    presets_with_prompts = {
+        industry_id: _preset_with_prompt(preset)
+        for industry_id, preset in _BASE_PRESETS.items()
+    }
+    return success_response({'presets': presets_with_prompts}, event)
 
 
 @parse_json_body
@@ -644,9 +571,9 @@ def _get_config(event: dict[str, Any], context: Any) -> dict[str, Any]:
 def _save_config(event: dict[str, Any], context: Any, body: dict, industry: str) -> dict[str, Any]:
     """POST/PUT /brand-config - Create or update configuration."""
     # Validate industry
-    if industry not in INDUSTRY_PRESETS:
+    if industry not in _BASE_PRESETS:
         return validation_error(
-            f"Invalid industry. Must be one of: {', '.join(INDUSTRY_PRESETS.keys())}",
+            f"Invalid industry. Must be one of: {', '.join(_BASE_PRESETS.keys())}",
             event,
             'industry'
         )

--- a/lambda/api/manage-query-prompts.py
+++ b/lambda/api/manage-query-prompts.py
@@ -16,6 +16,7 @@ import boto3
 sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response, validation_error
+from shared.constants import MAX_QUERY_PROMPTS_DEFAULT
 from shared.decorators import api_handler, parse_json_body, validate
 from shared.utils import get_timestamp
 
@@ -28,7 +29,11 @@ dynamodb = boto3.resource('dynamodb')
 QUERY_PROMPTS_TABLE = os.environ['QUERY_PROMPTS_TABLE']
 query_prompts_table = dynamodb.Table(QUERY_PROMPTS_TABLE)
 
-MAX_PROMPTS = 10
+# Soft business cap — bounded per-user prompts. Override with
+# `MAX_QUERY_PROMPTS` env var at deploy time. Must be <= the scan Limit in
+# `list_prompts` below; bumping this without also raising the scan limit
+# would silently truncate the UI.
+MAX_PROMPTS = int(os.environ.get('MAX_QUERY_PROMPTS', MAX_QUERY_PROMPTS_DEFAULT))
 
 
 @api_handler
@@ -60,7 +65,10 @@ def handler(event, context):
 
 def list_prompts(event, context):
     """GET /api/query-prompts - List all query prompts."""
-    response = query_prompts_table.scan(Limit=50)
+    # Scan with headroom over MAX_PROMPTS so tuning the cap upward doesn't
+    # silently truncate the UI. 5x buffer is arbitrary but comfortable for
+    # the business-soft-cap scale.
+    response = query_prompts_table.scan(Limit=max(50, MAX_PROMPTS * 5))
     items = response.get('Items', [])
     # Sort by created_at descending
     items.sort(key=lambda x: x.get('created_at', ''), reverse=True)

--- a/lambda/api/test_content_studio_idempotency.py
+++ b/lambda/api/test_content_studio_idempotency.py
@@ -1,0 +1,258 @@
+"""
+Regression tests for content-studio async generation idempotency (audit #23).
+
+Background — the previous implementation generated a fresh `uuid.uuid4()`
+primary key on every call to `create_pending_content`. If API Gateway
+retried a POST (default behavior on read timeouts) or a user double-clicked
+the generate button, two rows were created with two separate UUIDs and
+two separate async Lambda self-invocations fired. The client saw two
+results, and Bedrock got billed twice for the same work.
+
+The fix:
+- `_compute_idempotency_key(idea)` derives a deterministic 32-char hex
+  key from idea_id + keyword + content_angle + output_language + a
+  rounded 5-minute time bucket.
+- `create_pending_content` uses that key as the DynamoDB primary key with
+  a conditional `attribute_not_exists(id)` put. Duplicates hit the
+  condition, fall back to a `get_item`, and return `(existing, created=False)`.
+- `_generate_content` skips the async Lambda invocation when
+  `created is False` so retries don't spawn duplicate generations.
+
+These tests pin:
+- Same idea + same window → same key → same row
+- Same idea + different window → different key → new row (user-intent re-run)
+- Different idea data → different key even in same window
+- Conditional-check failure paths return the existing row
+- Caller skips async invocation on idempotent hit
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Env vars the module reads at import time.
+os.environ.setdefault('DYNAMODB_TABLE_SEARCH_RESULTS', 'test-search')
+os.environ.setdefault('DYNAMODB_TABLE_CITATIONS', 'test-citations')
+os.environ.setdefault('DYNAMODB_TABLE_CRAWLED_CONTENT', 'test-crawled')
+os.environ.setdefault('DYNAMODB_TABLE_CONTENT_STUDIO', 'test-content-studio')
+
+_HERE = os.path.dirname(__file__)
+_MODULE_PATH = os.path.join(_HERE, 'content-studio.py')
+
+_LAMBDA_DIR = os.path.dirname(_HERE)
+if _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+_spec = importlib.util.spec_from_file_location(
+    'content_studio_under_test', _MODULE_PATH
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules['content_studio_under_test'] = _mod
+_spec.loader.exec_module(_mod)
+
+
+class _FakeClientError(Exception):
+    """Minimal ClientError substitute with the .response shape the code
+    expects. Actual botocore.exceptions.ClientError is used at runtime;
+    we swap for testability so tests don't depend on the boto3 error
+    hierarchy details."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.response = {'Error': {'Code': code}}
+
+
+class TestComputeIdempotencyKey:
+    """The key must be deterministic for the same inputs + window and
+    diverge only on meaningful input changes."""
+
+    def test_same_idea_same_window_produces_same_key(self) -> None:
+        idea = {
+            'id': 'idea-1',
+            'keyword': 'luxury hotels',
+            'content_angle': 'comprehensive_guide',
+            'output_language': 'English',
+        }
+        k1 = _mod._compute_idempotency_key(idea)
+        k2 = _mod._compute_idempotency_key(idea)
+        assert k1 == k2
+
+    def test_different_keyword_produces_different_key(self) -> None:
+        base = {
+            'id': 'idea-1',
+            'content_angle': 'comprehensive_guide',
+            'output_language': 'English',
+        }
+        k1 = _mod._compute_idempotency_key({**base, 'keyword': 'luxury hotels'})
+        k2 = _mod._compute_idempotency_key({**base, 'keyword': 'budget hotels'})
+        assert k1 != k2
+
+    def test_different_content_angle_produces_different_key(self) -> None:
+        """Same idea, different angle = different generation output
+        expected, so different key."""
+        base = {
+            'id': 'idea-1',
+            'keyword': 'hotels',
+            'output_language': 'English',
+        }
+        k1 = _mod._compute_idempotency_key({**base, 'content_angle': 'comprehensive_guide'})
+        k2 = _mod._compute_idempotency_key({**base, 'content_angle': 'reputation_management'})
+        assert k1 != k2
+
+    def test_different_language_produces_different_key(self) -> None:
+        base = {
+            'id': 'idea-1',
+            'keyword': 'hotels',
+            'content_angle': 'comprehensive_guide',
+        }
+        k1 = _mod._compute_idempotency_key({**base, 'output_language': 'English'})
+        k2 = _mod._compute_idempotency_key({**base, 'output_language': 'Spanish'})
+        assert k1 != k2
+
+    def test_different_window_produces_different_key(self) -> None:
+        """A user who re-triggers generation after the window expires
+        should get a fresh key (no longer an idempotent hit)."""
+        idea = {'id': 'idea-1', 'keyword': 'hotels', 'content_angle': 'comprehensive_guide'}
+        # Tiny 0.001-minute window so consecutive calls fall in different buckets.
+        # This works because _compute_idempotency_key uses int(timestamp // window_seconds)
+        # and we can simulate window rollover by patching utc_now across calls.
+        real_utc_now = _mod.utc_now
+        from datetime import UTC, datetime
+        fixed_early = datetime(2026, 4, 18, 12, 0, 0, tzinfo=UTC)
+        fixed_later = datetime(2026, 4, 18, 12, 10, 0, tzinfo=UTC)
+
+        with patch.object(_mod, 'utc_now', return_value=fixed_early):
+            k1 = _mod._compute_idempotency_key(idea)
+        with patch.object(_mod, 'utc_now', return_value=fixed_later):
+            k2 = _mod._compute_idempotency_key(idea)
+
+        assert k1 != k2
+        # Sanity: our patch didn't accidentally break utc_now globally.
+        assert _mod.utc_now is real_utc_now
+
+    def test_returns_thirty_two_char_hex(self) -> None:
+        """DynamoDB keys must be predictable length. 32 hex chars = 128 bits
+        of collision resistance, plenty for this use case."""
+        idea = {'id': 'idea-1', 'keyword': 'kw', 'content_angle': 'ca'}
+        key = _mod._compute_idempotency_key(idea)
+        assert len(key) == 32
+        assert all(c in '0123456789abcdef' for c in key)
+
+
+class TestCreatePendingContent:
+    """The conditional write + get_item fallback behaviour."""
+
+    def _fake_table(self, put_raises: Exception | None = None,
+                    get_item_return: dict | None = None) -> MagicMock:
+        table = MagicMock()
+        if put_raises is not None:
+            table.put_item.side_effect = put_raises
+        table.get_item.return_value = {'Item': get_item_return} if get_item_return else {}
+        return table
+
+    def _patched_resource(self, table: MagicMock) -> MagicMock:
+        resource = MagicMock()
+        resource.Table.return_value = table
+        return resource
+
+    def test_writes_new_row_with_deterministic_key_on_fresh_call(self) -> None:
+        table = self._fake_table()
+        resource = self._patched_resource(table)
+        idea = {'id': 'idea-1', 'keyword': 'hotels', 'content_angle': 'comprehensive_guide'}
+
+        with patch.object(_mod, 'dynamodb', resource):
+            item, created = _mod.create_pending_content(idea)
+
+        assert created is True
+        # The row's primary key must equal the idempotency key.
+        assert item['id'] == _mod._compute_idempotency_key(idea)
+
+    def test_uses_conditional_expression_attribute_not_exists(self) -> None:
+        """Regression guard: someone removing the ConditionExpression would
+        re-introduce the duplicate-write bug."""
+        table = self._fake_table()
+        resource = self._patched_resource(table)
+
+        with patch.object(_mod, 'dynamodb', resource):
+            _mod.create_pending_content({'id': 'x', 'keyword': 'kw', 'content_angle': 'a'})
+
+        put_kwargs = table.put_item.call_args.kwargs
+        assert put_kwargs['ConditionExpression'] == 'attribute_not_exists(id)'
+
+    def test_returns_existing_row_on_conditional_check_failure(self) -> None:
+        """The core idempotency behavior — duplicate requests return the
+        existing record with created=False."""
+        existing_row = {
+            'id': 'some-key',
+            'status': 'generating',
+            'keyword': 'hotels',
+            'idea_id': 'idea-1',
+        }
+        error = _FakeClientError('ConditionalCheckFailedException')
+        table = self._fake_table(put_raises=error, get_item_return=existing_row)
+        resource = self._patched_resource(table)
+
+        # Point the module's ClientError at our fake so the except catches it.
+        with patch.object(_mod, 'dynamodb', resource), \
+             patch.object(_mod, 'ClientError', _FakeClientError):
+            item, created = _mod.create_pending_content({
+                'id': 'idea-1', 'keyword': 'hotels', 'content_angle': 'a',
+            })
+
+        assert created is False
+        assert item == existing_row
+
+    def test_reraises_non_conditional_client_errors(self) -> None:
+        """Only ConditionalCheckFailedException is the idempotent-hit case.
+        Other DynamoDB errors must propagate."""
+        error = _FakeClientError('ProvisionedThroughputExceededException')
+        table = self._fake_table(put_raises=error)
+        resource = self._patched_resource(table)
+
+        with patch.object(_mod, 'dynamodb', resource), \
+             patch.object(_mod, 'ClientError', _FakeClientError):
+            try:
+                _mod.create_pending_content({'id': 'x', 'keyword': 'kw', 'content_angle': 'a'})
+            except _FakeClientError:
+                # Expected: non-conditional error propagates.
+                pass
+            else:
+                raise AssertionError('Expected _FakeClientError to propagate')
+
+    def test_raises_runtime_error_when_existing_item_disappears(self) -> None:
+        """Very unlikely race: row existed when put failed, gone when we read
+        back. Better to surface the race than silently continue with a
+        fabricated record."""
+        error = _FakeClientError('ConditionalCheckFailedException')
+        table = self._fake_table(put_raises=error, get_item_return=None)
+        resource = self._patched_resource(table)
+
+        with patch.object(_mod, 'dynamodb', resource), \
+             patch.object(_mod, 'ClientError', _FakeClientError):
+            try:
+                _mod.create_pending_content({'id': 'x', 'keyword': 'kw', 'content_angle': 'a'})
+            except RuntimeError as e:
+                assert 'disappeared' in str(e).lower()
+            else:
+                raise AssertionError('Expected RuntimeError on missing row')
+
+    def test_returned_tuple_order_is_item_then_created_flag(self) -> None:
+        """Regression guard: callers unpack `item, created = ...`. Reversing
+        the order would silently break every caller."""
+        table = self._fake_table()
+        resource = self._patched_resource(table)
+
+        with patch.object(_mod, 'dynamodb', resource):
+            result = _mod.create_pending_content({
+                'id': 'x', 'keyword': 'kw', 'content_angle': 'a',
+            })
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], dict)
+        assert isinstance(result[1], bool)

--- a/lambda/deduplication/handler.py
+++ b/lambda/deduplication/handler.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import boto3
 
+from shared.constants import MAX_CITATIONS_PER_KEYWORD_DEFAULT
 from shared.step_function_response import log_error, step_function_success
 
 # Import shared utilities
@@ -26,6 +27,13 @@ dynamodb = boto3.resource('dynamodb')
 # Fail-fast: Required environment variables
 CITATIONS_TABLE_NAME = os.environ['CITATIONS_TABLE_NAME']
 citations_table = dynamodb.Table(CITATIONS_TABLE_NAME)
+
+# Runtime override for the citations-per-keyword cap. Defaults to the shared
+# constant; setting `MAX_CITATIONS_PER_KEYWORD` in the Lambda environment lets
+# operators tune the cap without redeploying code.
+MAX_CITATIONS_PER_KEYWORD = int(
+    os.environ.get('MAX_CITATIONS_PER_KEYWORD', MAX_CITATIONS_PER_KEYWORD_DEFAULT)
+)
 
 
 def deduplicate_citations(results: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -73,17 +81,23 @@ def deduplicate_citations(results: list[dict[str, Any]]) -> dict[str, dict[str, 
     return deduplicated
 
 
-def prioritize_citations(deduplicated: dict[str, dict[str, Any]], max_citations: int = 20) -> list[dict[str, Any]]:
+def prioritize_citations(
+    deduplicated: dict[str, dict[str, Any]],
+    max_citations: int | None = None,
+) -> list[dict[str, Any]]:
     """
     Prioritize citations by citation count and limit to top N.
 
     Args:
         deduplicated: Dictionary of deduplicated citations
-        max_citations: Maximum number of citations to return
-
-    Returns:
-        List of prioritized citations with priority numbers
+        max_citations: Maximum number of citations to return. Defaults to
+            the module-level ``MAX_CITATIONS_PER_KEYWORD`` (overridable via
+            env var). Pass an explicit value for per-call overrides in
+            tests or migration scripts.
     """
+    if max_citations is None:
+        max_citations = MAX_CITATIONS_PER_KEYWORD
+
     # Convert to list and sort by citation count (descending)
     citations_list = []
     for normalized_url, metadata in deduplicated.items():
@@ -194,8 +208,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         # Step 1: Deduplicate citations across all providers
         deduplicated = deduplicate_citations(results)
 
-        # Step 2: Prioritize citations by citation count
-        prioritized = prioritize_citations(deduplicated, max_citations=20)
+        # Step 2: Prioritize citations by citation count (top N from shared config)
+        prioritized = prioritize_citations(deduplicated)
 
         # Step 3: Store citations in DynamoDB
         store_citations(keyword, prioritized)

--- a/lambda/search/brand_extractor.py
+++ b/lambda/search/brand_extractor.py
@@ -12,6 +12,7 @@ not exact string matching. This allows the LLM to understand brand hierarchies
 import logging
 from typing import Any
 
+from shared.industry_presets import INDUSTRY_PRESETS, get_preset
 from shared.llm_json import parse_llm_json
 from shared.models import ModelRole, invoke_bedrock
 from shared.prompt_safety import (
@@ -24,72 +25,8 @@ from shared.utils import get_brand_config
 
 logger = logging.getLogger(__name__)
 
-# Industry presets with pre-built extraction prompts
-INDUSTRY_PRESETS = {
-    "hotels": {
-        "name": "Hotels & Hospitality",
-        "description": "Track hotel brands, chains, and individual properties",
-        "entity_types": ["hotel chains", "hotel brands", "individual properties", "resorts", "boutique hotels"],
-        "example_brands": ["Marriott", "Hilton", "Hyatt", "InterContinental", "Four Seasons"],
-        "extraction_focus": "hotel and accommodation recommendations"
-    },
-    "restaurants": {
-        "name": "Restaurants & Food Service",
-        "description": "Track restaurant chains, fast food, and dining brands",
-        "entity_types": ["restaurant chains", "fast food brands", "casual dining", "fine dining", "coffee shops"],
-        "example_brands": ["McDonald's", "Starbucks", "Chipotle", "Olive Garden", "Domino's"],
-        "extraction_focus": "restaurant and dining recommendations"
-    },
-    "airlines": {
-        "name": "Airlines & Aviation",
-        "description": "Track airline brands and aviation companies",
-        "entity_types": ["airlines", "aviation companies", "low-cost carriers", "premium airlines"],
-        "example_brands": ["Delta", "United", "American Airlines", "Southwest", "JetBlue", "Ryanair"],
-        "extraction_focus": "airline and flight recommendations"
-    },
-    "retail": {
-        "name": "Retail & Consumer Brands",
-        "description": "Track retail stores and consumer product brands",
-        "entity_types": ["retail stores", "e-commerce brands", "consumer products", "fashion brands"],
-        "example_brands": ["Amazon", "Walmart", "Target", "Nike", "Adidas", "Apple"],
-        "extraction_focus": "product and retail recommendations"
-    },
-    "fashion": {
-        "name": "Fashion & Apparel",
-        "description": "Track fashion brands, clothing, and footwear",
-        "entity_types": ["fashion brands", "clothing brands", "footwear brands", "luxury brands", "sportswear"],
-        "example_brands": ["Nike", "Adidas", "Zara", "H&M", "Gucci", "Louis Vuitton", "Puma"],
-        "extraction_focus": "fashion and apparel recommendations"
-    },
-    "automotive": {
-        "name": "Automotive",
-        "description": "Track car brands and automotive companies",
-        "entity_types": ["car manufacturers", "automotive brands", "EV companies", "luxury car brands"],
-        "example_brands": ["Toyota", "Ford", "Tesla", "BMW", "Mercedes-Benz", "Honda"],
-        "extraction_focus": "vehicle and automotive recommendations"
-    },
-    "technology": {
-        "name": "Technology & Software",
-        "description": "Track tech companies and software brands",
-        "entity_types": ["tech companies", "software brands", "SaaS products", "hardware brands"],
-        "example_brands": ["Apple", "Google", "Microsoft", "Amazon", "Meta", "Salesforce"],
-        "extraction_focus": "technology and software recommendations"
-    },
-    "finance": {
-        "name": "Finance & Banking",
-        "description": "Track banks, financial services, and fintech",
-        "entity_types": ["banks", "credit card companies", "fintech", "insurance companies", "investment firms"],
-        "example_brands": ["Chase", "Bank of America", "PayPal", "Visa", "Mastercard", "Goldman Sachs"],
-        "extraction_focus": "financial service recommendations"
-    },
-    "custom": {
-        "name": "Custom Industry",
-        "description": "Define your own industry and brand types",
-        "entity_types": [],
-        "example_brands": [],
-        "extraction_focus": "brand and company recommendations"
-    }
-}
+# INDUSTRY_PRESETS is re-exported from shared.industry_presets above so external
+# callers that imported it from this module still resolve.
 
 # Default extraction configuration
 DEFAULT_EXTRACTION_CONFIG = {
@@ -119,7 +56,7 @@ class LLMBrandExtractor:
         # Use default config if None or empty dict
         self.config = config if config else DEFAULT_EXTRACTION_CONFIG
         self.industry = self.config.get("industry", "hotels")
-        self.industry_preset = INDUSTRY_PRESETS.get(self.industry, INDUSTRY_PRESETS["custom"])
+        self.industry_preset = get_preset(self.industry)
 
     def extract_mentions(self, text: str) -> list[dict[str, Any]]:
         """

--- a/lambda/shared/constants.py
+++ b/lambda/shared/constants.py
@@ -1,0 +1,85 @@
+"""
+Shared constants for scoring formulas, aggregation thresholds, and limits.
+
+These values were previously inlined as magic numbers in individual
+handlers. Audit item 27 called out the readability + tunability cost of
+scattering them; this module collects the ones that have cross-handler
+meaning so the formulas become self-documenting.
+
+Rule of thumb for what belongs here:
+- A number that appears in more than one file OR
+- A number whose meaning is not obvious from context AND changing it
+  requires a coordinated review across files.
+
+If a number is truly local to one function (e.g. a retry count tuned to a
+specific API's throttling behavior), leave it inline with a comment.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Visibility score (0-100) weights — used by get-visibility-metrics.py AND
+# get-historical-trends.py.
+#
+# The weights sum to 100 intentionally:
+#   40 (provider coverage) + 30 (rank) + 20 (mentions) + 10 (sentiment) = 100.
+#
+# If you change any of these, update ALL four — the formula is a weighted
+# average, not independent factors. See `calculate_visibility_score` in
+# get-visibility-metrics.py for the authoritative implementation.
+# ---------------------------------------------------------------------------
+VISIBILITY_PROVIDER_WEIGHT = 40
+VISIBILITY_RANK_WEIGHT = 30
+VISIBILITY_MENTION_WEIGHT = 20
+VISIBILITY_SENTIMENT_WEIGHT = 10
+
+# Rank math caps: treat ranks worse than 10 as "off the list". `11 - rank`
+# produces a 0-10 inverse, divided by 10 to normalize to 0-1.
+VISIBILITY_RANK_CAP = 10
+VISIBILITY_RANK_INVERSE_BASE = 11
+
+# Mention math: logarithmic saturation at 50 mentions. After 50 mentions
+# additional counts stop contributing to the score — prevents one extremely
+# prolific brand from washing out everyone else.
+VISIBILITY_MENTION_SATURATION_COUNT = 50
+# The log base is `saturation + 1` because log(50 + 1) maps 50 mentions to
+# the score's ceiling. Callers use `math.log(n + 1) / math.log(51)`.
+VISIBILITY_MENTION_LOG_BASE = VISIBILITY_MENTION_SATURATION_COUNT + 1
+
+# Sentinel for "not ranked" — flows through best_rank reducers. Any number
+# above VISIBILITY_RANK_CAP gives the same score (zero rank contribution),
+# so 999 is arbitrary but safe.
+UNRANKED_SENTINEL = 999
+
+
+# ---------------------------------------------------------------------------
+# Trend direction classifier thresholds — used by get-historical-trends.py.
+#
+# `get_trend_direction` runs a linear regression over a series of visibility
+# scores. Slope is in score-points per period (day/week/month depending on
+# the caller's selection). The thresholds were tuned for the 0-100 visibility
+# range — a slope of +2 means gaining ~2 score points per period on average,
+# which is a meaningful dashboard change.
+# ---------------------------------------------------------------------------
+TREND_DIRECTION_IMPROVING_SLOPE = 2.0
+TREND_DIRECTION_DECLINING_SLOPE = -2.0
+
+
+# ---------------------------------------------------------------------------
+# Deduplication limits — used by deduplication/handler.py.
+#
+# `MAX_CITATIONS_PER_KEYWORD` bounds how many deduplicated citations survive
+# the prioritize step. Raising this grows the Citations table and the payload
+# size to downstream consumers; lowering it drops lower-priority sources.
+# Env var `MAX_CITATIONS_PER_KEYWORD` overrides at runtime.
+# ---------------------------------------------------------------------------
+MAX_CITATIONS_PER_KEYWORD_DEFAULT = 20
+
+
+# ---------------------------------------------------------------------------
+# Query prompt limits — used by manage-query-prompts.py.
+#
+# Soft business cap: 10 prompts per user. Increasing requires also bumping
+# the `scan(Limit=...)` in `list_prompts` to match.
+# ---------------------------------------------------------------------------
+MAX_QUERY_PROMPTS_DEFAULT = 10

--- a/lambda/shared/industry_presets.py
+++ b/lambda/shared/industry_presets.py
@@ -1,0 +1,138 @@
+"""
+Single source of truth for industry preset metadata.
+
+Both ``search/brand_extractor.py`` (the LLM extraction pipeline) and
+``api/manage-brand-config.py`` (the dashboard settings API) need the same
+industry catalog. Previously each file declared its own ``INDUSTRY_PRESETS``
+dict; the two copies drifted in shape (the API version baked a
+``default_prompt`` string into every entry, computed from the other fields).
+
+This module holds the structural data. Handlers that need the
+``default_prompt`` derive it at request time from the helper they already
+own — that keeps this module free of API-specific presentation concerns and
+avoids pulling the prompt-template scaffolding into the extraction Lambda.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class IndustryPreset(TypedDict):
+    """Shape of a single preset entry. The ``default_prompt`` is not part
+    of this contract — it's a derived value owned by the dashboard API."""
+
+    name: str
+    description: str
+    entity_types: list[str]
+    example_brands: list[str]
+    extraction_focus: str
+
+
+INDUSTRY_PRESETS: dict[str, IndustryPreset] = {
+    "hotels": {
+        "name": "Hotels & Hospitality",
+        "description": "Track hotel brands, chains, and individual properties",
+        "entity_types": [
+            "hotel chains", "hotel brands", "individual properties", "resorts", "boutique hotels",
+        ],
+        "example_brands": [
+            "Marriott", "Hilton", "Hyatt", "InterContinental", "Four Seasons",
+        ],
+        "extraction_focus": "hotel and accommodation recommendations",
+    },
+    "restaurants": {
+        "name": "Restaurants & Food Service",
+        "description": "Track restaurant chains, fast food, and dining brands",
+        "entity_types": [
+            "restaurant chains", "fast food brands", "casual dining", "fine dining", "coffee shops",
+        ],
+        "example_brands": [
+            "McDonald's", "Starbucks", "Chipotle", "Olive Garden", "Domino's",
+        ],
+        "extraction_focus": "restaurant and dining recommendations",
+    },
+    "airlines": {
+        "name": "Airlines & Aviation",
+        "description": "Track airline brands and aviation companies",
+        "entity_types": [
+            "airlines", "aviation companies", "low-cost carriers", "premium airlines",
+        ],
+        "example_brands": [
+            "Delta", "United", "American Airlines", "Southwest", "JetBlue", "Ryanair",
+        ],
+        "extraction_focus": "airline and flight recommendations",
+    },
+    "retail": {
+        "name": "Retail & Consumer Brands",
+        "description": "Track retail stores and consumer product brands",
+        "entity_types": [
+            "retail stores", "e-commerce brands", "consumer products", "fashion brands",
+        ],
+        "example_brands": [
+            "Amazon", "Walmart", "Target", "Nike", "Adidas", "Apple",
+        ],
+        "extraction_focus": "product and retail recommendations",
+    },
+    "fashion": {
+        "name": "Fashion & Apparel",
+        "description": "Track fashion brands, clothing, and footwear",
+        "entity_types": [
+            "fashion brands", "clothing brands", "footwear brands", "luxury brands", "sportswear",
+        ],
+        "example_brands": [
+            "Nike", "Adidas", "Zara", "H&M", "Gucci", "Louis Vuitton", "Puma",
+        ],
+        "extraction_focus": "fashion and apparel recommendations",
+    },
+    "automotive": {
+        "name": "Automotive",
+        "description": "Track car brands and automotive companies",
+        "entity_types": [
+            "car manufacturers", "automotive brands", "EV companies", "luxury car brands",
+        ],
+        "example_brands": [
+            "Toyota", "Ford", "Tesla", "BMW", "Mercedes-Benz", "Honda",
+        ],
+        "extraction_focus": "vehicle and automotive recommendations",
+    },
+    "technology": {
+        "name": "Technology & Software",
+        "description": "Track tech companies and software brands",
+        "entity_types": [
+            "tech companies", "software brands", "SaaS products", "hardware brands",
+        ],
+        "example_brands": [
+            "Apple", "Google", "Microsoft", "Amazon", "Meta", "Salesforce",
+        ],
+        "extraction_focus": "technology and software recommendations",
+    },
+    "finance": {
+        "name": "Finance & Banking",
+        "description": "Track banks, financial services, and fintech",
+        "entity_types": [
+            "banks", "credit card companies", "fintech", "insurance companies", "investment firms",
+        ],
+        "example_brands": [
+            "Chase", "Bank of America", "PayPal", "Visa", "Mastercard", "Goldman Sachs",
+        ],
+        "extraction_focus": "financial service recommendations",
+    },
+    "custom": {
+        "name": "Custom Industry",
+        "description": "Define your own industry and brand types",
+        "entity_types": [],
+        "example_brands": [],
+        "extraction_focus": "brand and company recommendations",
+    },
+}
+
+
+def get_preset(industry_id: str) -> IndustryPreset:
+    """Look up a preset by industry id, falling back to ``custom``.
+
+    Both callers (brand extractor, dashboard API) were doing the same
+    ``.get(id, presets["custom"])`` lookup inline. Centralizing here keeps
+    the fallback consistent and defends against typos in future callers.
+    """
+    return INDUSTRY_PRESETS.get(industry_id, INDUSTRY_PRESETS["custom"])

--- a/lambda/shared/test_constants.py
+++ b/lambda/shared/test_constants.py
@@ -1,0 +1,107 @@
+"""
+Tests for shared.constants.
+
+These pin the critical invariants that the handlers consuming these
+constants rely on. A regression here would silently break scoring math
+across visibility-metrics and historical-trends.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import constants  # type: ignore[import-not-found]
+
+
+class TestVisibilityScoreWeights:
+    """The four visibility weights must sum to 100 — the formula is a
+    weighted average, not independent factors."""
+
+    def test_weights_sum_to_one_hundred(self) -> None:
+        total = (
+            constants.VISIBILITY_PROVIDER_WEIGHT
+            + constants.VISIBILITY_RANK_WEIGHT
+            + constants.VISIBILITY_MENTION_WEIGHT
+            + constants.VISIBILITY_SENTIMENT_WEIGHT
+        )
+        assert total == 100
+
+    def test_provider_weight_is_largest(self) -> None:
+        """Provider coverage dominates the score — if anyone rebalances
+        they must update the comment in get-visibility-metrics.py too."""
+        weights = [
+            constants.VISIBILITY_PROVIDER_WEIGHT,
+            constants.VISIBILITY_RANK_WEIGHT,
+            constants.VISIBILITY_MENTION_WEIGHT,
+            constants.VISIBILITY_SENTIMENT_WEIGHT,
+        ]
+        assert constants.VISIBILITY_PROVIDER_WEIGHT == max(weights)
+
+    def test_all_weights_are_positive(self) -> None:
+        weights = [
+            constants.VISIBILITY_PROVIDER_WEIGHT,
+            constants.VISIBILITY_RANK_WEIGHT,
+            constants.VISIBILITY_MENTION_WEIGHT,
+            constants.VISIBILITY_SENTIMENT_WEIGHT,
+        ]
+        assert all(w > 0 for w in weights)
+
+
+class TestVisibilityRankMath:
+    """The rank inverse formula depends on these two constants being
+    coupled: VISIBILITY_RANK_INVERSE_BASE == VISIBILITY_RANK_CAP + 1.
+    The '+1' makes rank=1 score maximum and rank=10 score zero."""
+
+    def test_rank_inverse_base_equals_rank_cap_plus_one(self) -> None:
+        assert (
+            constants.VISIBILITY_RANK_INVERSE_BASE
+            == constants.VISIBILITY_RANK_CAP + 1
+        )
+
+    def test_unranked_sentinel_is_above_rank_cap(self) -> None:
+        """Sentinel must be > cap so min() against it in reducers stays
+        the sentinel until a real rank shows up."""
+        assert constants.UNRANKED_SENTINEL > constants.VISIBILITY_RANK_CAP
+
+
+class TestMentionLogBase:
+    """`VISIBILITY_MENTION_LOG_BASE == VISIBILITY_MENTION_SATURATION_COUNT + 1`
+    is the invariant that makes `math.log(n + 1) / math.log(log_base)` saturate
+    to exactly 1.0 when n == saturation_count. If these drift the mention
+    component will no longer saturate at the documented count."""
+
+    def test_log_base_equals_saturation_plus_one(self) -> None:
+        assert (
+            constants.VISIBILITY_MENTION_LOG_BASE
+            == constants.VISIBILITY_MENTION_SATURATION_COUNT + 1
+        )
+
+
+class TestTrendDirectionSlopes:
+    """Thresholds are symmetric — if they drift asymmetric, the dashboard
+    will feel biased toward one direction."""
+
+    def test_improving_and_declining_slopes_are_symmetric(self) -> None:
+        assert (
+            constants.TREND_DIRECTION_IMPROVING_SLOPE
+            == -constants.TREND_DIRECTION_DECLINING_SLOPE
+        )
+
+    def test_improving_slope_is_positive(self) -> None:
+        assert constants.TREND_DIRECTION_IMPROVING_SLOPE > 0
+
+    def test_declining_slope_is_negative(self) -> None:
+        assert constants.TREND_DIRECTION_DECLINING_SLOPE < 0
+
+
+class TestBusinessLimits:
+    """Business caps — both are positive integers."""
+
+    def test_max_citations_is_positive(self) -> None:
+        assert constants.MAX_CITATIONS_PER_KEYWORD_DEFAULT > 0
+
+    def test_max_query_prompts_is_positive(self) -> None:
+        assert constants.MAX_QUERY_PROMPTS_DEFAULT > 0

--- a/lambda/shared/test_industry_presets.py
+++ b/lambda/shared/test_industry_presets.py
@@ -1,0 +1,85 @@
+"""
+Tests for shared.industry_presets.
+
+The preset catalog previously lived in two files with slightly different
+shapes (the API version carried `default_prompt`, the extractor version did
+not). Consolidation risk: breaking either consumer by changing the structural
+contract. These tests pin the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import industry_presets  # type: ignore[import-not-found]
+
+
+REQUIRED_FIELDS = {"name", "description", "entity_types", "example_brands", "extraction_focus"}
+
+
+class TestIndustryPresetCatalog:
+    def test_catalog_is_not_empty(self) -> None:
+        assert len(industry_presets.INDUSTRY_PRESETS) > 0
+
+    def test_custom_fallback_exists(self) -> None:
+        """`get_preset` falls back to 'custom' for unknown industries —
+        if this key is missing, every unknown-industry lookup would
+        raise KeyError."""
+        assert "custom" in industry_presets.INDUSTRY_PRESETS
+
+    def test_every_preset_has_all_required_fields(self) -> None:
+        for industry_id, preset in industry_presets.INDUSTRY_PRESETS.items():
+            missing = REQUIRED_FIELDS - set(preset.keys())
+            assert not missing, f"{industry_id!r} missing fields: {missing}"
+
+    def test_every_preset_has_string_name(self) -> None:
+        for industry_id, preset in industry_presets.INDUSTRY_PRESETS.items():
+            assert isinstance(preset["name"], str) and preset["name"], (
+                f"{industry_id!r} name is empty or non-string"
+            )
+
+    def test_every_preset_entity_types_is_a_list(self) -> None:
+        for industry_id, preset in industry_presets.INDUSTRY_PRESETS.items():
+            assert isinstance(preset["entity_types"], list), (
+                f"{industry_id!r} entity_types is not a list"
+            )
+
+    def test_every_preset_example_brands_is_a_list(self) -> None:
+        for industry_id, preset in industry_presets.INDUSTRY_PRESETS.items():
+            assert isinstance(preset["example_brands"], list), (
+                f"{industry_id!r} example_brands is not a list"
+            )
+
+    def test_custom_preset_has_empty_entity_types_and_example_brands(self) -> None:
+        """`custom` is the fallback for deployments that haven't picked
+        an industry. Dashboard UX depends on it starting empty."""
+        custom = industry_presets.INDUSTRY_PRESETS["custom"]
+        assert custom["entity_types"] == []
+        assert custom["example_brands"] == []
+
+
+class TestGetPreset:
+    def test_returns_preset_for_known_industry(self) -> None:
+        preset = industry_presets.get_preset("hotels")
+        assert preset["name"] == "Hotels & Hospitality"
+
+    def test_returns_custom_preset_for_unknown_industry(self) -> None:
+        """Every caller in the codebase relied on this fallback. Missing
+        it would have required every handler to handle KeyError."""
+        preset = industry_presets.get_preset("nonexistent-industry-id")
+        assert preset["name"] == "Custom Industry"
+
+    def test_returns_custom_preset_for_empty_string(self) -> None:
+        preset = industry_presets.get_preset("")
+        assert preset["name"] == "Custom Industry"
+
+    def test_preserves_hotels_example_brands(self) -> None:
+        """Regression guard: example_brands are shown in the dashboard
+        industry selector. Losing them during consolidation would break
+        the UI."""
+        preset = industry_presets.get_preset("hotels")
+        assert "Marriott" in preset["example_brands"]
+        assert "Hilton" in preset["example_brands"]


### PR DESCRIPTION
## Summary

Refactor and bug-fix bundle from the lambda audit. Three related changes:

- `refactor/shared-constants` — extract magic numbers to `shared/constants` (audit #27)
- `refactor/industry-presets` — single source of truth for `INDUSTRY_PRESETS` (audit #29)
- `fix/content-studio-idempotency` — idempotent content-studio async generation (audit #23)

## Commits (3)

- `43d0142` refactor(lambda): extract magic numbers to shared/constants (audit #27)
- `7b9460a` refactor(lambda): single source of truth for INDUSTRY_PRESETS (audit #29)
- `9a5d0c5` fix(lambda): idempotent content-studio async generation (audit #23)

## Removed from this PR

The slider CAPTCHA drag-distance commit (audit #31) was dropped. Reason: it improved a CAPTCHA-bypass implementation that should not exist in this repo. The legitimate path is **Amazon Bedrock AgentCore Browser with Web Bot Auth (Preview)**, which is already configured in CDK (`browserSigning: { enabled: true }` on `CrawlerBrowser`). A separate PR removes the bypass code from `main`.

## Stacked on

PR #32 (`perf/historical-trends-parallel`). Will rebase onto `main` after upstream PRs merge.

## Tested

- Lambda unit tests pass
- Content-studio idempotency verified via dedup-key replay