### PR TITLE
feat(web): add print-to-PDF button on every view

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,11 +12,13 @@ import {
 import '@aws-amplify/ui-react/styles.css';
 import { useDashboardData } from './hooks/useDashboardData';
 import { useExecutionPolling } from './hooks/useExecutionPolling';
+import { usePrintMode } from './hooks/usePrintMode';
 import { Sidebar } from './components/Layout/Sidebar';
 import { TabContent } from './components/Layout/TabContent';
 import { ConfirmModal } from './components/ui/Modal';
 import { AboutModal } from './components/About';
 import { ThemeToggle } from './components/ui/ThemeToggle';
+import { PrintToPdfButton } from './components/ui/PrintToPdfButton';
 import { Spinner } from './components/ui/Spinner';
 import type {
   TabType, Schedule 
@@ -149,6 +151,10 @@ function MainApp() {
     execution, triggerAnalysis, startMonitoring, isRunning 
   } = useExecutionPolling(refetch);
 
+  // Print mode: when ?print=1 is in the URL we hide the sidebar/header chrome
+  // and auto-trigger the browser print dialog once data has loaded.
+  const { isPrintMode } = usePrintMode({ ready: !loading && Boolean(stats) });
+
   // Clear rawResponsesPath when navigating away from raw-responses
   useEffect(() => {
     if (location.pathname !== '/raw-responses') {
@@ -200,19 +206,31 @@ function MainApp() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <Sidebar
-        activeTab={activeTab}
-        onTabChange={handleTabChange}
-        keywordsCount={keywords.length}
-        schedulesCount={schedules.length}
-        isRunning={isRunning}
-        isOpen={sidebarOpen}
-        onToggle={() => setSidebarOpen(!sidebarOpen)}
-      />
+    <div className={`min-h-screen bg-gray-50 dark:bg-gray-900 ${isPrintMode ? 'print-mode' : ''}`}>
+      {!isPrintMode && (
+        <Sidebar
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          keywordsCount={keywords.length}
+          schedulesCount={schedules.length}
+          isRunning={isRunning}
+          isOpen={sidebarOpen}
+          onToggle={() => setSidebarOpen(!sidebarOpen)}
+        />
+      )}
 
-      <main className="lg:ml-64 min-h-screen">
-        <header className="h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between px-4 sm:px-6 lg:px-8 sticky top-0 z-10">
+      <main className={`${isPrintMode ? '' : 'lg:ml-64'} min-h-screen`}>
+        {isPrintMode ? (
+          <header className="px-4 sm:px-6 lg:px-8 py-4 border-b border-gray-200 dark:border-gray-700 print-header">
+            <h1 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white">
+              {PAGE_TITLES[activeTab]}
+            </h1>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {new Date().toLocaleString()}
+            </p>
+          </header>
+        ) : (
+          <header className="h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between px-4 sm:px-6 lg:px-8 sticky top-0 z-10">
           <button
             onClick={() => setSidebarOpen(!sidebarOpen)}
             className="lg:hidden p-2 -ml-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
@@ -232,6 +250,7 @@ function MainApp() {
                 <span className="hidden sm:inline">Refreshing</span>
               </span>
             )}
+            <PrintToPdfButton />
             <ThemeToggle />
             <button
               onClick={async () => {
@@ -260,6 +279,7 @@ function MainApp() {
             </button>
           </div>
         </header>
+        )}
 
         <div className="p-4 sm:p-6 lg:p-8">
           <div className="max-w-7xl mx-auto">

--- a/web/src/components/ui/PrintToPdfButton.spec.tsx
+++ b/web/src/components/ui/PrintToPdfButton.spec.tsx
@@ -1,0 +1,92 @@
+import {
+  render, screen, fireEvent,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import { PrintToPdfButton } from './PrintToPdfButton';
+
+/**
+ * `PrintToPdfButton` opens the current URL in a new tab with `?print=1`
+ * appended, so the auto-print layout in `MainApp` can take over there
+ * without disturbing the user's current tab.
+ *
+ * These tests pin:
+ *  - the button uses `window.open`, not `window.location.href` (so the
+ *    current tab keeps state),
+ *  - `?print=1` is appended to whatever path the user is on,
+ *  - existing query params are preserved (e.g., persona filters),
+ *  - the new tab is opened with `noopener,noreferrer` (security),
+ *  - the button is keyboard-reachable with a descriptive aria-label.
+ */
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <PrintToPdfButton />
+    </MemoryRouter>,
+  );
+
+describe('PrintToPdfButton', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens a new tab when clicked', () => {
+    renderAt('/visibility');
+    fireEvent.click(screen.getByRole('button'));
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends print=1 to the current path', () => {
+    renderAt('/citations');
+    fireEvent.click(screen.getByRole('button'));
+    expect(window.open).toHaveBeenCalledWith(
+      '/citations?print=1',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('preserves existing query params alongside print=1', () => {
+    renderAt('/visibility?persona=parent-with-kids');
+    fireEvent.click(screen.getByRole('button'));
+    expect(window.open).toHaveBeenCalledWith(
+      '/visibility?persona=parent-with-kids&print=1',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('overrides an existing print value rather than duplicating it', () => {
+    renderAt('/brands?print=0');
+    fireEvent.click(screen.getByRole('button'));
+    expect(window.open).toHaveBeenCalledWith(
+      '/brands?print=1',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('opens the new tab with noopener,noreferrer to prevent reverse-tabnabbing', () => {
+    renderAt('/');
+    fireEvent.click(screen.getByRole('button'));
+    expect(window.open).toHaveBeenCalledWith(
+      expect.any(String),
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('exposes a descriptive aria-label for assistive tech', () => {
+    renderAt('/');
+    expect(
+      screen.getByLabelText('Save current view as PDF (opens in new tab)'),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/PrintToPdfButton.tsx
+++ b/web/src/components/ui/PrintToPdfButton.tsx
@@ -1,0 +1,60 @@
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Opens the current view in a new browser tab with `?print=1` appended.
+ *
+ * The print-mode layout (see `App.tsx`) detects this query param and:
+ *  - hides the sidebar and most chrome,
+ *  - automatically triggers `window.print()` so the user lands directly
+ *    on the browser's "Save as PDF" / printer dialog.
+ *
+ * The user can either save the PDF, send to a printer, or close the
+ * dialog and still see the print-formatted view in the new tab.
+ */
+export const PrintToPdfButton = () => {
+  const location = useLocation();
+
+  const handleClick = () => {
+    const params = new URLSearchParams(location.search);
+    params.set('print', '1');
+    const target = `${location.pathname}?${params.toString()}${location.hash}`;
+    // window.open with absolute URL keeps the auth/session cookies on the new tab.
+    window.open(target, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+      title="Save view as PDF"
+      aria-label="Save current view as PDF (opens in new tab)"
+    >
+      {/* Document outline with folded corner + "PDF" label inside — universally read as "save as PDF" */}
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M14 3H6a2 2 0 00-2 2v14a2 2 0 002 2h12a2 2 0 002-2V9l-6-6z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M14 3v6h6"
+        />
+        <text
+          x="12"
+          y="17.5"
+          textAnchor="middle"
+          fontSize="5"
+          fontWeight="700"
+          fill="currentColor"
+          stroke="none"
+        >
+          PDF
+        </text>
+      </svg>
+    </button>
+  );
+};

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -3,6 +3,7 @@ export {
 } from './Modal';
 export { Spinner } from './Spinner';
 export { ThemeToggle } from './ThemeToggle';
+export { PrintToPdfButton } from './PrintToPdfButton';
 export {
   formatInlineMarkdown, formatResponse, extractUrls, findMentionPositions 
 } from './MarkdownProcessor';

--- a/web/src/hooks/usePrintMode.spec.tsx
+++ b/web/src/hooks/usePrintMode.spec.tsx
@@ -1,0 +1,107 @@
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import { usePrintMode } from './usePrintMode';
+
+/**
+ * `usePrintMode` reads `?print=1` from the current URL and, when present
+ * AND `ready` is true, calls `window.print()` after a short delay.
+ *
+ * Tests pin:
+ *  - the hook returns `isPrintMode=false` for normal URLs (no auto-print),
+ *  - the hook returns `isPrintMode=true` when `?print=1` is set,
+ *  - `window.print` is only called once `ready` flips to true,
+ *  - the timeout is cleared on unmount (no `print()` after the new tab
+ *    is closed),
+ *  - the configurable delay actually controls when the print fires.
+ */
+
+const wrapperAt = (path: string) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+  );
+  return Wrapper;
+};
+
+describe('usePrintMode', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'print').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns isPrintMode=false when the URL has no print param', () => {
+    const { result } = renderHook(() => usePrintMode(), {wrapper: wrapperAt('/visibility'),});
+    expect(result.current.isPrintMode).toBe(false);
+  });
+
+  it('returns isPrintMode=true when the URL has ?print=1', () => {
+    const { result } = renderHook(() => usePrintMode(), {wrapper: wrapperAt('/visibility?print=1'),});
+    expect(result.current.isPrintMode).toBe(true);
+  });
+
+  it('does not auto-print when isPrintMode is false', () => {
+    renderHook(() => usePrintMode(), { wrapper: wrapperAt('/visibility') });
+    vi.advanceTimersByTime(5000);
+    expect(window.print).not.toHaveBeenCalled();
+  });
+
+  it('triggers window.print after the delay when print mode is on and ready', () => {
+    renderHook(() => usePrintMode({
+      ready: true,
+      printDelayMs: 1000 
+    }), {wrapper: wrapperAt('/citations?print=1'),});
+    vi.advanceTimersByTime(1000);
+    expect(window.print).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits to print until ready transitions to true', () => {
+    const { rerender } = renderHook(
+      ({ ready }) => usePrintMode({
+        ready,
+        printDelayMs: 500 
+      }),
+      {
+        initialProps: { ready: false },
+        wrapper: wrapperAt('/?print=1'),
+      },
+    );
+    vi.advanceTimersByTime(2000);
+    expect(window.print).not.toHaveBeenCalled();
+
+    rerender({ ready: true });
+    vi.advanceTimersByTime(500);
+    expect(window.print).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the pending print timer on unmount', () => {
+    const { unmount } = renderHook(
+      () => usePrintMode({
+        ready: true,
+        printDelayMs: 1000 
+      }),
+      { wrapper: wrapperAt('/?print=1') },
+    );
+    unmount();
+    vi.advanceTimersByTime(2000);
+    expect(window.print).not.toHaveBeenCalled();
+  });
+
+  it('respects a custom printDelayMs', () => {
+    renderHook(() => usePrintMode({
+      ready: true,
+      printDelayMs: 250 
+    }), {wrapper: wrapperAt('/?print=1'),});
+    vi.advanceTimersByTime(249);
+    expect(window.print).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(window.print).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/usePrintMode.ts
+++ b/web/src/hooks/usePrintMode.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Detects whether the current route is in print mode (`?print=1`) and, if so,
+ * automatically opens the browser's print dialog after a short delay.
+ *
+ * The delay gives lazy-loaded views, charts, and async data hooks time to
+ * render before the screenshot the print dialog snapshots.
+ *
+ * @param ready  Optional flag that callers can use to gate auto-print until
+ *               their data has loaded. When `false` the hook waits; when
+ *               `true` it kicks the print dialog after `printDelayMs`.
+ * @param printDelayMs  Default 1500ms — long enough for chart.js renders to
+ *                      complete on a typical dashboard view but short enough
+ *                      that the user doesn't feel a lag.
+ *
+ * @returns `isPrintMode` flag for the caller to decide layout choices.
+ */
+export function usePrintMode({
+  ready = true,
+  printDelayMs = 1500,
+}: {
+  ready?: boolean;
+  printDelayMs?: number 
+} = {}): { isPrintMode: boolean } {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const isPrintMode = params.get('print') === '1';
+
+  useEffect(() => {
+    if (!isPrintMode || !ready) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      window.print();
+    }, printDelayMs);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [isPrintMode, ready, printDelayMs]);
+
+  return { isPrintMode };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -337,3 +337,77 @@
 .dark [data-amplify-authenticator] [data-amplify-router-content] {
   background-color: rgb(31 41 55); /* gray-800 */
 }
+
+/* ----------------------------------------------------------------------- */
+/*  Print mode                                                             */
+/* ----------------------------------------------------------------------- */
+
+/*
+ * `print-mode` is added to <body>'s direct child <div> by App.tsx when the
+ * URL contains `?print=1`. It signals "remove navigation chrome and prep for
+ * a paper/PDF screenshot" even before the actual `@media print` rules kick
+ * in (so the new tab looks like a print preview on screen too).
+ */
+.print-mode .print-hidden {
+  display: none !important;
+}
+
+.print-mode {
+  /* Preserve background colors of charts, badges, and stat cards in PDF
+     output instead of stripping them to white. */
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
+}
+
+.print-mode .print-header {
+  margin-bottom: 0.5rem;
+}
+
+@media print {
+  /* Hide every element marked .print-hidden anywhere in the tree, even
+     outside of print-mode (modal portals, debug panels, etc.). */
+  .print-hidden,
+  [data-print-hidden="true"] {
+    display: none !important;
+  }
+
+  /* Page breaks helpers. Add `.page-break-before` to a section to start it
+     on a fresh page; `.avoid-break-inside` keeps a card together. */
+  .page-break-before {
+    break-before: page;
+  }
+  .avoid-break-inside {
+    break-inside: avoid;
+  }
+
+  /* Color preservation across all print contexts. */
+  * {
+    print-color-adjust: exact !important;
+    -webkit-print-color-adjust: exact !important;
+  }
+
+  /* Remove sticky positioning so headers don't repeat awkwardly mid-page. */
+  .sticky {
+    position: static !important;
+  }
+
+  /* Force charts to a printable size — on paper, full-width with capped
+     height keeps them legible. */
+  canvas {
+    max-width: 100% !important;
+    height: auto !important;
+  }
+
+  /* Light background regardless of the saved theme so PDFs are readable
+     when printed on white paper. */
+  body,
+  .print-mode {
+    background: white !important;
+    color: black !important;
+  }
+
+  /* Default page margins; the browser print dialog can override these. */
+  @page {
+    margin: 0.5in;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a "Save view as PDF" button to the global dashboard header. Clicking it opens the current view in a new browser tab with `?print=1` appended; the new tab hides the sidebar, simplifies the header, waits for data to load, and then automatically opens the browser's native print dialog (which has the **Save as PDF** destination on every Chromium-based browser, plus Safari and Firefox).

Available on every view automatically — Dashboard, Visibility, Brand Mentions, Citations, Prompt Insights, Citation Gaps, Action Center, Keyword Research, Content Studio, Recent Searches, Raw Responses, Run Analysis, Schedule, and Settings — because the button lives in the shared header next to the theme toggle.

## Why URL-driven print mode

- Leaves the user's working tab untouched (filters, scroll position, in-flight selections).
- Lets users tweak the print preview, paper size, orientation, and margins natively.
- Prints whatever the user is currently looking at — no separate PDF-generation pipeline to maintain (no jsPDF / Puppeteer / etc).
- Single global button covers all 14 views without per-view changes.

## Files

| File | Purpose |
|---|---|
| `web/src/components/ui/PrintToPdfButton.tsx` | The button. Folded-corner document icon labelled "PDF". |
| `web/src/components/ui/PrintToPdfButton.spec.tsx` | 6 tests pinning click behaviour, query-param composition, `noopener,noreferrer`, aria-label. |
| `web/src/hooks/usePrintMode.ts` | Reads `?print=1`, schedules `window.print()` after `printDelayMs` (default 1500ms) once `ready` is true. |
| `web/src/hooks/usePrintMode.spec.tsx` | 7 tests: detection, ready-gating, delay, unmount cleanup. |
| `web/src/App.tsx` | Renders the simplified print-mode layout: no sidebar, no margin offset, header reduced to title + timestamp. |
| `web/src/components/ui/index.ts` | Barrel export. |
| `web/src/index.css` | `@media print` rules: page-break helpers (`.page-break-before`, `.avoid-break-inside`), colour preservation, sticky removal, canvas sizing, forced-light background. |

## How it behaves

1. User on `/visibility?persona=parent-with-kids` clicks the PDF button.
2. New tab opens at `/visibility?persona=parent-with-kids&print=1`.
3. New tab renders with no sidebar; header shows just the page title and the print timestamp.
4. Once `useDashboardData` finishes loading, `usePrintMode` schedules `window.print()` after 1.5s — long enough for chart.js renders to settle.
5. Browser shows its native print dialog. User picks "Save as PDF", chooses a destination, hits Save.
6. User can also cancel the dialog and still see the print-formatted view; it's a real route, not a popup.

The original tab is unaffected. `noopener,noreferrer` on `window.open` blocks reverse-tabnabbing.

## Tests

- 13 new vitest cases (6 button + 7 hook).
- All 688 web tests pass.
- Type-check clean (`tsc --noEmit`).
- Lint clean for the new files (auto-fixed stylistic preferences in 4 files).

## Verification gaps

Did not boot the live dev server because Vite reads `VITE_USER_POOL_ID` / `VITE_API_URL` from a deployed CDK stack at build time. The behaviour is unit-tested with fake timers and `MemoryRouter`. Reviewer should sanity-check by running locally against a deployed environment.
