### PR TITLE
refactor: normalize DynamoDB env-var names across Lambdas (audit #12)

### DIFF
--- a/lambda/api/get-citations.py
+++ b/lambda/api/get-citations.py
@@ -18,6 +18,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response
 from shared.decorators import api_handler, validate
+from shared.env_vars import resolve_table_env
 from shared.utils import get_brand_config
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,8 @@ logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-CITATIONS_TABLE = os.environ['CITATIONS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+CITATIONS_TABLE = resolve_table_env('DYNAMODB_TABLE_CITATIONS', 'CITATIONS_TABLE')
 citations_table = dynamodb.Table(CITATIONS_TABLE)
 
 # Optional: Brand config table for dynamic brand detection

--- a/lambda/api/get-crawled-content.py
+++ b/lambda/api/get-crawled-content.py
@@ -16,6 +16,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response
 from shared.decorators import api_handler, optional_limit, validate
+from shared.env_vars import resolve_table_env
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -23,8 +24,10 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource('dynamodb')
 s3_client = boto3.client('s3')
 
-# Fail-fast: Required environment variables
-CRAWLED_CONTENT_TABLE = os.environ['CRAWLED_CONTENT_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+CRAWLED_CONTENT_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_CRAWLED_CONTENT', 'CRAWLED_CONTENT_TABLE',
+)
 
 
 def generate_presigned_url(s3_uri: str, expiration: int = 900) -> str:

--- a/lambda/api/get-keywords.py
+++ b/lambda/api/get-keywords.py
@@ -15,14 +15,15 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response
 from shared.decorators import api_handler, optional_limit, validate
+from shared.env_vars import resolve_table_env
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-KEYWORDS_TABLE = os.environ['KEYWORDS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+KEYWORDS_TABLE = resolve_table_env('DYNAMODB_TABLE_KEYWORDS', 'KEYWORDS_TABLE')
 keywords_table = dynamodb.Table(KEYWORDS_TABLE)
 
 # Valid values

--- a/lambda/api/get-searches.py
+++ b/lambda/api/get-searches.py
@@ -17,14 +17,15 @@ sys.path.insert(0, '/opt/python')
 from shared.api_response import success_response
 from shared.config import PROVIDERS
 from shared.decorators import api_handler, optional_limit, validate
+from shared.env_vars import resolve_table_env
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-SEARCH_RESULTS_TABLE = os.environ['SEARCH_RESULTS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+SEARCH_RESULTS_TABLE = resolve_table_env('DYNAMODB_TABLE_SEARCH_RESULTS', 'SEARCH_RESULTS_TABLE')
 table = dynamodb.Table(SEARCH_RESULTS_TABLE)
 
 

--- a/lambda/api/get-stats.py
+++ b/lambda/api/get-stats.py
@@ -19,6 +19,7 @@ sys.path.insert(0, '/opt/python')
 from shared.api_response import success_response
 from shared.config import PROVIDERS
 from shared.decorators import api_handler, optional_provider, validate
+from shared.env_vars import resolve_table_env
 from shared.utils import get_timestamp
 
 logger = logging.getLogger(__name__)
@@ -26,11 +27,11 @@ logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-SEARCH_RESULTS_TABLE = os.environ['SEARCH_RESULTS_TABLE']
-CITATIONS_TABLE = os.environ['CITATIONS_TABLE']
-CRAWLED_CONTENT_TABLE = os.environ['CRAWLED_CONTENT_TABLE']
-KEYWORDS_TABLE = os.environ['KEYWORDS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+SEARCH_RESULTS_TABLE = resolve_table_env('DYNAMODB_TABLE_SEARCH_RESULTS', 'SEARCH_RESULTS_TABLE')
+CITATIONS_TABLE = resolve_table_env('DYNAMODB_TABLE_CITATIONS', 'CITATIONS_TABLE')
+CRAWLED_CONTENT_TABLE = resolve_table_env('DYNAMODB_TABLE_CRAWLED_CONTENT', 'CRAWLED_CONTENT_TABLE')
+KEYWORDS_TABLE = resolve_table_env('DYNAMODB_TABLE_KEYWORDS', 'KEYWORDS_TABLE')
 
 search_results_table = dynamodb.Table(SEARCH_RESULTS_TABLE)
 citations_table = dynamodb.Table(CITATIONS_TABLE)

--- a/lambda/api/get-url-breakdown.py
+++ b/lambda/api/get-url-breakdown.py
@@ -17,6 +17,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response
 from shared.decorators import api_handler, validate
+from shared.env_vars import resolve_table_env
 from shared.utils import normalize_url
 
 logger = logging.getLogger(__name__)
@@ -24,8 +25,10 @@ logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-SEARCH_RESULTS_TABLE = os.environ['SEARCH_RESULTS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+SEARCH_RESULTS_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_SEARCH_RESULTS', 'SEARCH_RESULTS_TABLE',
+)
 search_results_table = dynamodb.Table(SEARCH_RESULTS_TABLE)
 
 

--- a/lambda/api/manage-keywords.py
+++ b/lambda/api/manage-keywords.py
@@ -16,6 +16,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response, validation_error
 from shared.decorators import api_handler, parse_json_body, validate
+from shared.env_vars import resolve_table_env
 from shared.utils import get_timestamp
 
 logger = logging.getLogger(__name__)
@@ -23,8 +24,8 @@ logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-KEYWORDS_TABLE = os.environ['KEYWORDS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+KEYWORDS_TABLE = resolve_table_env('DYNAMODB_TABLE_KEYWORDS', 'KEYWORDS_TABLE')
 keywords_table = dynamodb.Table(KEYWORDS_TABLE)
 
 

--- a/lambda/api/manage-providers.py
+++ b/lambda/api/manage-providers.py
@@ -17,6 +17,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import api_response, not_found_response, success_response, validation_error
 from shared.decorators import api_handler, cors_preflight, parse_json_body, route_handler
+from shared.env_vars import resolve_table_env
 from shared.utils import get_timestamp
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,10 @@ logger.setLevel(logging.INFO)
 secrets_client = boto3.client('secretsmanager')
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-PROVIDER_CONFIG_TABLE = os.environ['PROVIDER_CONFIG_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+PROVIDER_CONFIG_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_PROVIDER_CONFIG', 'PROVIDER_CONFIG_TABLE',
+)
 SECRETS_PREFIX = os.environ.get('SECRETS_PREFIX', 'citation-analysis/')
 
 # Provider type constants

--- a/lambda/api/manage-query-prompts.py
+++ b/lambda/api/manage-query-prompts.py
@@ -18,6 +18,7 @@ sys.path.insert(0, '/opt/python')
 from shared.api_response import success_response, validation_error
 from shared.constants import MAX_QUERY_PROMPTS_DEFAULT
 from shared.decorators import api_handler, parse_json_body, validate
+from shared.env_vars import resolve_table_env
 from shared.utils import get_timestamp
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,10 @@ logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-QUERY_PROMPTS_TABLE = os.environ['QUERY_PROMPTS_TABLE']
+# Fail-fast: Required environment variables (audit #12 canonical naming).
+QUERY_PROMPTS_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_QUERY_PROMPTS', 'QUERY_PROMPTS_TABLE',
+)
 query_prompts_table = dynamodb.Table(QUERY_PROMPTS_TABLE)
 
 # Soft business cap — bounded per-user prompts. Override with

--- a/lambda/api/trigger-analysis.py
+++ b/lambda/api/trigger-analysis.py
@@ -19,6 +19,7 @@ sys.path.insert(0, '/opt/python')
 
 from shared.api_response import success_response, validation_error
 from shared.decorators import api_handler
+from shared.env_vars import resolve_table_env
 from shared.utils import get_timestamp, get_timestamp_compact
 
 logger = logging.getLogger(__name__)
@@ -27,10 +28,16 @@ logger.setLevel(logging.INFO)
 stepfunctions = boto3.client('stepfunctions')
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
+# Fail-fast: Required environment variables (audit #12 canonical naming).
 STATE_MACHINE_ARN = os.environ['STATE_MACHINE_ARN']
-KEYWORDS_TABLE = os.environ['KEYWORDS_TABLE']
-QUERY_PROMPTS_TABLE = os.environ.get('QUERY_PROMPTS_TABLE', 'CitationAnalysis-QueryPrompts')
+KEYWORDS_TABLE = resolve_table_env('DYNAMODB_TABLE_KEYWORDS', 'KEYWORDS_TABLE')
+# Query prompts table is optional — the analysis flow has a no-prompt fallback
+# for deployments that haven't enabled the feature yet. Default mirrors the
+# CDK stack's resource name for bootstrap deploys.
+QUERY_PROMPTS_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_QUERY_PROMPTS', 'QUERY_PROMPTS_TABLE',
+    required=False, default='CitationAnalysis-QueryPrompts',
+)
 
 keywords_table = dynamodb.Table(KEYWORDS_TABLE)
 query_prompts_table = dynamodb.Table(QUERY_PROMPTS_TABLE)

--- a/lambda/deduplication/handler.py
+++ b/lambda/deduplication/handler.py
@@ -12,6 +12,7 @@ from typing import Any
 import boto3
 
 from shared.constants import MAX_CITATIONS_PER_KEYWORD_DEFAULT
+from shared.env_vars import resolve_table_env
 from shared.step_function_response import log_error, step_function_success
 
 # Import shared utilities
@@ -24,9 +25,13 @@ logger.setLevel(logging.INFO)
 # Initialize DynamoDB client
 dynamodb = boto3.resource('dynamodb')
 
-# Fail-fast: Required environment variables
-CITATIONS_TABLE_NAME = os.environ['CITATIONS_TABLE_NAME']
-citations_table = dynamodb.Table(CITATIONS_TABLE_NAME)
+# Fail-fast: Required environment variables. Reads the canonical
+# DYNAMODB_TABLE_CITATIONS name first, falls back to the legacy
+# CITATIONS_TABLE_NAME until the CDK stack stops setting it (audit #12).
+CITATIONS_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_CITATIONS', 'CITATIONS_TABLE_NAME', 'CITATIONS_TABLE',
+)
+citations_table = dynamodb.Table(CITATIONS_TABLE)
 
 # Runtime override for the citations-per-keyword cap. Defaults to the shared
 # constant; setting `MAX_CITATIONS_PER_KEYWORD` in the Lambda environment lets

--- a/lambda/parse-keywords/handler.py
+++ b/lambda/parse-keywords/handler.py
@@ -27,7 +27,11 @@ logger.setLevel(logging.INFO)
 s3_client = boto3.client('s3')
 dynamodb = boto3.resource('dynamodb')
 
-KEYWORDS_TABLE = os.environ.get('KEYWORDS_TABLE', 'CitationAnalysis-Keywords')
+KEYWORDS_TABLE = (
+    os.environ.get('DYNAMODB_TABLE_KEYWORDS')
+    or os.environ.get('KEYWORDS_TABLE')
+    or 'CitationAnalysis-Keywords'
+)
 
 
 def read_keywords_from_dynamodb() -> list[str]:

--- a/lambda/search/handler.py
+++ b/lambda/search/handler.py
@@ -72,7 +72,14 @@ def get_extraction_config() -> dict[str, Any]:
 SECRETS_PREFIX = os.environ.get('SECRETS_PREFIX', 'citation-analysis/')
 DYNAMODB_TABLE_SEARCH_RESULTS = os.environ.get('DYNAMODB_TABLE_SEARCH_RESULTS')
 RAW_RESPONSES_BUCKET = os.environ.get('RAW_RESPONSES_BUCKET')
-PROVIDER_CONFIG_TABLE = os.environ.get('PROVIDER_CONFIG_TABLE', 'CitationAnalysis-ProviderConfig')
+# Provider config table — canonical name first, legacy fallback for in-flight
+# deploys. Default mirrors the CDK resource name so a bootstrap deploy works
+# even before env vars flow through. Audit #12.
+PROVIDER_CONFIG_TABLE = (
+    os.environ.get('DYNAMODB_TABLE_PROVIDER_CONFIG')
+    or os.environ.get('PROVIDER_CONFIG_TABLE')
+    or 'CitationAnalysis-ProviderConfig'
+)
 
 # Cache for secrets with TTL
 _secrets_cache = {}

--- a/lambda/shared/env_vars.py
+++ b/lambda/shared/env_vars.py
@@ -1,0 +1,70 @@
+"""
+Environment variable resolution with legacy-name migration support.
+
+Historical context: the project accumulated three DynamoDB table env-var
+naming conventions — bare names (``SEARCH_RESULTS_TABLE``), prefixed names
+(``DYNAMODB_TABLE_SEARCH_RESULTS``), and a mix of suffixed variants
+(``CITATIONS_TABLE_NAME``). Audit item 12 called this out as a deploy
+footgun: renaming any handler's env-var requires a coordinated CDK deploy
+or Python/CDK go out of sync and the Lambda can't cold-start.
+
+This helper reads the canonical ``DYNAMODB_TABLE_*`` name first and falls
+back to any legacy names passed in. That means:
+
+- Python code can be deployed independently of CDK (new name first).
+- CDK can set both old and new env vars during the transition so any
+  Lambda version works with any stack version.
+- Once every handler has migrated, the transitional mapping in CDK can
+  be cleaned up and this helper's fallback path becomes dead code —
+  at which point the legacy-name list can be removed from each caller.
+
+Keep this module tiny and dependency-free so it can live in the shared
+layer and import cheaply at cold-start.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_table_env(canonical_name: str, *legacy_names: str,
+                      required: bool = True,
+                      default: str | None = None) -> str | None:
+    """Resolve a DynamoDB table name from env vars with legacy fallback.
+
+    Args:
+        canonical_name: The preferred env var name (must be
+            ``DYNAMODB_TABLE_*``). Tried first.
+        *legacy_names: Historical env var names to try as fallback, in
+            priority order. Present here to unblock Python-side migration
+            while CDK still sets the old names.
+        required: If True, raise ``KeyError`` when none of the candidates
+            resolve to a non-empty value. If False, return ``default``.
+        default: Value returned when ``required=False`` and nothing resolves.
+
+    Returns:
+        The resolved table name, or ``default`` when ``required=False``.
+
+    Raises:
+        KeyError: When ``required=True`` and no env var resolves.
+    """
+    if not canonical_name.startswith('DYNAMODB_TABLE_'):
+        # Fail fast on misuse — the whole point of this helper is to
+        # enforce the prefix convention.
+        raise ValueError(
+            f"Canonical table env vars must use the DYNAMODB_TABLE_ prefix; "
+            f"got {canonical_name!r}"
+        )
+
+    for name in (canonical_name, *legacy_names):
+        value = os.environ.get(name)
+        if value:
+            return value
+
+    if required:
+        candidates = ", ".join([canonical_name, *legacy_names])
+        raise KeyError(
+            f"None of {{{candidates}}} are set in the Lambda environment. "
+            "Check the CDK stack environment block."
+        )
+    return default

--- a/lambda/shared/providers.py
+++ b/lambda/shared/providers.py
@@ -34,8 +34,9 @@ def get_enabled_provider_count(table_name: str | None = None) -> int:
     """Return the number of providers currently enabled in the config table.
 
     Fallback rules:
-    - If ``PROVIDER_CONFIG_TABLE`` (or the passed ``table_name``) is not
-      set, return ``len(PROVIDERS)`` (treat all providers as enabled).
+    - If ``DYNAMODB_TABLE_PROVIDER_CONFIG`` (or legacy ``PROVIDER_CONFIG_TABLE``,
+      or the passed ``table_name``) is not set, return ``len(PROVIDERS)``
+      (treat all providers as enabled).
     - If the table scan raises, log and return ``len(PROVIDERS)`` —
       provider-count is a denominator in visibility-score math and
       returning zero would produce div-by-zero or useless metrics.
@@ -45,10 +46,14 @@ def get_enabled_provider_count(table_name: str | None = None) -> int:
       convention).
 
     Args:
-        table_name: Override the ``PROVIDER_CONFIG_TABLE`` env var for
+        table_name: Override the ``DYNAMODB_TABLE_PROVIDER_CONFIG`` env var for
             testing. Production callers should omit.
     """
-    resolved = table_name or os.environ.get('PROVIDER_CONFIG_TABLE')
+    resolved = (
+        table_name
+        or os.environ.get('DYNAMODB_TABLE_PROVIDER_CONFIG')
+        or os.environ.get('PROVIDER_CONFIG_TABLE')
+    )
     if not resolved:
         return len(PROVIDERS)
 

--- a/lambda/shared/test_env_vars.py
+++ b/lambda/shared/test_env_vars.py
@@ -1,0 +1,114 @@
+"""
+Tests for shared.env_vars.resolve_table_env.
+
+This helper drives the DynamoDB env-var naming migration (audit #12). The
+Python code reads the canonical ``DYNAMODB_TABLE_*`` name first, falling
+back to any legacy names passed in, which lets the Python + CDK rollouts
+deploy in either order without a cold-start failure.
+
+These tests pin:
+- Canonical name takes priority even when legacy is set
+- Legacy name resolves when canonical is missing
+- KeyError raised when required and nothing resolves
+- Default returned when optional and nothing resolves
+- Empty-string env vars count as unset (truthy check)
+- Enforces the DYNAMODB_TABLE_ prefix contract to prevent misuse
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import env_vars  # type: ignore[import-not-found]
+
+
+class TestResolveTableEnv:
+    def test_returns_canonical_value_when_only_canonical_set(self) -> None:
+        with patch.dict(os.environ, {'DYNAMODB_TABLE_FOO': 'canonical-foo'}, clear=True):
+            result = env_vars.resolve_table_env('DYNAMODB_TABLE_FOO', 'FOO_LEGACY')
+        assert result == 'canonical-foo'
+
+    def test_returns_canonical_value_when_both_set(self) -> None:
+        """Regression guard: canonical MUST take priority, otherwise
+        deploying the new Python code with both env vars set would still
+        resolve to the legacy value and the migration would stall."""
+        with patch.dict(os.environ, {
+            'DYNAMODB_TABLE_FOO': 'canonical-foo',
+            'FOO_LEGACY': 'legacy-foo',
+        }, clear=True):
+            result = env_vars.resolve_table_env('DYNAMODB_TABLE_FOO', 'FOO_LEGACY')
+        assert result == 'canonical-foo'
+
+    def test_returns_legacy_value_when_only_legacy_set(self) -> None:
+        """The transitional case: CDK deploys first with both env vars
+        set, Python rolls out later — until then the Lambda must keep
+        working with only the legacy name."""
+        with patch.dict(os.environ, {'FOO_LEGACY': 'legacy-foo'}, clear=True):
+            result = env_vars.resolve_table_env('DYNAMODB_TABLE_FOO', 'FOO_LEGACY')
+        assert result == 'legacy-foo'
+
+    def test_returns_first_legacy_name_when_multiple_fallbacks(self) -> None:
+        """Priority: canonical, then each legacy in order."""
+        with patch.dict(os.environ, {'SECOND_LEGACY': 'second'}, clear=True):
+            result = env_vars.resolve_table_env(
+                'DYNAMODB_TABLE_FOO', 'FIRST_LEGACY', 'SECOND_LEGACY',
+            )
+        assert result == 'second'
+
+        with patch.dict(os.environ, {
+            'FIRST_LEGACY': 'first',
+            'SECOND_LEGACY': 'second',
+        }, clear=True):
+            result = env_vars.resolve_table_env(
+                'DYNAMODB_TABLE_FOO', 'FIRST_LEGACY', 'SECOND_LEGACY',
+            )
+        assert result == 'first'
+
+    def test_raises_key_error_when_required_and_nothing_set(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(KeyError) as excinfo:
+                env_vars.resolve_table_env('DYNAMODB_TABLE_FOO', 'FOO_LEGACY')
+        # Error message should mention every candidate so ops can fix the
+        # CDK stack without guessing.
+        assert 'DYNAMODB_TABLE_FOO' in str(excinfo.value)
+        assert 'FOO_LEGACY' in str(excinfo.value)
+
+    def test_returns_default_when_optional_and_nothing_set(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            result = env_vars.resolve_table_env(
+                'DYNAMODB_TABLE_FOO', 'FOO_LEGACY',
+                required=False, default='default-value',
+            )
+        assert result == 'default-value'
+
+    def test_returns_none_when_optional_no_default_and_nothing_set(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            result = env_vars.resolve_table_env(
+                'DYNAMODB_TABLE_FOO', 'FOO_LEGACY', required=False,
+            )
+        assert result is None
+
+    def test_treats_empty_string_env_var_as_unset(self) -> None:
+        """DynamoDB table names can't be empty. An empty-string env var
+        is almost certainly a deployment accident (unset variable
+        substitution in a shell) — fall through to the next candidate."""
+        with patch.dict(os.environ, {
+            'DYNAMODB_TABLE_FOO': '',
+            'FOO_LEGACY': 'legacy-foo',
+        }, clear=True):
+            result = env_vars.resolve_table_env('DYNAMODB_TABLE_FOO', 'FOO_LEGACY')
+        assert result == 'legacy-foo'
+
+    def test_rejects_non_prefixed_canonical_name(self) -> None:
+        """The helper enforces the DYNAMODB_TABLE_ prefix on the canonical
+        arg. Accepting any name would defeat the whole point of the
+        naming-consistency migration."""
+        with pytest.raises(ValueError) as excinfo:
+            env_vars.resolve_table_env('FOO_TABLE', 'FOO_LEGACY')
+        assert 'DYNAMODB_TABLE_' in str(excinfo.value)

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -695,6 +695,8 @@ export class CitationAnalysisStack extends cdk.Stack {
       description: 'Parse keywords from S3 or direct input',
       logGroup: parseKeywordsLogGroup,
       environment: {
+        // Audit #12 canonical name + legacy for in-flight rollouts.
+        DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
         KEYWORDS_TABLE: keywordsTable.tableName,
       },
     });
@@ -724,9 +726,12 @@ export class CitationAnalysisStack extends cdk.Stack {
       environment: {
         DYNAMODB_TABLE_SEARCH_RESULTS: searchResultsTable.tableName,
         DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,
+        // Canonical name (audit #12). Legacy PROVIDER_CONFIG_TABLE kept for
+        // in-flight deploys; can be dropped after one full rollout.
+        DYNAMODB_TABLE_PROVIDER_CONFIG: providerConfigTable.tableName,
+        PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
         SECRETS_PREFIX: 'citation-analysis/',
         RAW_RESPONSES_BUCKET: rawResponsesBucket.bucketName,
-        PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
         ...bedrockTierEnv,
       },
     });
@@ -752,7 +757,12 @@ export class CitationAnalysisStack extends cdk.Stack {
       memorySize: 256,
       description: 'Deduplicate and prioritize citations',
       logGroup: deduplicationLogGroup,
-      environment: {CITATIONS_TABLE_NAME: citationsTable.tableName,},
+      environment: {
+        // Canonical name (audit #12). Legacy CITATIONS_TABLE_NAME kept for
+        // in-flight deploys; can be dropped after one full rollout.
+        DYNAMODB_TABLE_CITATIONS: citationsTable.tableName,
+        CITATIONS_TABLE_NAME: citationsTable.tableName,
+      },
     });
 
     // Crawler Lambda Layer - Browser tools (Playwright + AgentCore)
@@ -1167,17 +1177,19 @@ export class CitationAnalysisStack extends cdk.Stack {
       memorySize: 512,
       description: 'API: Consolidated stats, visibility, insights, gaps, recommendations, and trends',
       environment: {
-        // get-stats env vars
-        SEARCH_RESULTS_TABLE: searchResultsTable.tableName,
-        CITATIONS_TABLE: citationsTable.tableName,
-        CRAWLED_CONTENT_TABLE: crawledContentTable.tableName,
-        KEYWORDS_TABLE: keywordsTable.tableName,
-        // visibility/insights env vars
+        // Audit #12: canonical DYNAMODB_TABLE_* names. Legacy names kept
+        // for in-flight deploys; can be dropped after one full rollout.
         DYNAMODB_TABLE_SEARCH_RESULTS: searchResultsTable.tableName,
         DYNAMODB_TABLE_CITATIONS: citationsTable.tableName,
         DYNAMODB_TABLE_CRAWLED_CONTENT: crawledContentTable.tableName,
         DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,
         DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
+        DYNAMODB_TABLE_PROVIDER_CONFIG: providerConfigTable.tableName,
+        // Legacy names (to be removed once rollout is verified):
+        SEARCH_RESULTS_TABLE: searchResultsTable.tableName,
+        CITATIONS_TABLE: citationsTable.tableName,
+        CRAWLED_CONTENT_TABLE: crawledContentTable.tableName,
+        KEYWORDS_TABLE: keywordsTable.tableName,
         PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
         ...bedrockTierEnv,
       },
@@ -1203,9 +1215,14 @@ export class CitationAnalysisStack extends cdk.Stack {
       memorySize: 256,
       description: 'API: Consolidated citations, URL breakdown, searches, crawled content, and raw responses',
       environment: {
+        // Audit #12 canonical names.
+        DYNAMODB_TABLE_CITATIONS: citationsTable.tableName,
+        DYNAMODB_TABLE_SEARCH_RESULTS: searchResultsTable.tableName,
+        DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,
+        DYNAMODB_TABLE_CRAWLED_CONTENT: crawledContentTable.tableName,
+        // Legacy names, dropped once rollout verified.
         CITATIONS_TABLE: citationsTable.tableName,
         SEARCH_RESULTS_TABLE: searchResultsTable.tableName,
-        DYNAMODB_TABLE_BRAND_CONFIG: brandConfigTable.tableName,
         CRAWLED_CONTENT_TABLE: crawledContentTable.tableName,
         RAW_RESPONSES_BUCKET: rawResponsesBucket.bucketName,
         SCREENSHOTS_BUCKET: screenshotsBucket.bucketName,
@@ -1256,6 +1273,10 @@ export class CitationAnalysisStack extends cdk.Stack {
       memorySize: 256,
       description: 'API: Consolidated keyword get/create/update/delete and keyword research',
       environment: {
+        // Audit #12 canonical names.
+        DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
+        DYNAMODB_TABLE_KEYWORD_RESEARCH: keywordResearchTable.tableName,
+        // Legacy names, dropped once rollout verified.
         KEYWORDS_TABLE: keywordsTable.tableName,
         KEYWORD_RESEARCH_TABLE: keywordResearchTable.tableName,
         SECRETS_PREFIX: 'citation-analysis/',
@@ -1278,10 +1299,14 @@ export class CitationAnalysisStack extends cdk.Stack {
       memorySize: 256,
       description: 'API: Consolidated query prompts, schedules, and provider config',
       environment: {
+        // Audit #12 canonical names.
+        DYNAMODB_TABLE_QUERY_PROMPTS: queryPromptsTable.tableName,
+        DYNAMODB_TABLE_PROVIDER_CONFIG: providerConfigTable.tableName,
+        // Legacy names, dropped once rollout verified.
         QUERY_PROMPTS_TABLE: queryPromptsTable.tableName,
+        PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
         STATE_MACHINE_ARN: stateMachine.stateMachineArn,
         SCHEDULE_ROLE_ARN: schedulerRole.roleArn,
-        PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
         SECRETS_PREFIX: 'citation-analysis/',
       },
     });
@@ -1303,6 +1328,10 @@ export class CitationAnalysisStack extends cdk.Stack {
       description: 'API: Consolidated trigger analysis and execution status',
       environment: {
         STATE_MACHINE_ARN: stateMachine.stateMachineArn,
+        // Audit #12 canonical names.
+        DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
+        DYNAMODB_TABLE_QUERY_PROMPTS: queryPromptsTable.tableName,
+        // Legacy names, dropped once rollout verified.
         KEYWORDS_TABLE: keywordsTable.tableName,
         QUERY_PROMPTS_TABLE: queryPromptsTable.tableName,
       },


### PR DESCRIPTION
## Summary

Normalizes DynamoDB environment-variable names across all Lambdas (audit #12). The CDK stack and Lambda handlers were using inconsistent env-var naming for table references. This PR introduces a single naming convention and updates both the infra and Lambda code.

## Commits (1)

- `4ed5302` refactor(lambda): normalize DynamoDB env-var names (audit #12)

## Stacked on

PR #33 (`fix/content-studio-idempotency`). Will rebase onto `main` after upstream PRs merge.

## Tested

- `npm run build` passes (CDK TypeScript)
- `cdk synth` produces valid CloudFormation
- All Lambdas resolve table names from the new env vars

## Reviewer notes

CDK change touching env-var names is potentially deploy-impacting. Worth verifying the CloudFormation diff before merging.
