### PR TITLE
feat(citations): inverse index via UrlIndex GSI on Citations table

### DIFF
--- a/lambda/api/get-url-breakdown.py
+++ b/lambda/api/get-url-breakdown.py
@@ -2,15 +2,20 @@
 Get URL Breakdown API Lambda
 
 Returns keywords and providers that cited a specific URL.
+
+Backed by the ``UrlIndex`` GSI on the Citations table (PK=normalized_url,
+SK=keyword, projection=ALL). Replaces the previous full-scan over
+SearchResults — see audit item: "consider adding a GSI on citations or
+maintaining a separate URL-to-keyword mapping table".
 """
 
 import logging
-import os
 import sys
 from typing import Any
 from urllib.parse import unquote
 
 import boto3
+from boto3.dynamodb.conditions import Key
 
 # Add shared module to path
 sys.path.insert(0, '/opt/python')
@@ -26,23 +31,90 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource('dynamodb')
 
 # Fail-fast: Required environment variables (audit #12 canonical naming).
-SEARCH_RESULTS_TABLE = resolve_table_env(
-    'DYNAMODB_TABLE_SEARCH_RESULTS', 'SEARCH_RESULTS_TABLE',
+CITATIONS_TABLE = resolve_table_env(
+    'DYNAMODB_TABLE_CITATIONS', 'CITATIONS_TABLE',
 )
-search_results_table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+citations_table = dynamodb.Table(CITATIONS_TABLE)
+
+# Inverse index GSI: PK=normalized_url, SK=keyword, projection=ALL.
+URL_INDEX_NAME = 'UrlIndex'
+
+# Pagination cap. Each page is up to 1 MB; with the deduplicated Citations
+# rows (a few hundred bytes each) and the cap of MAX_CITATIONS_PER_KEYWORD
+# rows per keyword, even a globally cited URL stays well under this limit.
+_MAX_QUERY_PAGES = 10
 
 
-def _normalize_for_comparison(url: str) -> str:
-    """Normalize URL for comparison - lowercase and remove trailing slash."""
-    normalized = normalize_url(url)
-    # Additional normalization for comparison
-    normalized = normalized.lower().rstrip('/')
-    return normalized
+def _query_url_index(target_normalized: str) -> list[dict[str, Any]]:
+    """
+    Query the ``UrlIndex`` GSI for every Citations row whose ``normalized_url``
+    matches the target. Returns the raw items so the caller can shape the
+    response.
+    """
+    items: list[dict[str, Any]] = []
+    pages = 0
+    last_evaluated_key: dict[str, Any] | None = None
+
+    while pages < _MAX_QUERY_PAGES:
+        query_kwargs: dict[str, Any] = {
+            'IndexName': URL_INDEX_NAME,
+            'KeyConditionExpression': Key('normalized_url').eq(target_normalized),
+        }
+        if last_evaluated_key:
+            query_kwargs['ExclusiveStartKey'] = last_evaluated_key
+
+        response = citations_table.query(**query_kwargs)
+        items.extend(response.get('Items', []))
+        pages += 1
+
+        last_evaluated_key = response.get('LastEvaluatedKey')
+        if not last_evaluated_key:
+            break
+
+    if last_evaluated_key:
+        logger.warning(
+            "UrlIndex query hit the %d-page cap (url=%s, items=%d). "
+            "Results are truncated.",
+            _MAX_QUERY_PAGES, target_normalized, len(items),
+        )
+
+    return items
 
 
-def _urls_match(url1: str, url2: str) -> bool:
-    """Check if two URLs match after normalization."""
-    return _normalize_for_comparison(url1) == _normalize_for_comparison(url2)
+def _expand_to_breakdown(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Each Citations row aggregates citing_providers; the breakdown response
+    expands one entry per (keyword, provider) pair so existing UI consumers
+    keep working unchanged.
+    """
+    breakdown: list[dict[str, Any]] = []
+    for item in items:
+        keyword = item.get('keyword', '')
+        # last_updated is the most recent run that wrote this row; if
+        # missing fall back to first_seen for legacy rows pre-dating the
+        # field.
+        timestamp = item.get('last_updated') or item.get('first_seen', '')
+
+        providers = item.get('citing_providers') or []
+        if not providers:
+            # Legacy rows without provider tracking still represent a
+            # citation event; surface them with provider="" rather than
+            # dropping them.
+            breakdown.append({
+                'keyword': keyword,
+                'provider': '',
+                'timestamp': timestamp,
+            })
+            continue
+
+        for provider in providers:
+            breakdown.append({
+                'keyword': keyword,
+                'provider': provider,
+                'timestamp': timestamp,
+            })
+
+    return breakdown
 
 
 @api_handler
@@ -53,62 +125,28 @@ def handler(event: dict[str, Any], context: Any, url: str) -> dict[str, Any]:
     """
     GET /api/url-breakdown?url=https://example.com
 
-    Returns breakdown of which keywords and providers cited this URL.
+    Returns a breakdown of which keywords and providers cited this URL.
+    Implementation queries the ``UrlIndex`` GSI on the Citations table
+    instead of scanning SearchResults.
     """
-    # URL decode in case it's encoded
     target_url = unquote(url)
-    target_normalized = _normalize_for_comparison(target_url)
+    target_normalized = normalize_url(target_url)
 
-    logger.info(f"Looking for URL: {target_url}")
-    logger.info(f"Normalized target: {target_normalized}")
+    logger.info("Looking up URL %s (normalized: %s)", target_url, target_normalized)
 
-    # Scan all search results with pagination
-    # Note: For better performance at scale, consider adding a GSI on citations
-    # or maintaining a separate URL-to-keyword mapping table
-    breakdown = []
-    last_evaluated_key = None
-    items_scanned = 0
-    max_items = 5000  # Safety limit
+    items = _query_url_index(target_normalized)
+    breakdown = _expand_to_breakdown(items)
 
-    while items_scanned < max_items:
-        scan_params = {'Limit': 500}
-        if last_evaluated_key:
-            scan_params['ExclusiveStartKey'] = last_evaluated_key
+    # Sort by timestamp (most recent first) for stable, user-friendly output.
+    breakdown.sort(key=lambda entry: entry.get('timestamp', ''), reverse=True)
 
-        response = search_results_table.scan(**scan_params)
-        items = response.get('Items', [])
-        items_scanned += len(items)
-
-        # Find all keyword-provider combinations that cited this URL
-        for item in items:
-            citations = item.get('citations', [])
-            keyword = item.get('keyword', '')
-            provider = item.get('provider', '')
-            timestamp = item.get('timestamp', '')
-
-            # Check if this URL is in the citations (with normalized comparison)
-            for citation in citations:
-                citation_url = citation if isinstance(citation, str) else citation.get('S', '')
-                if citation_url and _urls_match(citation_url, target_url):
-                    breakdown.append({
-                        'keyword': keyword,
-                        'provider': provider,
-                        'timestamp': timestamp
-                    })
-                    break  # Only count once per search result
-
-        # Check if there are more items to scan
-        last_evaluated_key = response.get('LastEvaluatedKey')
-        if not last_evaluated_key:
-            break
-
-    logger.info(f"Scanned {items_scanned} items, found {len(breakdown)} matches")
-
-    # Sort by timestamp (most recent first)
-    breakdown.sort(key=lambda x: x.get('timestamp', ''), reverse=True)
+    logger.info(
+        "Returning %d breakdown entries from %d Citations rows for %s",
+        len(breakdown), len(items), target_normalized,
+    )
 
     return success_response({
         'url': target_url,
         'total_citations': len(breakdown),
-        'breakdown': breakdown
+        'breakdown': breakdown,
     }, event)

--- a/lambda/api/test_url_breakdown_inverse_index.py
+++ b/lambda/api/test_url_breakdown_inverse_index.py
@@ -1,0 +1,292 @@
+"""
+Tests for the citations inverse-index migration in `get-url-breakdown.py`.
+
+Background — the previous implementation answered "which keywords cited
+URL X?" by paginating through up to 5000 SearchResults rows, comparing
+each citation string after normalization. That cost grows linearly with
+search volume and dominated p99 latency on the URL detail view.
+
+This refactor delegates the lookup to a GSI on the Citations table
+(``UrlIndex``: PK=normalized_url, SK=keyword, projection=ALL). DynamoDB
+maintains the index for free as the dedup Lambda upserts citation rows.
+
+These tests pin:
+  - The handler queries ``UrlIndex`` (not the base table, not a scan).
+  - The breakdown payload expands ``citing_providers`` into one entry per
+    (keyword, provider) pair to preserve the existing response contract.
+  - Pagination terminates and is bounded.
+  - Edge cases (empty providers, missing timestamps) don't drop rows or crash.
+  - URL normalization is applied so percent-encoded inputs resolve to the
+    same key DynamoDB has on disk.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Required env vars must be present BEFORE the module imports — the handler
+# resolves them at module load via ``resolve_table_env``.
+os.environ.setdefault('DYNAMODB_TABLE_CITATIONS', 'test-citations')
+
+_HERE = os.path.dirname(__file__)
+_MODULE_PATH = os.path.join(_HERE, 'get-url-breakdown.py')
+
+_LAMBDA_DIR = os.path.dirname(_HERE)
+if _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+_spec = importlib.util.spec_from_file_location(
+    'get_url_breakdown_under_test', _MODULE_PATH
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules['get_url_breakdown_under_test'] = _mod
+_spec.loader.exec_module(_mod)
+
+
+def _fake_table(pages: list[dict]) -> MagicMock:
+    """
+    Build a MagicMock DynamoDB Table whose ``query`` returns the given
+    pages in order. Each page is a dict like
+    ``{'Items': [...], 'LastEvaluatedKey': {...} or None}``.
+    """
+    table = MagicMock()
+    table.query.side_effect = pages
+    return table
+
+
+def _make_event(url: str) -> dict:
+    """Mimic the API Gateway proxy event shape the handler expects."""
+    return {
+        'queryStringParameters': {'url': url},
+        'headers': {},
+        'requestContext': {'http': {'method': 'GET'}},
+    }
+
+
+class TestQueryUrlIndex:
+    """Verify the index query goes to the right place and respects paging."""
+
+    def test_queries_url_index_by_normalized_url(self) -> None:
+        table = _fake_table([{'Items': [], 'LastEvaluatedKey': None}])
+        with patch.object(_mod, 'citations_table', table):
+            _mod._query_url_index('https://example.com/page')
+
+        # One call, targeting the inverse-index GSI by name.
+        assert table.query.call_count == 1
+        kwargs = table.query.call_args.kwargs
+        assert kwargs['IndexName'] == 'UrlIndex'
+
+    def test_query_uses_normalized_url_as_partition_key(self) -> None:
+        """The partition key on UrlIndex is ``normalized_url`` — the key
+        condition must match that attribute."""
+        table = _fake_table([{'Items': [], 'LastEvaluatedKey': None}])
+        with patch.object(_mod, 'citations_table', table):
+            _mod._query_url_index('https://example.com/page')
+
+        kce = table.query.call_args.kwargs['KeyConditionExpression']
+        # boto3 Condition objects expose operands via ``_values``: the first
+        # operand is the Key/Attr object, the second is the literal value.
+        key_attr, value = kce._values
+        assert key_attr.name == 'normalized_url'
+        assert value == 'https://example.com/page'
+
+    def test_paginates_until_no_last_evaluated_key(self) -> None:
+        pages = [
+            {'Items': [{'keyword': 'a'}], 'LastEvaluatedKey': {'k': 1}},
+            {'Items': [{'keyword': 'b'}], 'LastEvaluatedKey': {'k': 2}},
+            {'Items': [{'keyword': 'c'}], 'LastEvaluatedKey': None},
+        ]
+        table = _fake_table(pages)
+        with patch.object(_mod, 'citations_table', table):
+            items = _mod._query_url_index('https://example.com')
+
+        assert [i['keyword'] for i in items] == ['a', 'b', 'c']
+        assert table.query.call_count == 3
+
+    def test_stops_at_max_query_pages_when_results_unbounded(self) -> None:
+        """A pathological table that never returns ``LastEvaluatedKey=None``
+        must not loop forever — the cap exists so a misbehaving GSI can't
+        burn the Lambda timeout."""
+        infinite_page = {'Items': [{'keyword': 'kw'}], 'LastEvaluatedKey': {'k': 1}}
+        table = MagicMock()
+        table.query.return_value = infinite_page
+        with patch.object(_mod, 'citations_table', table):
+            items = _mod._query_url_index('https://example.com')
+
+        assert table.query.call_count == _mod._MAX_QUERY_PAGES
+        assert len(items) == _mod._MAX_QUERY_PAGES
+
+
+class TestExpandToBreakdown:
+    """The breakdown response contract: one entry per (keyword, provider)."""
+
+    def test_expands_citing_providers_into_one_entry_per_provider(self) -> None:
+        items = [
+            {
+                'keyword': 'best hotels',
+                'citing_providers': ['openai', 'perplexity', 'gemini'],
+                'last_updated': '2026-04-17T12:00:00Z',
+            }
+        ]
+        breakdown = _mod._expand_to_breakdown(items)
+
+        assert breakdown == [
+            {'keyword': 'best hotels', 'provider': 'openai',
+             'timestamp': '2026-04-17T12:00:00Z'},
+            {'keyword': 'best hotels', 'provider': 'perplexity',
+             'timestamp': '2026-04-17T12:00:00Z'},
+            {'keyword': 'best hotels', 'provider': 'gemini',
+             'timestamp': '2026-04-17T12:00:00Z'},
+        ]
+
+    def test_preserves_keyword_for_each_expanded_provider_entry(self) -> None:
+        """Multiple keywords cite the same URL — every expanded entry must
+        carry the keyword from its source row, not get cross-pollinated."""
+        items = [
+            {'keyword': 'kw-a', 'citing_providers': ['openai'],
+             'last_updated': '2026-01-01T00:00:00Z'},
+            {'keyword': 'kw-b', 'citing_providers': ['claude'],
+             'last_updated': '2026-01-02T00:00:00Z'},
+        ]
+        breakdown = _mod._expand_to_breakdown(items)
+
+        keywords = sorted(entry['keyword'] for entry in breakdown)
+        assert keywords == ['kw-a', 'kw-b']
+
+    def test_falls_back_to_first_seen_when_last_updated_missing(self) -> None:
+        """Legacy rows pre-dating ``last_updated`` still report a timestamp."""
+        items = [
+            {
+                'keyword': 'kw',
+                'citing_providers': ['openai'],
+                'first_seen': '2025-12-01T00:00:00Z',
+            }
+        ]
+        breakdown = _mod._expand_to_breakdown(items)
+        assert breakdown[0]['timestamp'] == '2025-12-01T00:00:00Z'
+
+    def test_empty_citing_providers_yields_one_entry_with_blank_provider(
+        self,
+    ) -> None:
+        """A Citations row should never have empty providers in practice,
+        but if one slips in, surface it (blank provider) rather than drop
+        the keyword silently."""
+        items = [
+            {
+                'keyword': 'kw',
+                'citing_providers': [],
+                'last_updated': '2026-04-17T12:00:00Z',
+            }
+        ]
+        breakdown = _mod._expand_to_breakdown(items)
+
+        assert breakdown == [
+            {'keyword': 'kw', 'provider': '',
+             'timestamp': '2026-04-17T12:00:00Z'},
+        ]
+
+    def test_missing_citing_providers_field_yields_blank_provider_entry(
+        self,
+    ) -> None:
+        """Same defensive contract when the field is absent entirely."""
+        items = [{'keyword': 'kw', 'last_updated': '2026-04-17T12:00:00Z'}]
+        breakdown = _mod._expand_to_breakdown(items)
+
+        assert breakdown == [
+            {'keyword': 'kw', 'provider': '',
+             'timestamp': '2026-04-17T12:00:00Z'},
+        ]
+
+
+class TestHandlerResponseShape:
+    """End-to-end tests for the API contract."""
+
+    def test_returns_breakdown_sorted_by_timestamp_desc(self) -> None:
+        items = [
+            {'keyword': 'old', 'citing_providers': ['openai'],
+             'last_updated': '2026-01-01T00:00:00Z'},
+            {'keyword': 'new', 'citing_providers': ['openai'],
+             'last_updated': '2026-04-17T12:00:00Z'},
+        ]
+        table = _fake_table([{'Items': items, 'LastEvaluatedKey': None}])
+
+        with patch.object(_mod, 'citations_table', table):
+            response = _mod.handler(_make_event('https://example.com'), None)
+
+        import json
+        body = json.loads(response['body'])
+        breakdown = body['breakdown']
+        # Newest first — consumers sort/display in this order on the UI.
+        assert breakdown[0]['keyword'] == 'new'
+        assert breakdown[1]['keyword'] == 'old'
+
+    def test_total_citations_counts_expanded_entries(self) -> None:
+        """``total_citations`` is the count the UI shows; it must reflect
+        the expanded (keyword, provider) pairs, not the raw row count."""
+        items = [
+            {'keyword': 'kw', 'citing_providers': ['openai', 'gemini', 'claude'],
+             'last_updated': '2026-04-17T12:00:00Z'},
+        ]
+        table = _fake_table([{'Items': items, 'LastEvaluatedKey': None}])
+
+        with patch.object(_mod, 'citations_table', table):
+            response = _mod.handler(_make_event('https://example.com'), None)
+
+        import json
+        body = json.loads(response['body'])
+        assert body['total_citations'] == 3
+
+    def test_returns_empty_breakdown_when_url_not_found(self) -> None:
+        table = _fake_table([{'Items': [], 'LastEvaluatedKey': None}])
+        with patch.object(_mod, 'citations_table', table):
+            response = _mod.handler(
+                _make_event('https://nobody-cites-this.example'), None
+            )
+
+        import json
+        body = json.loads(response['body'])
+        assert body['total_citations'] == 0
+        assert body['breakdown'] == []
+
+    def test_response_url_field_is_decoded_input_not_normalized(self) -> None:
+        """The ``url`` echoed back is the user-facing input (post-unquote)
+        so the UI displays what the user clicked, not the normalized form
+        used internally."""
+        table = _fake_table([{'Items': [], 'LastEvaluatedKey': None}])
+        with patch.object(_mod, 'citations_table', table):
+            response = _mod.handler(
+                _make_event('https%3A%2F%2Fexample.com%2Fpage'), None
+            )
+
+        import json
+        body = json.loads(response['body'])
+        assert body['url'] == 'https://example.com/page'
+
+
+class TestNoLongerScansSearchResults:
+    """Regression guard: the previous implementation imported and scanned
+    the SearchResults table. The migration removes that dependency
+    entirely; if it sneaks back, this test fails fast."""
+
+    def test_module_does_not_reference_search_results_table(self) -> None:
+        # The module should expose ``citations_table`` (the GSI host) and
+        # not reintroduce ``search_results_table``.
+        assert hasattr(_mod, 'citations_table')
+        assert not hasattr(_mod, 'search_results_table')
+
+    def test_module_does_not_call_table_scan(self) -> None:
+        """A scan call is the smoking gun for the old implementation."""
+        table = _fake_table([{'Items': [], 'LastEvaluatedKey': None}])
+        with patch.object(_mod, 'citations_table', table):
+            _mod.handler(_make_event('https://example.com'), None)
+
+        table.scan.assert_not_called()
+
+    def test_module_targets_url_index_constant(self) -> None:
+        """The GSI name is a single source of truth — keep it pinned."""
+        assert _mod.URL_INDEX_NAME == 'UrlIndex'

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -203,6 +203,30 @@ export class CitationAnalysisStack extends cdk.Stack {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // GSI: UrlIndex - Inverse index for "which keywords cite this URL?"
+    //
+    // The base table is keyed by (keyword, normalized_url) which makes the
+    // forward lookup ("citations for keyword X") cheap, but the reverse
+    // ("keywords that cite URL X") requires a full table scan. The
+    // get-url-breakdown handler used to scan SearchResults up to 5000 items
+    // to answer this. With this GSI, the same query is a bounded
+    // ``Query(normalized_url=X)`` against deduplicated rows.
+    //
+    // Projection is ALL because the breakdown endpoint needs
+    // citing_providers, citation_count, and last_updated alongside keyword.
+    citationsTable.addGlobalSecondaryIndex({
+      indexName: 'UrlIndex',
+      partitionKey: {
+        name: 'normalized_url',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'keyword',
+        type: dynamodb.AttributeType.STRING,
+      },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // DynamoDB Table: CrawledContent
     // Stores crawled page content and summaries
     const crawledContentTable = new dynamodb.Table(this, 'CrawledContentTable', {


### PR DESCRIPTION
## Summary

Adds an inverse index for citation lookups so the `/api/url-breakdown` endpoint
can answer "which keywords cite URL X?" without scanning the SearchResults
table.

The previous handler paginated up to 5000 SearchResults rows, scanning every
row's `citations` array to find matches. This change introduces a Global
Secondary Index on the existing Citations table:

```
CitationsTable
  PK=keyword, SK=normalized_url           (existing base table)
  GSI UrlIndex
    PK=normalized_url, SK=keyword          ← inverse direction
    projection=ALL
```

DynamoDB maintains the GSI automatically. The dedup Lambda's existing
`update_item` upserts populate it for free — no write-path changes needed.

## Why a GSI, not a new table

The codebase already has the Citations table receiving deduplicated writes
keyed by `(keyword, normalized_url)`. A GSI piggybacks on that write traffic
at the cost of one additional GSI write per dedup upsert, and avoids the
operational complexity of a parallel "URL-to-keyword" table that would need
its own write path and consistency story.

The codebase even hinted at this:
```python
# Note: For better performance at scale, consider adding a GSI on citations
# or maintaining a separate URL-to-keyword mapping table
```
This PR closes that comment.

## Changes

| File | Change |
|------|--------|
| `lib/citation-analysis-stack.ts` | Add `UrlIndex` GSI on `CitationsTable` |
| `lambda/api/get-url-breakdown.py` | Rewrite to query `UrlIndex` instead of scanning SearchResults |
| `lambda/api/test_url_breakdown_inverse_index.py` | 16 new unit tests |

## Response shape compatibility

The handler still returns:
```json
{
  "url": "<decoded user input>",
  "total_citations": <count>,
  "breakdown": [
    {"keyword": "...", "provider": "...", "timestamp": "..."},
    ...
  ]
}
```

Each Citations row aggregates `citing_providers` into a list, so the
handler expands one breakdown entry per `(keyword, provider)` pair.
`timestamp` uses `last_updated`, falling back to `first_seen` for legacy
rows.

## Tested

- `npm run build` passes (CDK TypeScript compiles cleanly).
- `pytest lambda/api/test_url_breakdown_inverse_index.py -v` → 16/16 pass.
- Tests cover: query targets `UrlIndex`, key condition uses
  `normalized_url`, pagination terminates and is bounded, expansion
  semantics, sort order, response shape, and regression guards
  (no more `search_results_table`, no `scan()` calls).
- Broader `pytest lambda/` → 281 passed; 20 pre-existing failures in
  `lambda/search/test_handler_prompts.py` are unrelated (`requests`
  module missing in this test-runner env).

## Migration notes

GSI creation backfills automatically when the stack is deployed. No data
migration step needed. Existing Citations rows already carry
`normalized_url` (it's the SK on the base table), so they project into
the GSI verbatim.

## Stacked on

PR #34 (`refactor/dynamodb-env-var-normalize`). Will rebase onto `main`
after the audit chain merges.
