### PR TITLE
chore(web): add optional dev-only API proxy

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -4,3 +4,22 @@
 
 # The default API URL is already configured in src/config.ts
 # Only set this if you want to use a different API endpoint
+
+# ---
+# Dev-only API proxy (optional)
+#
+# When running `npm run dev` locally, the deployed API's CORS policy
+# typically rejects requests from http://localhost:5173 because only the
+# production CloudFront origin is whitelisted. To work around this without
+# modifying live infrastructure, set both variables below in a gitignored
+# `web/.env.development.local`:
+#
+#   VITE_API_URL=/api
+#   VITE_API_PROXY_TARGET=https://your-api-gateway-url.execute-api.us-west-2.amazonaws.com/prod
+#
+# - VITE_API_URL=/api makes the browser call the Vite dev server (same-origin).
+# - VITE_API_PROXY_TARGET tells Vite where to forward those `/api/*` requests.
+#   Note: no trailing `/api` on the target — the path is preserved.
+#
+# The proxy only activates in development mode and only when
+# VITE_API_PROXY_TARGET is set, so production builds are unaffected.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,27 +1,51 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: false,
-    minify: 'terser',
-    chunkSizeWarningLimit: 1000,
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom'],
-          'vendor-charts': ['chart.js', 'react-chartjs-2'],
-          'vendor-xlsx': ['xlsx-js-style'],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  // Optional dev-only API proxy: when VITE_API_PROXY_TARGET is set we forward
+  // `/api/*` from the local dev server to the deployed API. The deployed
+  // backend's CORS policy only allows the production CloudFront origin, so
+  // direct browser calls from `localhost:5173` would fail. Routing through
+  // the dev server makes the browser see same-origin responses. Only kicks
+  // in for `npm run dev`; production builds resolve VITE_API_URL directly.
+  const proxyTarget = env.VITE_API_PROXY_TARGET ?? '';
+  const enableDevProxy = mode === 'development' && proxyTarget.length > 0;
+
+  return {
+    plugins: [react()],
+    server: enableDevProxy
+      ? {
+          proxy: {
+            '/api': {
+              target: proxyTarget,
+              changeOrigin: true,
+              secure: true,
+            },
+          },
+        }
+      : undefined,
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/test/setup.ts',
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: false,
+      minify: 'terser',
+      chunkSizeWarningLimit: 1000,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'vendor-react': ['react', 'react-dom'],
+            'vendor-charts': ['chart.js', 'react-chartjs-2'],
+            'vendor-xlsx': ['xlsx-js-style'],
+          },
         },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## What

Adds an opt-in Vite dev-server proxy that forwards `/api/*` from `http://localhost:5173` to a configurable target API. Activates only when the developer sets `VITE_API_PROXY_TARGET` in a gitignored `web/.env.development.local`.

## Why

Without this, running `npm run dev` against the deployed backend fails because the API's CORS allow-list only includes the production CloudFront origin (the `ALLOW_LOCALHOST` env var on the Lambdas is intentionally not enabled in deployed environments). Browser calls from `localhost:5173` get rejected before any other validation runs, blocking end-to-end testing of UI changes — for example the new print-to-PDF flow in #38 — against real API data.

The fixes available before this change were:

1. Toggle `ALLOW_LOCALHOST=true` on the deployed Lambdas — touches live infrastructure for a dev-only convenience and is easy to forget to revert.
2. Re-deploy with relaxed CORS — same problem, broader blast radius.
3. Run an entirely local stack — high friction and not always representative of the deployed config.

A dev-server proxy is the smallest possible change: the browser sees same-origin responses, so CORS never enters the picture, and nothing about deployed infra is altered.

## How

`web/vite.config.ts` is now a function form (`defineConfig(({ mode }) => …)`) so it can read env vars via `loadEnv`:

- The proxy is gated on **both** `mode === 'development'` and `VITE_API_PROXY_TARGET` being set. Production builds and CI go through the original code path (no `server.proxy` config emitted).
- When enabled, `/api/*` forwards to `VITE_API_PROXY_TARGET` with `changeOrigin: true` and `secure: true`.
- Pair with a gitignored `web/.env.development.local`:
  ```
  VITE_API_URL=/api
  VITE_API_PROXY_TARGET=https://<api-id>.execute-api.<region>.amazonaws.com/prod
  ```
  - `VITE_API_URL=/api` makes the browser hit the Vite dev server (same-origin).
  - `VITE_API_PROXY_TARGET` is the full deployed API base URL **without** a trailing `/api` — Vite preserves the path.

`web/.env.example` documents the two variables and how to wire them up so future developers don't have to read `vite.config.ts` to discover this workflow.

## Verification

- `npm run build` — clean (production code path is unchanged).
- `npm run type-check` — clean.
- `npm run dev` with the env vars set — verified that `localhost:5173` successfully fetches data from the deployed API and the dashboard renders with real values; without the env vars set, behavior is identical to current `main` (no proxy registered).

## Scope

- 1 file changed in src (`web/vite.config.ts`), plus `web/.env.example` documentation.
- No production code paths changed.
- No deployed infrastructure changed.
- No new dependencies.

## Related

- #38 — print-to-PDF (the feature whose validation surfaced the CORS blocker).
