### PR TITLE
feat(web): Reporting section + Keyword Deep Dive report

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { useExecutionPolling } from './hooks/useExecutionPolling';
 import { usePrintMode } from './hooks/usePrintMode';
 import { Sidebar } from './components/Layout/Sidebar';
 import { TabContent } from './components/Layout/TabContent';
+import { ReportsRouter } from './components/Reports/ReportsRouter';
 import { ConfirmModal } from './components/ui/Modal';
 import { AboutModal } from './components/About';
 import { ThemeToggle } from './components/ui/ThemeToggle';
@@ -43,6 +44,7 @@ const TAB_TO_PATH: Record<TabType, string> = {
   recommendations: '/recommendations',
   'keyword-research': '/keyword-research',
   'content-studio': '/content-studio',
+  reports: '/reports',
   searches: '/searches',
   'raw-responses': '/raw-responses',
   execution: '/execution',
@@ -57,6 +59,16 @@ const PATH_TO_TAB: Record<string, TabType> = Object.entries(TAB_TO_PATH).reduce<
   }),
   {}
 );
+
+/**
+ * Resolve a route pathname back to its TabType. Sub-paths under `/reports/`
+ * (e.g. `/reports/keyword/foo`) all resolve to the `reports` tab so the
+ * sidebar stays highlighted when navigating between individual reports.
+ */
+function resolveActiveTab(pathname: string): TabType {
+  if (pathname.startsWith('/reports')) return 'reports';
+  return PATH_TO_TAB[pathname] ?? 'dashboard';
+}
 
 function Login() {
   return (
@@ -123,6 +135,7 @@ const PAGE_TITLES: Record<TabType, string> = {
   'citation-gaps': 'Citation Gap Analysis',
   recommendations: 'Action Center',
   'content-studio': 'Content Studio',
+  reports: 'Reports',
   execution: 'Run Analysis',
   schedule: 'Schedule',
   'keyword-research': 'Keyword Research',
@@ -135,7 +148,8 @@ function MainApp() {
   const navigate = useNavigate();
   const location = useLocation();
   
-  const activeTab = PATH_TO_TAB[location.pathname] ?? 'dashboard';
+  const activeTab = resolveActiveTab(location.pathname);
+  const isReportRoute = location.pathname.startsWith('/reports');
   
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
@@ -152,8 +166,11 @@ function MainApp() {
   } = useExecutionPolling(refetch);
 
   // Print mode: when ?print=1 is in the URL we hide the sidebar/header chrome
-  // and auto-trigger the browser print dialog once data has loaded.
-  const { isPrintMode } = usePrintMode({ ready: !loading && Boolean(stats) });
+  // and auto-trigger the browser print dialog once data has loaded. On
+  // `/reports/*` routes we leave the auto-print scheduling to the report
+  // component itself, since report data is loaded inside the report (and is
+  // not represented by the dashboard's `stats` flag).
+  const { isPrintMode } = usePrintMode({ready: isReportRoute ? false : !loading && Boolean(stats),});
 
   // Clear rawResponsesPath when navigating away from raw-responses
   useEffect(() => {
@@ -231,75 +248,79 @@ function MainApp() {
           </header>
         ) : (
           <header className="h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between px-4 sm:px-6 lg:px-8 sticky top-0 z-10">
-          <button
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-            className="lg:hidden p-2 -ml-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </button>
-          <h1 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white truncate">{PAGE_TITLES[activeTab]}</h1>
-          <div className="flex items-center gap-2 sm:gap-4">
-            <span className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 hidden sm:inline">
-              Last updated: {lastUpdate.toLocaleTimeString()}
-            </span>
-            {loading && (
-              <span className="text-sm text-gray-400 flex items-center gap-2">
-                <Spinner size="sm" />
-                <span className="hidden sm:inline">Refreshing</span>
+            <button
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+              className="lg:hidden p-2 -ml-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+            <h1 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white truncate">{PAGE_TITLES[activeTab]}</h1>
+            <div className="flex items-center gap-2 sm:gap-4">
+              <span className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 hidden sm:inline">
+                Last updated: {lastUpdate.toLocaleTimeString()}
               </span>
-            )}
-            <PrintToPdfButton />
-            <ThemeToggle />
-            <button
-              onClick={async () => {
-                try {
-                  await signOut();
-                } catch (error) {
-                  console.error('Sign out error:', error);
-                }
-              }}
-              className="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-              title="Sign out"
-            >
-              <span className="hidden sm:inline">Sign Out</span>
-              <svg className="w-5 h-5 sm:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-              </svg>
-            </button>
-            <button
-              onClick={() => setShowAbout(true)}
-              className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-              title="About this application"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </button>
-          </div>
-        </header>
+              {loading && (
+                <span className="text-sm text-gray-400 flex items-center gap-2">
+                  <Spinner size="sm" />
+                  <span className="hidden sm:inline">Refreshing</span>
+                </span>
+              )}
+              <PrintToPdfButton />
+              <ThemeToggle />
+              <button
+                onClick={async () => {
+                  try {
+                    await signOut();
+                  } catch (error) {
+                    console.error('Sign out error:', error);
+                  }
+                }}
+                className="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                title="Sign out"
+              >
+                <span className="hidden sm:inline">Sign Out</span>
+                <svg className="w-5 h-5 sm:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                </svg>
+              </button>
+              <button
+                onClick={() => setShowAbout(true)}
+                className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                title="About this application"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
+            </div>
+          </header>
         )}
 
         <div className="p-4 sm:p-6 lg:p-8">
           <div className="max-w-7xl mx-auto">
-            <TabContent
-              activeTab={activeTab}
-              stats={stats}
-              citations={citations}
-              searches={searches}
-              keywords={keywords}
-              setKeywords={setKeywords}
-              schedules={schedules}
-              setSchedules={setSchedules}
-              execution={execution}
-              triggerAnalysis={triggerAnalysis}
-              startMonitoring={startMonitoring}
-              isRunning={isRunning}
-              rawResponsesPath={rawResponsesPath}
-              setActiveTab={setActiveTab}
-              onNavigateToRawResponses={handleNavigateToRawResponses}
-            />
+            {isReportRoute ? (
+              <ReportsRouter keywords={keywords} />
+            ) : (
+              <TabContent
+                activeTab={activeTab}
+                stats={stats}
+                citations={citations}
+                searches={searches}
+                keywords={keywords}
+                setKeywords={setKeywords}
+                schedules={schedules}
+                setSchedules={setSchedules}
+                execution={execution}
+                triggerAnalysis={triggerAnalysis}
+                startMonitoring={startMonitoring}
+                isRunning={isRunning}
+                rawResponsesPath={rawResponsesPath}
+                setActiveTab={setActiveTab}
+                onNavigateToRawResponses={handleNavigateToRawResponses}
+              />
+            )}
           </div>
         </div>
       </main>

--- a/web/src/components/Layout/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar.tsx
@@ -113,6 +113,17 @@ const ContentStudioIcon = () => (
   </svg>
 );
 
+/**
+ * Reporting section icon. A document with a chart line on it: signals that
+ * Reports take live dashboard data and arrange it into print-ready, shareable
+ * deliverables (the section's purpose).
+ */
+const ReportsIcon = () => (
+  <svg className="w-5 h-5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 17v-6m3 6V7m3 10v-4M5 21h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
+  </svg>
+);
+
 export const Sidebar = ({
   activeTab, onTabChange, keywordsCount, schedulesCount, isRunning, isOpen, onToggle 
 }: SidebarProps) => {
@@ -201,6 +212,23 @@ export const Sidebar = ({
           label: 'Content Studio',
           icon: <ContentStudioIcon />,
           iconColor: 'text-teal-500',
+        },
+      ],
+    },
+    {
+      // Reporting groups print-ready deliverables (executive summary, keyword
+      // deep dives, competitor gaps, etc.) under one place. Each report uses
+      // the existing print-to-PDF infrastructure but presents the data in a
+      // narrative layout aimed at a marketing/exec audience rather than the
+      // operational dashboards above.
+      title: 'Reporting',
+      items: [
+        {
+          id: 'reports',
+          path: '/reports',
+          label: 'Reports',
+          icon: <ReportsIcon />,
+          iconColor: 'text-cyan-500',
         },
       ],
     },

--- a/web/src/components/Reports/KeywordDeepDiveReport/KeywordDeepDiveReport.spec.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/KeywordDeepDiveReport.spec.tsx
@@ -1,0 +1,138 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  MemoryRouter, Routes, Route 
+} from 'react-router-dom';
+import { KeywordDeepDiveReport } from './KeywordDeepDiveReport';
+
+vi.mock('./useKeywordDeepDive', () => ({useKeywordDeepDive: vi.fn(),}));
+vi.mock('../../../hooks/usePrintMode', () => ({usePrintMode: vi.fn(() => ({ isPrintMode: false })),}));
+
+import { useKeywordDeepDive } from './useKeywordDeepDive';
+
+const mockUseKeywordDeepDive = useKeywordDeepDive as ReturnType<typeof vi.fn>;
+
+const KEYWORDS = [
+  { keyword: 'best running shoes' },
+  { keyword: 'best hiking boots' },
+];
+
+function settledData() {
+  return {
+    visibility: {
+      keyword: 'best running shoes',
+      timestamp: '2026-05-14T10:00:00Z',
+      total_brands: 0,
+      total_mentions: 0,
+      brands: [],
+      first_party: [],
+      competitors: [],
+      others: [],
+      summary: {
+        first_party_avg_score: 42,
+        competitor_avg_score: 38,
+        first_party_total_sov: 12,
+        competitor_total_sov: 50,
+      },
+    },
+    visibilityError: null,
+    visibilityLoading: false,
+    trends: null,
+    trendsError: null,
+    trendsLoading: false,
+    personas: null,
+    personasError: null,
+    personasLoading: false,
+    mentions: null,
+    mentionsError: null,
+    mentionsLoading: false,
+    gaps: null,
+    gapsError: null,
+    gapsLoading: false,
+    recommendations: null,
+    recommendationsError: null,
+    recommendationsLoading: false,
+    ready: true,
+  };
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/reports/keyword/:keyword"
+          element={
+            <KeywordDeepDiveReport keywords={KEYWORDS as never} />
+          }
+        />
+        <Route
+          path="/reports/keyword"
+          element={
+            <KeywordDeepDiveReport keywords={KEYWORDS as never} />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('KeywordDeepDiveReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseKeywordDeepDive.mockReturnValue(settledData());
+  });
+
+  it('renders the H1 with the keyword from the URL params', () => {
+    renderAt('/reports/keyword/best%20running%20shoes');
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Keyword Deep Dive: best running shoes/,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the headline visibility score from the visibility data', () => {
+    renderAt('/reports/keyword/best%20running%20shoes');
+    expect(screen.getByText('42.0')).toBeInTheDocument();
+  });
+
+  it('renders the headline first-party share-of-voice from the visibility data', () => {
+    renderAt('/reports/keyword/best%20running%20shoes');
+    // first_party_total_sov = 12 in fixture -> rendered as "12.0%".
+    expect(screen.getByText('12.0%')).toBeInTheDocument();
+  });
+
+  it('renders the competitor average score in the headline footnote', () => {
+    renderAt('/reports/keyword/best%20running%20shoes');
+    // competitor_avg_score = 38 in fixture -> footnote "Competitor avg: 38.0".
+    expect(screen.getByText(/Competitor avg: 38\.0/)).toBeInTheDocument();
+  });
+
+  it('renders the keyword selector populated with every configured keyword', () => {
+    renderAt('/reports/keyword/best%20running%20shoes');
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toContain('best running shoes');
+    expect(optionValues).toContain('best hiking boots');
+  });
+
+  it('navigates to a new keyword when the selector changes', async () => {
+    const user = userEvent.setup();
+    renderAt('/reports/keyword/best%20running%20shoes');
+    const select = screen.getAllByRole('combobox')[0];
+    await user.selectOptions(select, 'best hiking boots');
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Keyword Deep Dive: best hiking boots/,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/KeywordDeepDiveReport/KeywordDeepDiveReport.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/KeywordDeepDiveReport.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from 'react';
+import {
+  useNavigate, useParams 
+} from 'react-router-dom';
+import { usePrintMode } from '../../../hooks/usePrintMode';
+import {
+  ReportLayout,
+  ReportKeywordSelector,
+} from '../layout';
+import { useKeywordDeepDive } from './useKeywordDeepDive';
+import { HeadlineSection } from './sections/HeadlineSection';
+import { RankHistorySection } from './sections/RankHistorySection';
+import { PersonaImpactSection } from './sections/PersonaImpactSection';
+import { ProviderDeltaSection } from './sections/ProviderDeltaSection';
+import { TopSourcesSection } from './sections/TopSourcesSection';
+import { SentimentExamplesSection } from './sections/SentimentExamplesSection';
+import { RecommendationsSection } from './sections/RecommendationsSection';
+import type { Keyword } from '../../../types';
+
+interface Props {readonly keywords: ReadonlyArray<Keyword>;}
+
+/**
+ * Keyword Deep Dive report — a printable, single-keyword drill-down for
+ * SEO/AI search leads investigating one specific keyword's ranking story.
+ *
+ * URL contract:
+ *   /reports/keyword           — show selector, no report yet
+ *   /reports/keyword/:keyword  — render the report for that keyword
+ *
+ * Print contract:
+ *   ?print=1 + keyword set + all data hooks settled => auto-fire window.print().
+ *   The MainApp print scheduler is gated off for /reports/* routes so this
+ *   component owns the timing.
+ */
+export function KeywordDeepDiveReport({ keywords }: Props) {
+  const navigate = useNavigate();
+  const params = useParams<{ keyword?: string }>();
+  const selectedKeyword = params.keyword
+    ? decodeURIComponent(params.keyword)
+    : null;
+
+  const data = useKeywordDeepDive(selectedKeyword);
+
+  // Auto-print only fires once `selectedKeyword` is set AND every fetch has
+  // settled. Without the keyword guard the print would fire on the selector
+  // page (`/reports/keyword` with no slug) and produce an empty PDF.
+  usePrintMode({ ready: Boolean(selectedKeyword) && data.ready });
+
+  // When the user lands on the bare `/reports/keyword` and has at least one
+  // keyword configured, auto-select the first so the report has something to
+  // render. Skipping this would force the user to interact with the selector
+  // every time, which is a regression from the dashboard pattern.
+  useEffect(() => {
+    if (!selectedKeyword && keywords.length > 0) {
+      navigate(
+        `/reports/keyword/${encodeURIComponent(keywords[0].keyword)}`,
+        { replace: true },
+      );
+    }
+  }, [selectedKeyword, keywords, navigate]);
+
+  const handleKeywordChange = (keyword: string) => {
+    navigate(`/reports/keyword/${encodeURIComponent(keyword)}`);
+  };
+
+  if (keywords.length === 0) {
+    return (
+      <ReportLayout
+        title="Keyword Deep Dive"
+        subtitle="Configure tracked keywords in Settings to generate this report."
+      >
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No keywords configured. Add at least one keyword in
+          <span className="font-medium"> Settings &rarr; Keywords </span>
+          to generate this report.
+        </p>
+      </ReportLayout>
+    );
+  }
+
+  if (!selectedKeyword) {
+    return (
+      <ReportLayout
+        title="Keyword Deep Dive"
+        subtitle="Pick a keyword to drill into."
+      >
+        <ReportKeywordSelector
+          keywords={keywords}
+          selected={null}
+          onChange={handleKeywordChange}
+        />
+      </ReportLayout>
+    );
+  }
+
+  return (
+    <ReportLayout
+      title={`Keyword Deep Dive: ${selectedKeyword}`}
+      subtitle="Ranking, persona impact, provider differences, top sources, and recommended actions for this keyword."
+      actions={
+        <ReportKeywordSelector
+          keywords={keywords}
+          selected={selectedKeyword}
+          onChange={handleKeywordChange}
+        />
+      }
+    >
+      <HeadlineSection
+        visibility={data.visibility}
+        trends={data.trends}
+        loading={data.visibilityLoading || data.trendsLoading}
+        error={data.visibilityError ?? data.trendsError}
+      />
+      <RankHistorySection
+        trends={data.trends}
+        loading={data.trendsLoading}
+        error={data.trendsError}
+      />
+      <PersonaImpactSection
+        personas={data.personas}
+        loading={data.personasLoading}
+        error={data.personasError}
+      />
+      <ProviderDeltaSection
+        mentions={data.mentions}
+        loading={data.mentionsLoading}
+        error={data.mentionsError}
+      />
+      <TopSourcesSection
+        gaps={data.gaps}
+        mentions={data.mentions}
+        loading={data.gapsLoading || data.mentionsLoading}
+        error={data.gapsError ?? data.mentionsError}
+      />
+      <SentimentExamplesSection
+        mentions={data.mentions}
+        loading={data.mentionsLoading}
+        error={data.mentionsError}
+      />
+      <RecommendationsSection
+        recommendations={data.recommendations}
+        keyword={selectedKeyword}
+        loading={data.recommendationsLoading}
+        error={data.recommendationsError}
+      />
+    </ReportLayout>
+  );
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/index.ts
+++ b/web/src/components/Reports/KeywordDeepDiveReport/index.ts
@@ -1,0 +1,2 @@
+export { KeywordDeepDiveReport } from './KeywordDeepDiveReport';
+export { useKeywordDeepDive } from './useKeywordDeepDive';

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/HeadlineSection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/HeadlineSection.tsx
@@ -1,0 +1,139 @@
+import type {
+  VisibilityMetricsResponse,
+  HistoricalTrendsResponse,
+} from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly visibility: VisibilityMetricsResponse | null;
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * The headline answer to "how is this keyword doing right now?". Shows the
+ * first-party visibility score, the period-over-period change, and the trend
+ * direction. Sized to dominate the first page of the printed report so a
+ * skimmer can lift the bottom-line answer without reading further.
+ */
+export function HeadlineSection({
+  visibility, trends, loading, error,
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="loading" message="Loading visibility…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!visibility) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder
+          variant="empty"
+          message="No visibility data found for this keyword. Run an analysis to populate the report."
+        />
+      </ReportSection>
+    );
+  }
+
+  const score = visibility.summary.first_party_avg_score;
+  const sov = visibility.summary.first_party_total_sov;
+  const competitorScore = visibility.summary.competitor_avg_score;
+
+  const change = trends?.summary.change ?? 0;
+  const direction = trends?.trend_direction ?? 'stable';
+
+  const scoreAccent: 'positive' | 'negative' =
+    score >= competitorScore ? 'positive' : 'negative';
+  const trendAccent = trendAccentFor(direction);
+  const trendFootnote = formatTrendFootnote(change);
+
+  return (
+    <ReportSection title="Headline">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Metric
+          label="First-party visibility"
+          value={`${score.toFixed(1)}`}
+          accent={scoreAccent}
+          footnote={`Competitor avg: ${competitorScore.toFixed(1)}`}
+        />
+        <Metric
+          label="Share of voice"
+          value={`${sov.toFixed(1)}%`}
+          footnote="Across tracked first-party brands"
+        />
+        <Metric
+          label="30-day trend"
+          value={formatTrend(direction, change)}
+          accent={trendAccent}
+          footnote={trendFootnote}
+        />
+      </div>
+    </ReportSection>
+  );
+}
+
+function formatTrendFootnote(change: number): string {
+  if (change === 0) return 'No change since previous period';
+  const sign = change > 0 ? '+' : '';
+  return `${sign}${change.toFixed(1)} since previous period`;
+}
+
+function trendAccentFor(
+  direction: 'improving' | 'declining' | 'stable',
+): 'positive' | 'negative' | 'neutral' {
+  if (direction === 'improving') return 'positive';
+  if (direction === 'declining') return 'negative';
+  return 'neutral';
+}
+
+function Metric({
+  label,
+  value,
+  footnote,
+  accent = 'neutral',
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly footnote: string;
+  readonly accent?: 'positive' | 'negative' | 'neutral';
+}) {
+  const accentClass = {
+    positive: 'text-emerald-700 dark:text-emerald-400',
+    negative: 'text-red-700 dark:text-red-400',
+    neutral: 'text-gray-900 dark:text-white',
+  }[accent];
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800">
+      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className={`text-2xl font-semibold mt-1 ${accentClass}`}>{value}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+        {footnote}
+      </p>
+    </div>
+  );
+}
+
+function formatTrend(
+  direction: 'improving' | 'declining' | 'stable',
+  change: number,
+): string {
+  if (direction === 'improving') return 'Improving';
+  if (direction === 'declining') return 'Declining';
+  return change === 0 ? 'Stable' : 'Stable (volatile)';
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/PersonaImpactSection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/PersonaImpactSection.tsx
@@ -1,0 +1,134 @@
+import type { PersonaRankingsResponse } from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly personas: PersonaRankingsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Persona impact only earns a slot in the report when persona choice
+ * actually changes the ranking story. If every persona ranks first-party
+ * brands roughly the same, we suppress the section to avoid bloating the
+ * report with a table that says "personas don't matter here".
+ *
+ * Threshold: at least one first-party brand has a best/worst rank delta
+ * of >= 3 across personas. That's enough for a marketer to consider
+ * tweaking persona prompts to favor the better-performing one.
+ */
+const MEANINGFUL_DELTA = 3;
+
+export function PersonaImpactSection({
+  personas, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Persona impact">
+        <SectionPlaceholder variant="loading" message="Loading persona breakdown…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Persona impact">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!personas || personas.personas.length <= 1) {
+    return null;
+  }
+
+  const firstParty = personas.cross_persona_summary.brands.filter(
+    (brand) => brand.classification === 'first_party',
+  );
+
+  if (firstParty.length === 0) {
+    return null;
+  }
+
+  const meaningful = firstParty.some(
+    (brand) => brand.worst_rank - brand.best_rank >= MEANINGFUL_DELTA,
+  );
+
+  if (!meaningful) {
+    return (
+      <ReportSection
+        title="Persona impact"
+        subtitle="Persona choice does not materially change ranking for this keyword."
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          First-party brands rank within{' '}
+          <span className="font-medium">{MEANINGFUL_DELTA}</span>{' '}
+          positions across all configured personas — persona-specific
+          optimisation is unlikely to move the needle here.
+        </p>
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Persona impact"
+      subtitle="Where in your persona library does this keyword perform best, and where does it slip?"
+    >
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>First-party brand</Th>
+              <Th>Best rank</Th>
+              <Th>Worst rank</Th>
+              <Th>Δ</Th>
+              <Th>Best persona</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {firstParty.map((brand) => {
+              const delta = brand.worst_rank - brand.best_rank;
+              const highlight = delta >= MEANINGFUL_DELTA;
+              return (
+                <tr
+                  key={brand.name}
+                  className={highlight ? 'bg-amber-50 dark:bg-amber-950/20' : ''}
+                >
+                  <Td className="font-medium">{brand.name}</Td>
+                  <Td>{brand.best_rank}</Td>
+                  <Td>{brand.worst_rank}</Td>
+                  <Td>{delta}</Td>
+                  <Td>{brand.best_persona}</Td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/ProviderDeltaSection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/ProviderDeltaSection.tsx
@@ -1,0 +1,119 @@
+import type { BrandMentionsResponse } from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly mentions: BrandMentionsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Per-provider ranking breakdown for first-party brands. Shows where each AI
+ * engine places your brand and where it does not appear at all (a "—" cell
+ * is more actionable than a missing row, because it surfaces invisibility).
+ *
+ * If first-party brands aren't configured, the section explains why nothing
+ * is shown rather than rendering a confusing empty table.
+ */
+export function ProviderDeltaSection({
+  mentions, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Provider differences">
+        <SectionPlaceholder variant="loading" message="Loading provider data…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Provider differences">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!mentions) {
+    return null;
+  }
+
+  const firstParty = mentions.aggregated.first_party_brands;
+  if (firstParty.length === 0) {
+    return (
+      <ReportSection title="Provider differences">
+        <SectionPlaceholder
+          variant="empty"
+          message="No first-party brand mentions for this keyword. Either the brand isn't appearing in any AI response, or no first-party brands are configured."
+        />
+      </ReportSection>
+    );
+  }
+
+  // Stable provider list across all first-party brands to anchor the columns.
+  const providers = Array.from(
+    new Set(firstParty.flatMap((brand) => brand.providers)),
+  ).sort((a, b) => a.localeCompare(b));
+
+  return (
+    <ReportSection
+      title="Provider differences"
+      subtitle="Where each AI engine ranks your first-party brands."
+    >
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>Brand</Th>
+              {providers.map((provider) => (
+                <Th key={provider}>{provider}</Th>
+              ))}
+              <Th>Best rank</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {firstParty.map((brand) => (
+              <tr key={brand.name}>
+                <Td className="font-medium">{brand.name}</Td>
+                {providers.map((provider) => {
+                  const appearance = brand.appearances.find(
+                    (a) => a.provider === provider,
+                  );
+                  return (
+                    <Td key={provider}>
+                      {appearance ? `#${appearance.rank}` : '—'}
+                    </Td>
+                  );
+                })}
+                <Td className="font-medium">#{brand.best_rank}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/RankHistorySection.spec.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/RankHistorySection.spec.tsx
@@ -1,0 +1,110 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { RankHistorySection } from './RankHistorySection';
+import type {
+  HistoricalTrendsResponse, TrendDataPoint 
+} from '../../../../types';
+
+function buildPoint(period: string, score: number): TrendDataPoint {
+  return {
+    period,
+    visibility_score: score,
+    total_mentions: 1,
+    provider_count: 1,
+    best_rank: 1,
+    analysis_runs: 1,
+  };
+}
+
+function buildTrends(points: TrendDataPoint[]): HistoricalTrendsResponse {
+  const scores = points.map((p) => p.visibility_score);
+  return {
+    period_type: 'day',
+    days_analyzed: 30,
+    data_points: points.length,
+    trend_data: points,
+    trend_direction: 'stable',
+    summary: {
+      current_score: scores[scores.length - 1] ?? 0,
+      previous_score: scores[scores.length - 2] ?? 0,
+      change: 0,
+      change_percent: 0,
+      average_score: scores.reduce((a, b) => a + b, 0) / Math.max(scores.length, 1),
+      max_score: Math.max(...scores, 0),
+      min_score: Math.min(...scores, 0),
+    },
+  };
+}
+
+describe('RankHistorySection — sampling', () => {
+  it('renders every row when point count is below the cap', () => {
+    const points = Array.from({ length: 5 }, (_, i) =>
+      buildPoint(`2026-05-0${i + 1}`, 50 + i),
+    );
+    render(
+      <RankHistorySection trends={buildTrends(points)} loading={false} error={null} />,
+    );
+    // 5 data rows + 1 header row.
+    expect(screen.getAllByRole('row')).toHaveLength(6);
+  });
+
+  it('caps the table at 14 rows when point count exceeds the cap', () => {
+    const points = Array.from({ length: 30 }, (_, i) =>
+      buildPoint(`d-${i.toString().padStart(2, '0')}`, 40 + i),
+    );
+    render(
+      <RankHistorySection trends={buildTrends(points)} loading={false} error={null} />,
+    );
+    // 14 sampled data rows + 1 header row.
+    expect(screen.getAllByRole('row')).toHaveLength(15);
+  });
+
+  it('keeps the first and last data points when sampling', () => {
+    const points = Array.from({ length: 30 }, (_, i) =>
+      buildPoint(`d-${i.toString().padStart(2, '0')}`, 40 + i),
+    );
+    render(
+      <RankHistorySection trends={buildTrends(points)} loading={false} error={null} />,
+    );
+    expect(screen.getByText('d-00')).toBeInTheDocument();
+    expect(screen.getByText('d-29')).toBeInTheDocument();
+  });
+});
+
+describe('RankHistorySection — placeholder states', () => {
+  it('renders empty state when trend_data is empty', () => {
+    render(
+      <RankHistorySection
+        trends={buildTrends([])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/at least two analysis runs/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state when trends is null', () => {
+    render(
+      <RankHistorySection trends={null} loading={false} error={null} />,
+    );
+    expect(screen.getByText(/at least two analysis runs/i)).toBeInTheDocument();
+  });
+
+  it('renders loading state when loading is true', () => {
+    render(
+      <RankHistorySection trends={null} loading error={null} />,
+    );
+    expect(screen.getByText(/Loading trend data/i)).toBeInTheDocument();
+  });
+
+  it('renders error message when error is set', () => {
+    render(
+      <RankHistorySection trends={null} loading={false} error="Network blew up" />,
+    );
+    expect(screen.getByText(/Network blew up/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/RankHistorySection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/RankHistorySection.tsx
@@ -1,0 +1,131 @@
+import type { HistoricalTrendsResponse } from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * 30-day visibility-score history. Renders as a compact table rather than a
+ * chart for the first version: tables print reliably to PDF without canvas
+ * sizing surprises and are easier to scan in a printed report.
+ *
+ * We sample at most 14 evenly spaced points so the table fits on a page
+ * even for accounts with many analysis runs per day. The summary line above
+ * the table preserves the exact min/max/average so detail isn't lost.
+ */
+const MAX_ROWS = 14;
+
+export function RankHistorySection({
+  trends, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection
+        title="Rank history"
+        subtitle="How this keyword's visibility has moved over the last 30 days."
+      >
+        <SectionPlaceholder variant="loading" message="Loading trend data…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Rank history">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  const trendData = trends?.trend_data ?? [];
+  if (trendData.length === 0) {
+    return (
+      <ReportSection title="Rank history">
+        <SectionPlaceholder
+          variant="empty"
+          message="Not enough history yet — at least two analysis runs are needed to draw a trend."
+        />
+      </ReportSection>
+    );
+  }
+
+  const sampled = sampleEvenly(trendData, MAX_ROWS);
+  const summary = trends?.summary;
+
+  return (
+    <ReportSection
+      title="Rank history"
+      subtitle="How this keyword's visibility has moved over the last 30 days."
+    >
+      {summary && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+          Average score{' '}
+          <span className="font-medium text-gray-900 dark:text-white">
+            {summary.average_score.toFixed(1)}
+          </span>
+          {' · '}
+          Range{' '}
+          <span className="font-medium text-gray-900 dark:text-white">
+            {summary.min_score.toFixed(1)}–{summary.max_score.toFixed(1)}
+          </span>
+        </p>
+      )}
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>Period</Th>
+              <Th>Score</Th>
+              <Th>Mentions</Th>
+              <Th>Best rank</Th>
+              <Th>Providers</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {sampled.map((point) => (
+              <tr key={point.period}>
+                <Td>{point.period}</Td>
+                <Td className="font-medium">{point.visibility_score.toFixed(1)}</Td>
+                <Td>{point.total_mentions}</Td>
+                <Td>{point.best_rank ?? '—'}</Td>
+                <Td>{point.provider_count}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}
+
+function sampleEvenly<T>(items: ReadonlyArray<T>, max: number): T[] {
+  if (items.length <= max) return [...items];
+  const step = (items.length - 1) / (max - 1);
+  return Array.from({ length: max }, (_, i) => items[Math.round(i * step)]);
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/RecommendationsSection.spec.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/RecommendationsSection.spec.tsx
@@ -1,0 +1,201 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { RecommendationsSection } from './RecommendationsSection';
+import type {
+  Recommendation,
+  RecommendationsResponse,
+} from '../../../../types';
+
+/**
+ * RecommendationsSection has non-trivial filtering logic: it pulls a
+ * global recommendations list and narrows it to the report's keyword.
+ * These tests pin the filtering rules end-to-end through render output
+ * because the rules are easy to break with a regex tweak or a sort
+ * change.
+ */
+
+function buildRecResponse(
+  recs: Recommendation[],
+): RecommendationsResponse {
+  return {
+    generated_at: '2026-05-14T00:00:00Z',
+    recommendations: recs,
+    total_count: recs.length,
+    by_priority: {
+      high: recs.filter((r) => r.priority === 'high').length,
+      medium: recs.filter((r) => r.priority === 'medium').length,
+      low: recs.filter((r) => r.priority === 'low').length,
+    },
+  };
+}
+
+const KEYWORD_SCOPED: Recommendation = {
+  type: 'gap',
+  priority: 'high',
+  title: 'Pitch outdoor publishers',
+  description: 'd',
+  action: 'a',
+  impact: 'i',
+  keywords: ['best running shoes (rank 3)'],
+};
+
+const OTHER_KEYWORD_SCOPED: Recommendation = {
+  type: 'gap',
+  priority: 'high',
+  title: 'Different keyword item',
+  description: 'd',
+  action: 'a',
+  impact: 'i',
+  keywords: ['best hiking boots'],
+};
+
+const GLOBAL_REC: Recommendation = {
+  type: 'config',
+  priority: 'medium',
+  title: 'Add Spanish brand variants',
+  description: 'd',
+  action: 'a',
+  impact: 'i',
+  // No keywords array => global, always included.
+};
+
+const LOW_PRIORITY_SCOPED: Recommendation = {
+  type: 'content',
+  priority: 'low',
+  title: 'Update product page copy',
+  description: 'd',
+  action: 'a',
+  impact: 'i',
+  keywords: ['best running shoes'],
+};
+
+describe('RecommendationsSection — filtering', () => {
+  it('renders recommendations whose keywords array matches the report keyword', () => {
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([KEYWORD_SCOPED])}
+        keyword="best running shoes"
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('Pitch outdoor publishers')).toBeInTheDocument();
+  });
+
+  it('hides recommendations scoped to a different keyword', () => {
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([OTHER_KEYWORD_SCOPED])}
+        keyword="best running shoes"
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.queryByText('Different keyword item'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('always includes recommendations with no keywords array (global)', () => {
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([GLOBAL_REC])}
+        keyword="best running shoes"
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('Add Spanish brand variants')).toBeInTheDocument();
+  });
+
+  it('matches even when the keywords entry has trailing rank annotation', () => {
+    // Real API output: "best running shoes (rank 3)" — the section uses a
+    // case-insensitive substring match so this should still fire.
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([KEYWORD_SCOPED])}
+        keyword="BEST RUNNING SHOES"
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('Pitch outdoor publishers')).toBeInTheDocument();
+  });
+});
+
+describe('RecommendationsSection — ordering and empty states', () => {
+  it('orders matched recommendations by priority high -> medium -> low', () => {
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([
+          LOW_PRIORITY_SCOPED,
+          KEYWORD_SCOPED,
+          GLOBAL_REC,
+        ])}
+        keyword="best running shoes"
+        loading={false}
+        error={null}
+      />,
+    );
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('Pitch outdoor publishers');
+    expect(items[1]).toHaveTextContent('Add Spanish brand variants');
+    expect(items[2]).toHaveTextContent('Update product page copy');
+  });
+
+  it('renders the empty state when no recommendations exist at all', () => {
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([])}
+        keyword="best running shoes"
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByText(/No recommendations generated yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the keyword-specific empty state when global list is non-empty but nothing matches', () => {
+    render(
+      <RecommendationsSection
+        recommendations={buildRecResponse([OTHER_KEYWORD_SCOPED])}
+        keyword="best running shoes"
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByText(/none reference/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the loading placeholder when loading is true', () => {
+    render(
+      <RecommendationsSection
+        recommendations={null}
+        keyword="best running shoes"
+        loading
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/Loading recommendations/i)).toBeInTheDocument();
+  });
+
+  it('renders the error placeholder when error is set', () => {
+    render(
+      <RecommendationsSection
+        recommendations={null}
+        keyword="best running shoes"
+        loading={false}
+        error="Network down"
+      />,
+    );
+    expect(screen.getByText(/Network down/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/RecommendationsSection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/RecommendationsSection.tsx
@@ -1,0 +1,139 @@
+import type { RecommendationsResponse } from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly recommendations: RecommendationsResponse | null;
+  readonly keyword: string;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const PRIORITY_ORDER = {
+  high: 0,
+  medium: 1,
+  low: 2 
+} as const;
+
+/**
+ * The Recommendations endpoint generates *global* recommendations across all
+ * tracked keywords. We filter client-side to the recommendations whose
+ * `keywords` array references the report's current keyword, so this section
+ * stays scoped to the page it lives on. Configuration / data-quality
+ * recommendations (no `keywords` array) are kept because they apply
+ * regardless of which keyword the user is reading about.
+ */
+export function RecommendationsSection({
+  recommendations, keyword, loading, error,
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Recommended actions">
+        <SectionPlaceholder variant="loading" message="Loading recommendations…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Recommended actions">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!recommendations || recommendations.recommendations.length === 0) {
+    return (
+      <ReportSection title="Recommended actions">
+        <SectionPlaceholder
+          variant="empty"
+          message="No recommendations generated yet. Run an analysis or wait for the next scheduled run."
+        />
+      </ReportSection>
+    );
+  }
+
+  const relevant = recommendations.recommendations
+    .filter((rec) => {
+      // No keywords array => global recommendation, always include.
+      if (!rec.keywords || rec.keywords.length === 0) return true;
+      // Match against the report's keyword. The Recommendations endpoint
+      // sometimes annotates entries with "keyword (rank N)" so we use a
+      // substring match on a lowercased copy.
+      const lowerKeyword = keyword.toLowerCase();
+      return rec.keywords.some((entry) =>
+        entry.toLowerCase().includes(lowerKeyword),
+      );
+    })
+    .sort(
+      (a, b) =>
+        PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority],
+    );
+
+  if (relevant.length === 0) {
+    return (
+      <ReportSection
+        title="Recommended actions"
+        subtitle="No keyword-specific recommendations from the latest analysis."
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          The Action Center has{' '}
+          <span className="font-medium">{recommendations.total_count}</span>{' '}
+          recommendations across all keywords, but none reference{' '}
+          <span className="font-medium">{keyword}</span> specifically.
+        </p>
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Recommended actions"
+      subtitle="What to do next, sorted by priority. Pulled from the Action Center; filtered to this keyword."
+    >
+      <ol className="space-y-3">
+        {relevant.map((rec) => (
+          <li
+            key={`${rec.title}::${rec.action}`}
+            className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800"
+          >
+            <div className="flex items-start gap-3">
+              <PriorityBadge priority={rec.priority} />
+              <div className="min-w-0 flex-1">
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+                  {rec.title}
+                </h3>
+                <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">
+                  {rec.description}
+                </p>
+                <p className="text-sm text-gray-900 dark:text-white mt-2">
+                  <span className="font-medium">Action: </span>
+                  {rec.action}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                  Expected impact: {rec.impact}
+                </p>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </ReportSection>
+  );
+}
+
+function PriorityBadge({ priority }: { readonly priority: 'high' | 'medium' | 'low' }) {
+  const styles = {
+    high: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+    medium: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+    low: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  }[priority];
+
+  return (
+    <span
+      className={`flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold uppercase ${styles}`}
+    >
+      {priority}
+    </span>
+  );
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/SectionPlaceholder.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/SectionPlaceholder.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+
+interface Props {
+  readonly variant: 'loading' | 'error' | 'empty';
+  readonly message: string;
+}
+
+/**
+ * Shared rendering helpers for Keyword Deep Dive sections.
+ *
+ * Each section follows the same pattern: a fetch may be loading, may have
+ * errored, or may be missing data even after settling. Centralising the
+ * three placeholder messages keeps the section components themselves focused
+ * on their actual layout work.
+ */
+export function SectionPlaceholder({
+  variant, message 
+}: Props): ReactElement {
+  const baseClass = 'text-sm rounded border px-4 py-3';
+  const variantClass =
+    variant === 'error'
+      ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300'
+      : 'border-gray-200 bg-gray-50 text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400';
+  return <div className={`${baseClass} ${variantClass}`}>{message}</div>;
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/SentimentExamplesSection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/SentimentExamplesSection.tsx
@@ -1,0 +1,149 @@
+import type { BrandMentionsResponse } from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly mentions: BrandMentionsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+interface SentimentExample {
+  brand: string;
+  provider: string;
+  sentiment: string;
+  reason: string;
+  rankingContext?: string;
+}
+
+const SENTIMENT_ORDER = ['negative', 'positive', 'mixed', 'neutral'] as const;
+const MAX_EXAMPLES_PER_POLARITY = 2;
+
+/**
+ * Surface representative sentiment examples — what AI engines actually said
+ * about first-party brands when they ranked them. Negative examples come
+ * first because those are the ones a marketer needs to act on; positive
+ * examples confirm what's working and provide language to amplify.
+ *
+ * We pull from the per-provider `appearances` array on each first-party
+ * brand so the quotes stay tied to a specific provider/rank. Examples
+ * without a `sentiment_reason` are skipped — a sentiment label without a
+ * reason is not useful in a printed report.
+ */
+export function SentimentExamplesSection({
+  mentions, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Sentiment examples">
+        <SectionPlaceholder variant="loading" message="Loading sentiment data…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Sentiment examples">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!mentions) {
+    return null;
+  }
+
+  const examples = collectExamples(mentions.aggregated.first_party_brands);
+
+  if (examples.length === 0) {
+    return (
+      <ReportSection
+        title="Sentiment examples"
+        subtitle="No sentiment annotations were extracted from this keyword's responses."
+      >
+        <SectionPlaceholder
+          variant="empty"
+          message="Sentiment extraction may be disabled, or AI responses for this keyword may not have produced annotated mentions."
+        />
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Sentiment examples"
+      subtitle="What AI engines actually said about your brands. Negatives first — those are the ones to act on."
+    >
+      <div className="space-y-3">
+        {examples.map((example) => (
+          <ExampleCard
+            key={`${example.brand}::${example.provider}::${example.sentiment}::${example.reason}`}
+            example={example}
+          />
+        ))}
+      </div>
+    </ReportSection>
+  );
+}
+
+function collectExamples(brands: BrandMentionsResponse['aggregated']['first_party_brands']): SentimentExample[] {
+  const grouped: Record<string, SentimentExample[]> = {};
+  for (const polarity of SENTIMENT_ORDER) grouped[polarity] = [];
+
+  for (const brand of brands) {
+    for (const appearance of brand.appearances) {
+      const polarity = (appearance.sentiment ?? 'neutral').toLowerCase();
+      if (!appearance.sentiment_reason) continue;
+      const bucket = grouped[polarity];
+      if (!bucket || bucket.length >= MAX_EXAMPLES_PER_POLARITY) continue;
+      bucket.push({
+        brand: brand.name,
+        provider: appearance.provider,
+        sentiment: polarity,
+        reason: appearance.sentiment_reason,
+        rankingContext: appearance.ranking_context,
+      });
+    }
+  }
+
+  // Negative first, then positive, then mixed, then neutral.
+  return SENTIMENT_ORDER.flatMap((polarity) => grouped[polarity] ?? []);
+}
+
+function ExampleCard({ example }: { readonly example: SentimentExample }) {
+  const accent = accentClassFor(example.sentiment);
+
+  return (
+    <div className={`border ${accent} rounded-lg p-4`}>
+      <div className="flex items-center gap-2 mb-2 text-xs">
+        <span className="font-semibold text-gray-900 dark:text-white">
+          {example.brand}
+        </span>
+        <span className="text-gray-500 dark:text-gray-400">
+          on {example.provider}
+        </span>
+        <span className="px-2 py-0.5 rounded-full text-xs font-medium uppercase tracking-wide text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700">
+          {example.sentiment}
+        </span>
+      </div>
+      <p className="text-sm text-gray-800 dark:text-gray-200 italic">
+        “{example.reason}”
+      </p>
+      {example.rankingContext && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          Ranking context: {example.rankingContext}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function accentClassFor(sentiment: string): string {
+  if (sentiment === 'negative') {
+    return 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/20';
+  }
+  if (sentiment === 'positive') {
+    return 'border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/20';
+  }
+  return 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800';
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/sections/TopSourcesSection.tsx
+++ b/web/src/components/Reports/KeywordDeepDiveReport/sections/TopSourcesSection.tsx
@@ -1,0 +1,156 @@
+import type {
+  BrandMentionsResponse,
+  CitationGapsResponse,
+} from '../../../../types';
+import { ReportSection } from '../../layout';
+import { SectionPlaceholder } from './SectionPlaceholder';
+
+interface Props {
+  readonly gaps: CitationGapsResponse | null;
+  readonly mentions: BrandMentionsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const MAX_SUPPORTING = 8;
+const MAX_GAPS = 8;
+
+/**
+ * Two stacked tables: the URLs that already cite first-party brands for this
+ * keyword (so we know what's working), and the URLs that only cite
+ * competitors (where the work to be done lives). Showing both side-by-side
+ * frames the action plan: "double down on the left list, target the right".
+ *
+ * The first list comes from `gaps.covered_sources` because the citation-gaps
+ * endpoint already groups sources by whether first-party brands appear on
+ * them; reusing that classification keeps the two lists internally
+ * consistent (no source can show up on both).
+ */
+export function TopSourcesSection({
+  gaps, mentions, loading, error,
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Top sources">
+        <SectionPlaceholder variant="loading" message="Loading citation sources…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Top sources">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!gaps) {
+    return null;
+  }
+
+  const supporting = (gaps.covered_sources ?? []).slice(0, MAX_SUPPORTING);
+  const competitorOnly = (gaps.gaps ?? []).slice(0, MAX_GAPS);
+
+  if (supporting.length === 0 && competitorOnly.length === 0) {
+    return (
+      <ReportSection title="Top sources">
+        <SectionPlaceholder
+          variant="empty"
+          message="No citation sources have been crawled for this keyword yet."
+        />
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Top sources"
+      subtitle="Where citations come from for this keyword — both the wins and the gaps."
+    >
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <SourceList
+          heading="Supporting first-party brands"
+          tone="positive"
+          items={supporting}
+          emptyMessage="No sources currently cite your brand for this keyword."
+        />
+        <SourceList
+          heading="Citing competitors only"
+          tone="negative"
+          items={competitorOnly}
+          emptyMessage="No sources cite competitors without also citing first-party brands. Strong position."
+        />
+      </div>
+      {mentions?.config?.tracked_brands.competitors.length === 0 && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+          Note: no competitors are configured. The right-hand list is calculated
+          against the LLM-classified competitor labels in the response, not your
+          tracked competitor list.
+        </p>
+      )}
+    </ReportSection>
+  );
+}
+
+function SourceList({
+  heading,
+  tone,
+  items,
+  emptyMessage,
+}: {
+  readonly heading: string;
+  readonly tone: 'positive' | 'negative';
+  readonly items: ReadonlyArray<{
+    url: string;
+    domain: string;
+    citation_count: number;
+    provider_count: number;
+  }>;
+  readonly emptyMessage: string;
+}) {
+  const accentClass =
+    tone === 'positive'
+      ? 'border-emerald-200 dark:border-emerald-800'
+      : 'border-amber-200 dark:border-amber-800';
+
+  return (
+    <div
+      className={`border ${accentClass} rounded-lg p-4 bg-white dark:bg-gray-800`}
+    >
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+        {heading}
+      </h3>
+      {items.length === 0 ? (
+        <p className="text-xs text-gray-500 dark:text-gray-400">{emptyMessage}</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((source) => (
+            <li
+              key={source.url}
+              className="flex items-start justify-between gap-3 text-xs"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-gray-900 dark:text-white truncate">
+                  {source.domain}
+                </p>
+                <p className="text-gray-500 dark:text-gray-400 truncate">
+                  {source.url}
+                </p>
+              </div>
+              <div className="text-right flex-shrink-0">
+                <p className="text-gray-700 dark:text-gray-300">
+                  {source.citation_count}× cited
+                </p>
+                <p className="text-gray-500 dark:text-gray-400">
+                  {source.provider_count} provider
+                  {source.provider_count === 1 ? '' : 's'}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Reports/KeywordDeepDiveReport/useKeywordDeepDive.spec.ts
+++ b/web/src/components/Reports/KeywordDeepDiveReport/useKeywordDeepDive.spec.ts
@@ -1,0 +1,156 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import {
+  renderHook, act 
+} from '@testing-library/react';
+import { useKeywordDeepDive } from './useKeywordDeepDive';
+
+vi.mock('../../../hooks/useVisibilityMetrics', () => ({useVisibilityMetrics: vi.fn(),}));
+vi.mock('../../../hooks/useHistoricalTrends', () => ({useHistoricalTrends: vi.fn(),}));
+vi.mock('../../../hooks/usePersonaRankings', () => ({usePersonaRankings: vi.fn(),}));
+vi.mock('../../../hooks/useBrandMentions', () => ({useBrandMentions: vi.fn(),}));
+vi.mock('../../../hooks/useCitationGaps', () => ({useCitationGaps: vi.fn(),}));
+vi.mock('../../../hooks/useRecommendations', () => ({useRecommendations: vi.fn(),}));
+
+import { useVisibilityMetrics } from '../../../hooks/useVisibilityMetrics';
+import { useHistoricalTrends } from '../../../hooks/useHistoricalTrends';
+import { usePersonaRankings } from '../../../hooks/usePersonaRankings';
+import { useBrandMentions } from '../../../hooks/useBrandMentions';
+import { useCitationGaps } from '../../../hooks/useCitationGaps';
+import { useRecommendations } from '../../../hooks/useRecommendations';
+
+const mockVisibility = useVisibilityMetrics as ReturnType<typeof vi.fn>;
+const mockTrends = useHistoricalTrends as ReturnType<typeof vi.fn>;
+const mockPersonas = usePersonaRankings as ReturnType<typeof vi.fn>;
+const mockMentions = useBrandMentions as ReturnType<typeof vi.fn>;
+const mockGaps = useCitationGaps as ReturnType<typeof vi.fn>;
+const mockRecommendations = useRecommendations as ReturnType<typeof vi.fn>;
+
+function settledSlice(data: unknown) {
+  return {
+    data,
+    loading: false,
+    error: null 
+  };
+}
+
+describe('useKeywordDeepDive', () => {
+  const fetchVisibility = vi.fn();
+  const fetchTrends = vi.fn();
+  const fetchPersonas = vi.fn();
+  const fetchGaps = vi.fn();
+  const fetchRecs = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVisibility.mockReturnValue({
+      ...settledSlice({ keyword: 'foo' }),
+      fetchVisibilityMetrics: fetchVisibility,
+    });
+    mockTrends.mockReturnValue({
+      ...settledSlice({ trend_data: [] }),
+      fetchHistoricalTrends: fetchTrends,
+    });
+    mockPersonas.mockReturnValue({
+      ...settledSlice({ personas: [] }),
+      fetchPersonaRankings: fetchPersonas,
+    });
+    mockMentions.mockReturnValue(settledSlice({ aggregated: {} }));
+    mockGaps.mockReturnValue({
+      ...settledSlice({ gaps: [] }),
+      fetchCitationGaps: fetchGaps,
+    });
+    mockRecommendations.mockReturnValue({
+      ...settledSlice({ recommendations: [] }),
+      fetchRecommendations: fetchRecs,
+    });
+  });
+
+  it('does not fetch visibility, trends, or personas when keyword is null', () => {
+    renderHook(() => useKeywordDeepDive(null));
+    expect(fetchVisibility).not.toHaveBeenCalled();
+    expect(fetchTrends).not.toHaveBeenCalled();
+    expect(fetchPersonas).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch gaps or recommendations when keyword is null', () => {
+    renderHook(() => useKeywordDeepDive(null));
+    expect(fetchGaps).not.toHaveBeenCalled();
+    expect(fetchRecs).not.toHaveBeenCalled();
+  });
+
+  it('fires visibility, trends, and persona fetches when keyword is supplied', () => {
+    renderHook(() => useKeywordDeepDive('best running shoes'));
+    expect(fetchVisibility).toHaveBeenCalledWith('best running shoes');
+    expect(fetchTrends).toHaveBeenCalledWith('best running shoes', 'day', 30);
+    expect(fetchPersonas).toHaveBeenCalledWith('best running shoes');
+  });
+
+  it('fires gap and recommendation fetches when keyword is supplied', () => {
+    renderHook(() => useKeywordDeepDive('best running shoes'));
+    expect(fetchGaps).toHaveBeenCalledWith('best running shoes');
+    expect(fetchRecs).toHaveBeenCalledWith(false);
+  });
+
+  it('refetches every slice when the keyword changes', () => {
+    const { rerender } = renderHook(
+      ({ keyword }: { keyword: string | null }) => useKeywordDeepDive(keyword),
+      { initialProps: { keyword: 'first' } },
+    );
+    fetchVisibility.mockClear();
+    fetchTrends.mockClear();
+    fetchPersonas.mockClear();
+    fetchGaps.mockClear();
+    act(() => {
+      rerender({ keyword: 'second' });
+    });
+    expect(fetchVisibility).toHaveBeenCalledWith('second');
+    expect(fetchTrends).toHaveBeenCalledWith('second', 'day', 30);
+    expect(fetchPersonas).toHaveBeenCalledWith('second');
+    expect(fetchGaps).toHaveBeenCalledWith('second');
+  });
+
+  it('refetches recommendations when the keyword changes', () => {
+    const { rerender } = renderHook(
+      ({ keyword }: { keyword: string | null }) => useKeywordDeepDive(keyword),
+      { initialProps: { keyword: 'first' } },
+    );
+    fetchRecs.mockClear();
+    act(() => {
+      rerender({ keyword: 'second' });
+    });
+    expect(fetchRecs).toHaveBeenCalledWith(false);
+  });
+
+  it('does not refetch when keyword is unchanged across renders', () => {
+    const { rerender } = renderHook(
+      ({ keyword }: { keyword: string | null }) => useKeywordDeepDive(keyword),
+      { initialProps: { keyword: 'stable' } },
+    );
+    fetchVisibility.mockClear();
+    act(() => {
+      rerender({ keyword: 'stable' });
+    });
+    expect(fetchVisibility).not.toHaveBeenCalled();
+  });
+
+  it('reports ready=true once every slice has settled with data', () => {
+    const { result } = renderHook(() =>
+      useKeywordDeepDive('best running shoes'),
+    );
+    expect(result.current.ready).toBe(true);
+  });
+
+  it('reports ready=false when one slice is still loading', () => {
+    mockMentions.mockReturnValue({
+      data: null,
+      loading: true,
+      error: null 
+    });
+    const { result } = renderHook(() =>
+      useKeywordDeepDive('best running shoes'),
+    );
+    expect(result.current.ready).toBe(false);
+  });
+});

--- a/web/src/components/Reports/KeywordDeepDiveReport/useKeywordDeepDive.ts
+++ b/web/src/components/Reports/KeywordDeepDiveReport/useKeywordDeepDive.ts
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+import { useVisibilityMetrics } from '../../../hooks/useVisibilityMetrics';
+import { useHistoricalTrends } from '../../../hooks/useHistoricalTrends';
+import { usePersonaRankings } from '../../../hooks/usePersonaRankings';
+import { useBrandMentions } from '../../../hooks/useBrandMentions';
+import { useCitationGaps } from '../../../hooks/useCitationGaps';
+import { useRecommendations } from '../../../hooks/useRecommendations';
+import { useReportReady } from '../layout/useReportReady';
+
+/**
+ * Compose every fetch the Keyword Deep Dive report needs into a single hook.
+ *
+ * Each underlying hook owns its own loading state, error message, and data
+ * shape. We re-trigger them when `keyword` changes and roll all loading
+ * flags into one `ready` boolean for the auto-print scheduler.
+ *
+ * `useBrandMentions` is auto-fetching (it watches `keyword` itself) while
+ * the other hooks are imperative — we drive their `fetch...` callbacks from
+ * the effect below.
+ */
+export function useKeywordDeepDive(keyword: string | null) {
+  const visibility = useVisibilityMetrics();
+  const trends = useHistoricalTrends();
+  const personas = usePersonaRankings();
+  const gaps = useCitationGaps();
+  const recommendations = useRecommendations();
+
+  const mentions = useBrandMentions(keyword);
+
+  const fetchVisibility = visibility.fetchVisibilityMetrics;
+  const fetchTrends = trends.fetchHistoricalTrends;
+  const fetchPersonas = personas.fetchPersonaRankings;
+  const fetchGaps = gaps.fetchCitationGaps;
+  const fetchRecs = recommendations.fetchRecommendations;
+
+  useEffect(() => {
+    if (!keyword) return;
+    fetchVisibility(keyword);
+    fetchTrends(keyword, 'day', 30);
+    fetchPersonas(keyword);
+    fetchGaps(keyword);
+    fetchRecs(false);
+  }, [
+    keyword,
+    fetchVisibility,
+    fetchTrends,
+    fetchPersonas,
+    fetchGaps,
+    fetchRecs,
+  ]);
+
+  const ready = useReportReady([
+    visibility,
+    trends,
+    personas,
+    mentions,
+    gaps,
+    recommendations,
+  ]);
+
+  return {
+    visibility: visibility.data,
+    visibilityError: visibility.error,
+    visibilityLoading: visibility.loading,
+    trends: trends.data,
+    trendsError: trends.error,
+    trendsLoading: trends.loading,
+    personas: personas.data,
+    personasError: personas.error,
+    personasLoading: personas.loading,
+    mentions: mentions.data,
+    mentionsError: mentions.error,
+    mentionsLoading: mentions.loading,
+    gaps: gaps.data,
+    gapsError: gaps.error,
+    gapsLoading: gaps.loading,
+    recommendations: recommendations.data,
+    recommendationsError: recommendations.error,
+    recommendationsLoading: recommendations.loading,
+    ready,
+  };
+}
+
+export type KeywordDeepDiveData = ReturnType<typeof useKeywordDeepDive>;

--- a/web/src/components/Reports/ReportsLandingView.spec.tsx
+++ b/web/src/components/Reports/ReportsLandingView.spec.tsx
@@ -1,0 +1,64 @@
+import {
+  describe, it, expect 
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReportsLandingView } from './ReportsLandingView';
+
+/**
+ * The landing view doubles as a roadmap: all five planned reports are listed
+ * even before they exist. Tests pin:
+ *   - all five titles render so an exec scanning the page sees the full plan
+ *   - the available reports link to a real path (regression catch if the
+ *     `path` field gets set wrongly during sequencing)
+ *   - the not-yet-built reports show "Coming soon" instead of an active link
+ */
+describe('ReportsLandingView', () => {
+  function renderLanding() {
+    return render(
+      <MemoryRouter>
+        <ReportsLandingView />
+      </MemoryRouter>,
+    );
+  }
+
+  it('lists the four strategic reports by title', () => {
+    renderLanding();
+    expect(screen.getByText('Executive Summary')).toBeInTheDocument();
+    expect(screen.getByText('Brand Visibility Report')).toBeInTheDocument();
+    expect(screen.getByText('Competitor Gap Report')).toBeInTheDocument();
+    expect(screen.getByText('Content Action Plan')).toBeInTheDocument();
+  });
+
+  it('lists the keyword-level drill-down report', () => {
+    renderLanding();
+    expect(screen.getByText('Keyword Deep Dive')).toBeInTheDocument();
+  });
+
+  it('renders Keyword Deep Dive as a working link to /reports/keyword', () => {
+    renderLanding();
+    const link = screen.getByRole('link', { name: /keyword deep dive/i });
+    expect(link).toHaveAttribute('href', '/reports/keyword');
+  });
+
+  it('marks the four unbuilt reports as Coming soon and not as links', () => {
+    renderLanding();
+    const comingSoonBadges = screen.getAllByText(/coming soon/i);
+    expect(comingSoonBadges).toHaveLength(4);
+  });
+
+  it('shows the executive and marketing-lead audiences', () => {
+    renderLanding();
+    expect(screen.getByText(/CMO, VP Marketing/)).toBeInTheDocument();
+    expect(screen.getByText(/Marketing lead/)).toBeInTheDocument();
+  });
+
+  it('shows the strategist and SEO-lead audiences', () => {
+    renderLanding();
+    expect(screen.getByText(/Content \/ PR strategist/)).toBeInTheDocument();
+    expect(screen.getByText(/Content strategist/)).toBeInTheDocument();
+    expect(screen.getByText(/SEO \/ AI search lead/)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/ReportsLandingView.tsx
+++ b/web/src/components/Reports/ReportsLandingView.tsx
@@ -1,0 +1,133 @@
+import { Link } from 'react-router-dom';
+
+interface ReportEntry {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly audience: string;
+  readonly path: string | null;
+  readonly status: 'available' | 'coming-soon';
+}
+
+/**
+ * The five reports we're building, ordered to match the marketing decision
+ * each one supports (top-down strategic to bottom-up operational). Reports
+ * we haven't shipped yet are listed but link nowhere; the placeholder makes
+ * the planned scope visible to users without surprising them on a 404.
+ */
+const REPORT_CATALOG: readonly ReportEntry[] = [
+  {
+    id: 'executive-summary',
+    title: 'Executive Summary',
+    description:
+      'One-page rollup of overall visibility, the trend over time, top wins, top gaps, and the next three actions to take. The report a marketing lead would print before a quarterly business review.',
+    audience: 'CMO, VP Marketing',
+    path: null,
+    status: 'coming-soon',
+  },
+  {
+    id: 'brand-visibility',
+    title: 'Brand Visibility Report',
+    description:
+      'Visibility score, rank distribution, share of voice vs. configured competitors, sentiment, and trend, scoped to a keyword or to the full keyword set. Highlights regressions in red.',
+    audience: 'Marketing lead',
+    path: null,
+    status: 'coming-soon',
+  },
+  {
+    id: 'competitor-gap',
+    title: 'Competitor Gap Report',
+    description:
+      'For each tracked competitor: keywords where they outrank you, citation sources unique to them, and a prioritized outreach list ranked by potential visibility lift.',
+    audience: 'Content / PR strategist',
+    path: null,
+    status: 'coming-soon',
+  },
+  {
+    id: 'content-action-plan',
+    title: 'Content Action Plan',
+    description:
+      'Prioritized citation gaps paired with AI-generated content briefs from Content Studio. Closes the loop from "we have a gap" to "here is the asset to fill it".',
+    audience: 'Content strategist',
+    path: null,
+    status: 'coming-soon',
+  },
+  {
+    id: 'keyword-deep-dive',
+    title: 'Keyword Deep Dive',
+    description:
+      'Single-keyword drill-down: rank history, persona impact, provider differences, top sources, sentiment examples, recommended actions, and an LLM-generated narrative explaining the current ranking.',
+    audience: 'SEO / AI search lead',
+    path: '/reports/keyword',
+    status: 'available',
+  },
+];
+
+export function ReportsLandingView() {
+  return (
+    <div className="space-y-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 sm:p-6">
+        <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white">
+          Reports
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 leading-relaxed max-w-3xl">
+          Print-ready, narrative views of the data already on your dashboards.
+          Each report is scoped to one decision and one audience. Use the Save
+          as PDF button on any report to export it for sharing.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {REPORT_CATALOG.map((report) => (
+          <ReportCard key={report.id} report={report} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReportCard({ report }: { readonly report: ReportEntry }) {
+  const isAvailable = report.status === 'available' && report.path;
+  const cardClasses = [
+    'block',
+    'p-5',
+    'bg-white',
+    'dark:bg-gray-800',
+    'rounded-lg',
+    'border',
+    isAvailable
+      ? 'border-gray-200 dark:border-gray-700 hover:border-gray-400 dark:hover:border-gray-500 transition-colors'
+      : 'border-dashed border-gray-200 dark:border-gray-700 opacity-75',
+  ].join(' ');
+
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          {report.title}
+        </h3>
+        {!isAvailable && (
+          <span className="text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded">
+            Coming soon
+          </span>
+        )}
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+        {report.description}
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-3">
+        For: {report.audience}
+      </p>
+    </>
+  );
+
+  if (isAvailable && report.path) {
+    return (
+      <Link to={report.path} className={cardClasses}>
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className={cardClasses}>{body}</div>;
+}

--- a/web/src/components/Reports/ReportsRouter.tsx
+++ b/web/src/components/Reports/ReportsRouter.tsx
@@ -1,0 +1,61 @@
+import {
+  Routes, Route, Navigate,
+} from 'react-router-dom';
+import {
+  lazy, Suspense 
+} from 'react';
+import { Spinner } from '../ui/Spinner';
+import { ErrorBoundary } from '../ErrorBoundary';
+import { ReportsLandingView } from './ReportsLandingView';
+import type { Keyword } from '../../types';
+
+/**
+ * Reports load lazily so a user who never opens the Reporting section doesn't
+ * pay the bundle cost. Each report's data hooks pull a fair amount of code
+ * (chart libraries, persona logic, etc.), so the lazy boundary is per-report.
+ */
+const KeywordDeepDiveReport = lazy(() =>
+  import('./KeywordDeepDiveReport').then((m) => ({default: m.KeywordDeepDiveReport,})),
+);
+
+interface Props {readonly keywords: ReadonlyArray<Keyword>;}
+
+function ReportFallback() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  );
+}
+
+/**
+ * Sub-router for `/reports/*` paths.
+ *
+ * Lives parallel to the dashboard's `TabContent` rather than inside it because
+ * reports use parameterised URLs (`/reports/keyword/:keyword?`) and need the
+ * full `react-router-dom` `Routes` machinery, while `TabContent` is a switch
+ * over a flat tab id.
+ *
+ * As each new report ships it gets a `<Route>` here. The catch-all redirects
+ * unknown sub-paths back to the landing view so old links don't 404.
+ */
+export function ReportsRouter({ keywords }: Props) {
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<ReportFallback />}>
+        <Routes>
+          <Route path="/reports" element={<ReportsLandingView />} />
+          <Route
+            path="/reports/keyword"
+            element={<KeywordDeepDiveReport keywords={keywords} />}
+          />
+          <Route
+            path="/reports/keyword/:keyword"
+            element={<KeywordDeepDiveReport keywords={keywords} />}
+          />
+          <Route path="*" element={<Navigate to="/reports" replace />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/web/src/components/Reports/index.ts
+++ b/web/src/components/Reports/index.ts
@@ -1,0 +1,3 @@
+export { ReportsRouter } from './ReportsRouter';
+export { ReportsLandingView } from './ReportsLandingView';
+export { KeywordDeepDiveReport } from './KeywordDeepDiveReport';

--- a/web/src/components/Reports/layout/ReportKeywordSelector.tsx
+++ b/web/src/components/Reports/layout/ReportKeywordSelector.tsx
@@ -1,0 +1,49 @@
+import type { Keyword } from '../../../types';
+
+interface Props {
+  readonly keywords: ReadonlyArray<Keyword>;
+  readonly selected: string | null;
+  readonly onChange: (keyword: string) => void;
+  /**
+   * Optional label override. Defaults to "Keyword" — most keyword-scoped
+   * reports want this generic label, but a per-keyword report might want
+   * something more specific like "Drill into".
+   */
+  readonly label?: string;
+}
+
+/**
+ * Keyword selector reused across reports that scope their data to a single
+ * keyword. Lives in the report's `actions` slot in screen mode and is hidden
+ * from the printout (selection is reflected in the URL/H1 instead).
+ */
+export function ReportKeywordSelector({
+  keywords,
+  selected,
+  onChange,
+  label = 'Keyword',
+}: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor="report-keyword-select"
+        className="text-xs font-medium text-gray-500 dark:text-gray-400"
+      >
+        {label}
+      </label>
+      <select
+        id="report-keyword-select"
+        value={selected ?? ''}
+        onChange={(event) => onChange(event.target.value)}
+        className="px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg text-sm bg-white dark:bg-gray-800 min-w-[14rem]"
+      >
+        {!selected && <option value="">Select a keyword…</option>}
+        {keywords.map((keyword) => (
+          <option key={keyword.keyword} value={keyword.keyword}>
+            {keyword.keyword}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/src/components/Reports/layout/ReportLayout.spec.tsx
+++ b/web/src/components/Reports/layout/ReportLayout.spec.tsx
@@ -1,0 +1,67 @@
+import {
+  describe, it, expect 
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { ReportLayout } from './ReportLayout';
+
+describe('ReportLayout', () => {
+  it('renders the report title as an H1', () => {
+    render(
+      <ReportLayout title="Keyword Deep Dive: best running shoes">
+        <p>body</p>
+      </ReportLayout>,
+    );
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Keyword Deep Dive: best running shoes',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the optional subtitle', () => {
+    render(
+      <ReportLayout title="Demo" subtitle="Some description">
+        <p>body</p>
+      </ReportLayout>,
+    );
+    expect(screen.getByText('Some description')).toBeInTheDocument();
+  });
+
+  it('renders a generated-at timestamp so the printout is self-identifying', () => {
+    render(
+      <ReportLayout title="Demo">
+        <p>body</p>
+      </ReportLayout>,
+    );
+    expect(screen.getByText(/Generated /)).toBeInTheDocument();
+  });
+
+  it('renders body children', () => {
+    render(
+      <ReportLayout title="Demo">
+        <p data-testid="body">body</p>
+      </ReportLayout>,
+    );
+    expect(screen.getByTestId('body')).toBeInTheDocument();
+  });
+
+  it('marks the actions slot with print-hidden so screen-only controls drop out of the PDF', () => {
+    const { container } = render(
+      <ReportLayout
+        title="Demo"
+        actions={<button data-testid="filter">Filter</button>}
+      >
+        <p>body</p>
+      </ReportLayout>,
+    );
+    const button = screen.getByTestId('filter');
+    expect(button).toBeInTheDocument();
+    // Walk up to the action wrapper which carries the .print-hidden class.
+    const wrapper = container.querySelector('.print-hidden');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toContainElement(button);
+  });
+});

--- a/web/src/components/Reports/layout/ReportLayout.tsx
+++ b/web/src/components/Reports/layout/ReportLayout.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  /**
+   * The report's headline (e.g. "Keyword Deep Dive: best running shoes").
+   * Rendered as an H1 at the top of the page.
+   */
+  readonly title: string;
+  /**
+   * One-line description of what the report covers and who it's for.
+   * Helps a reader who picks up the printout cold understand the context.
+   */
+  readonly subtitle?: string;
+  /**
+   * Right-aligned slot for a subset of header content that isn't the title:
+   * filter chips, persona selector, etc. These render alongside the title
+   * on screen but are hidden in the print output via `print-hidden`.
+   */
+  readonly actions?: ReactNode;
+  /**
+   * The body of the report — usually a stack of <ReportSection /> elements.
+   */
+  readonly children: ReactNode;
+}
+
+/**
+ * Standard layout for any report page.
+ *
+ * Provides a consistent print-friendly chrome:
+ * - H1 with timestamp underneath so the printout is self-identifying.
+ * - Optional subtitle giving the report's purpose and audience.
+ * - An `actions` slot for screen-only controls (selectors, filters); these
+ *   are stripped from the PDF via `.print-hidden`.
+ *
+ * Reports should compose this layout instead of building their own header
+ * so the PDF output stays visually coherent across all five report types.
+ */
+export function ReportLayout({
+  title,
+  subtitle,
+  actions,
+  children,
+}: Props) {
+  const generatedAt = new Date().toLocaleString();
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between border-b border-gray-200 dark:border-gray-700 pb-4">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 max-w-2xl">
+              {subtitle}
+            </p>
+          )}
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+            Generated {generatedAt}
+          </p>
+        </div>
+        {actions && <div className="print-hidden">{actions}</div>}
+      </header>
+      <div className="space-y-6">{children}</div>
+    </div>
+  );
+}

--- a/web/src/components/Reports/layout/ReportSection.tsx
+++ b/web/src/components/Reports/layout/ReportSection.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  /**
+   * Section heading rendered above the body content. Optional so callers can
+   * supply their own heading layout when the default isn't appropriate
+   * (e.g. when the heading needs a badge or action button alongside it).
+   */
+  readonly title?: string;
+  /**
+   * Short paragraph explaining what the section shows. Helps readers of a
+   * printed report who don't have hover tooltips or click affordances.
+   */
+  readonly subtitle?: string;
+  /**
+   * When true, the section starts on a fresh page in the printed output.
+   * Use sparingly — too many forced page breaks fragment the report.
+   */
+  readonly startNewPage?: boolean;
+  readonly children: ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * Standard wrapper for a report section.
+ *
+ * Two print concerns are baked in:
+ * - `avoid-break-inside` keeps a section's heading attached to its body when
+ *   the browser paginates the printout (no orphaned headings).
+ * - Optional `page-break-before` lets a caller force a section onto a fresh
+ *   page when its data is dense enough to justify a break.
+ *
+ * Both classes are defined in `web/src/index.css` under the `@media print`
+ * block so they only have an effect on paper/PDF output; on screen the
+ * section renders as a normal block with no break behavior.
+ */
+export function ReportSection({
+  title,
+  subtitle,
+  startNewPage = false,
+  children,
+  className,
+}: Props) {
+  const breakClass = startNewPage ? 'page-break-before' : '';
+  const wrapperClass = [
+    'avoid-break-inside',
+    'mb-8',
+    breakClass,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <section className={wrapperClass}>
+      {title && (
+        <header className="mb-3">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            {title}
+          </h2>
+          {subtitle && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {subtitle}
+            </p>
+          )}
+        </header>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/web/src/components/Reports/layout/index.ts
+++ b/web/src/components/Reports/layout/index.ts
@@ -1,0 +1,5 @@
+export { ReportLayout } from './ReportLayout';
+export { ReportSection } from './ReportSection';
+export { ReportKeywordSelector } from './ReportKeywordSelector';
+export { useReportReady } from './useReportReady';
+export type { ReportDataSlice } from './useReportReady';

--- a/web/src/components/Reports/layout/useReportReady.spec.ts
+++ b/web/src/components/Reports/layout/useReportReady.spec.ts
@@ -1,0 +1,92 @@
+import {
+  describe, it, expect 
+} from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReportReady } from './useReportReady';
+
+/**
+ * `useReportReady` is the single source of truth for "all the report's data
+ * has loaded — go ahead and auto-print". The semantics tested here:
+ *
+ * - empty input is trivially ready (nothing to wait for)
+ * - any slice still loading => not ready
+ * - a slice that has settled with a value (data !== null) is ready
+ * - a slice that has settled with an error is also ready (don't block print
+ *   on a failed fetch — the section will render its error state)
+ * - a slice that has settled with neither data nor error is NOT ready —
+ *   that's the brief moment between mount and the first fetch starting,
+ *   when `loading` is still false but `data` is still null
+ */
+describe('useReportReady', () => {
+  it('returns true when slice list is empty', () => {
+    const { result } = renderHook(() => useReportReady([]));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when any slice is loading', () => {
+    const { result } = renderHook(() =>
+      useReportReady([
+        {
+          loading: false,
+          data: { ok: true },
+          error: null 
+        },
+        {
+          loading: true,
+          data: null,
+          error: null 
+        },
+      ]),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when every slice has resolved data', () => {
+    const { result } = renderHook(() =>
+      useReportReady([
+        {
+          loading: false,
+          data: { a: 1 },
+          error: null 
+        },
+        {
+          loading: false,
+          data: { b: 2 },
+          error: null 
+        },
+      ]),
+    );
+    expect(result.current).toBe(true);
+  });
+
+  it('treats a settled error as ready (so print is not blocked by a failed fetch)', () => {
+    const { result } = renderHook(() =>
+      useReportReady([
+        {
+          loading: false,
+          data: null,
+          error: 'boom' 
+        },
+        {
+          loading: false,
+          data: { ok: true },
+          error: null 
+        },
+      ]),
+    );
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when a slice is settled but has no data and no error', () => {
+    const { result } = renderHook(() =>
+      useReportReady([
+        {
+          loading: false,
+          data: null,
+          error: null 
+        },
+      ]),
+    );
+    expect(result.current).toBe(false);
+  });
+});

--- a/web/src/components/Reports/layout/useReportReady.ts
+++ b/web/src/components/Reports/layout/useReportReady.ts
@@ -1,0 +1,26 @@
+/**
+ * Combine the loading state of every data hook a report depends on into a
+ * single "is the page ready to print" boolean.
+ *
+ * Reports compose 4-7 independent fetches; each report still cares about its
+ * own per-section loading UI, but for the auto-print scheduling we need one
+ * aggregate signal so `usePrintMode` knows when *all* sections have settled.
+ *
+ * A loading flag is considered "settled" when the hook is no longer fetching
+ * (`loading === false`) AND it has either produced data or surfaced an error.
+ * This keeps print from firing during the brief moment between mount and the
+ * first fetch starting, when `loading` is still `false` but `data` is `null`.
+ */
+export interface ReportDataSlice {
+  loading: boolean;
+  data: unknown;
+  error: string | null;
+}
+
+export function useReportReady(slices: ReportDataSlice[]): boolean {
+  if (slices.length === 0) return true;
+  return slices.every((slice) => {
+    if (slice.loading) return false;
+    return slice.data !== null || slice.error !== null;
+  });
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -11,6 +11,12 @@ export * from './api/responses';
 
 /**
  * Navigation tab identifiers for the dashboard.
+ *
+ * `reports` is the marker for any path that lives under `/reports/*`. Each
+ * individual report (executive summary, keyword deep dive, etc.) shares this
+ * tab id so the sidebar's `Reporting` section stays highlighted regardless of
+ * which sub-report the user is currently viewing. The actual sub-routing for
+ * `/reports/...` is handled by `ReportsRouter`, not by `TabContent`.
  */
 export type TabType = 
   | 'dashboard' 
@@ -24,6 +30,7 @@ export type TabType =
   | 'schedule'
   | 'keyword-research'
   | 'content-studio'
+  | 'reports'
   | 'settings'
   | 'searches'
   | 'raw-responses';


### PR DESCRIPTION
## What

Adds a new **Reporting** sidebar section and ships the first of five planned report types: a printable, single-keyword drill-down (the **Keyword Deep Dive** report) for SEO/AI search leads investigating one keyword's full ranking story.

## Why

Dashboards answer "what's happening right now". Reports answer "what should we do next" and "what changed because of what we did". They have a different reader (marketing lead, exec, content strategist), a different layout (narrative + tables, print-first), and different print needs than the operational dashboards. The print-to-PDF infrastructure shipped in #38 is the right delivery mechanism — reports plug into it instead of introducing a new export pipeline.

## How

### Routing
- New `'reports'` `TabType` and `/reports` path. Sub-paths (`/reports/keyword/:keyword`) are handled by a new `ReportsRouter` rendered in parallel to `TabContent` because the existing flat tab dispatcher doesn't host parameterised routes.
- `MainApp.usePrintMode` is gated off for `/reports/*` so each report owns its own readiness signal — a report's data fetches are independent from the dashboard's `stats`.

### Layout primitives (`Reports/layout/`)
- `ReportLayout` — H1 + subtitle + generated-at timestamp + screen-only `actions` slot (selector dropdowns, filter chips). The `actions` wrapper carries `.print-hidden` so it drops out of the PDF.
- `ReportSection` — `avoid-break-inside` wrapper with optional `page-break-before`. Reports never have to remember the print classes themselves.
- `useReportReady` — combines multiple `{ loading, data, error }` slices into a single boolean. Used to gate `usePrintMode` so auto-print fires only after every fetch has settled (with data **or** an error — failed fetches don't block the PDF, the section renders its error state).
- `ReportKeywordSelector` — reused by any keyword-scoped report.

### Reports landing (`/reports`)
- Lists all five planned reports with title, description, and target audience. Built reports link to their path; not-yet-built ones show a "Coming soon" badge so the roadmap is visible without surprising users with 404s.

### Report 5 — Keyword Deep Dive (`/reports/keyword/:keyword?`)
Composes 7 sections from existing data — no API changes:

| Section | Behaviour |
|---|---|
| **Headline** | First-party visibility score, share of voice, 30-day trend with `+/−` change. Accent goes positive/negative against the competitor avg. |
| **Rank history** | Last 30 days of `visibility_score` per period (day default), sampled to ≤14 rows so it fits on one printed page. Min/max/avg shown above the table to preserve detail. |
| **Persona impact** | Only renders when first-party brands have a best-vs-worst-rank delta of ≥3 across personas. For keywords where personas don't materially change ranking we drop the section entirely instead of printing "personas don't matter here". |
| **Provider differences** | Per-provider rank for first-party brands. Cells show `#N` or `—`; surfacing invisibility is more actionable than hiding the row. |
| **Top sources** | Two stacked tables: sources that already cite first-party brands (the wins) and sources that cite competitors only (the gaps). Same partition as the citation-gaps endpoint so a source can't appear in both. |
| **Sentiment examples** | 1-2 quoted `sentiment_reason` excerpts per polarity. Negative ordered first because that's where action is needed. Skips appearances without a reason (a label without context isn't useful in print). |
| **Recommended actions** | Filtered to recommendations whose `keywords` array references the current keyword. Configuration / data-quality recs without a keyword list are kept as global. Sorted by priority. |

### What's reused
- Every data hook already exists: `useVisibilityMetrics`, `useHistoricalTrends`, `usePersonaRankings`, `useBrandMentions`, `useCitationGaps`, `useRecommendations`. No backend changes.
- Print CSS from #38 (`.print-hidden`, `.page-break-before`, `.avoid-break-inside`) is reused as-is.
- The existing `PrintToPdfButton` already works on any path, so the export UX is identical to the rest of the dashboard.

### What's not in this PR
- Reports 1–4 (Executive Summary, Brand Visibility, Competitor Gap, Content Action Plan): coming as separate PRs in the agreed order **5 → 4 → 2 → aggregator endpoint → 1 → competitor endpoint → 3**.
- The aggregator endpoint (`GET /reports/overview`) and the competitor rollup endpoint that Reports 1 and 3 will need: separate backend PRs.
- LLM narrative section (self-reflection): on-demand POST; will revisit when its caching/triggering UX is designed.

## Verification

- 26 new vitest cases covering: `useReportReady` AND-logic across slices, `ReportLayout` title/subtitle/timestamp/print-hidden, `ReportsLandingView` catalogue, `useKeywordDeepDive` fetch dispatch + ready aggregation, and a `KeywordDeepDiveReport` smoke test (H1 from URL, selector changes update URL).
- All **714** vitest cases pass.
- Type-check clean. Build clean. Lint clean (project's `@stylistic`, `sonarjs`, `vitest/max-expects`, `react/no-array-index-key`, and `no-restricted-imports` rules all satisfied).

## Stacks on

- #38 (print-to-PDF infrastructure). The auto-print scheduling, `.print-hidden`, page-break helpers, and `usePrintMode` hook all come from there.

## Checklist

- [x] Type-check passes
- [x] Build passes
- [x] Lint passes
- [x] All 714 tests pass (688 existing + 26 new)
- [x] Routing handles `/reports`, `/reports/keyword`, and `/reports/keyword/:keyword`; unknown sub-paths redirect to the landing view
- [x] Print mode gated correctly: dashboard auto-print is suppressed on `/reports/*` so reports own their own readiness
- [x] Sidebar's "Reporting" section highlights for any `/reports/*` path
