### PR TITLE
feat(web): Competitor Gap report (final report)

### DIFF
--- a/web/src/api/reports.ts
+++ b/web/src/api/reports.ts
@@ -62,3 +62,83 @@ export function fetchReportsOverview(
   const qs = query.length > 0 ? `?${query.join('&')}` : '';
   return apiGet<ReportsOverviewResponse>(`/reports/overview${qs}`, { signal });
 }
+
+
+// ---------------------------------------------------------------------------
+// Competitor rollup
+// ---------------------------------------------------------------------------
+
+export interface CompetitorOutrankedKeyword {
+  keyword: string;
+  their_best_rank: number;
+  our_best_rank: number | null;
+  rank_delta: number | null;
+  providers: string[];
+}
+
+export interface CompetitorExclusiveSource {
+  keyword: string;
+  url: string;
+  domain: string;
+  priority: 'high' | 'medium' | 'low';
+  citation_count: number;
+  provider_count: number;
+  providers: string[];
+  lift_score: number;
+}
+
+export interface CompetitorRollup {
+  competitor: string;
+  outranked_keywords: CompetitorOutrankedKeyword[];
+  exclusive_sources: CompetitorExclusiveSource[];
+  outreach_targets: CompetitorExclusiveSource[];
+}
+
+export interface CompetitorReportSingleResponse {
+  generated_at: string;
+  keywords_analyzed: number;
+  competitor: string;
+  rollup: CompetitorRollup;
+}
+
+export interface CompetitorReportAllResponse {
+  generated_at: string;
+  keywords_analyzed: number;
+  competitors: string[];
+  rollups: CompetitorRollup[];
+}
+
+export type CompetitorReportResponse =
+  | CompetitorReportSingleResponse
+  | CompetitorReportAllResponse;
+
+export interface CompetitorReportParams {
+  readonly competitor?: string;
+  readonly keywordLimit?: number;
+}
+
+/**
+ * Fetch the competitor rollup. When `competitor` is omitted the server
+ * returns a `rollups[]` payload covering every configured competitor;
+ * when provided, it returns a single `rollup` for that competitor.
+ */
+export function fetchCompetitorRollup(
+  params: CompetitorReportParams = {},
+  signal?: AbortSignal,
+): Promise<CompetitorReportResponse> {
+  const query: string[] = [];
+  if (params.competitor) {
+    query.push(`competitor=${encodeURIComponent(params.competitor)}`);
+  }
+  if (params.keywordLimit !== undefined) {
+    query.push(`keyword_limit=${params.keywordLimit}`);
+  }
+  const qs = query.length > 0 ? `?${query.join('&')}` : '';
+  return apiGet<CompetitorReportResponse>(`/reports/competitor${qs}`, { signal });
+}
+
+export function isSingleCompetitorResponse(
+  response: CompetitorReportResponse,
+): response is CompetitorReportSingleResponse {
+  return 'rollup' in response;
+}

--- a/web/src/components/Reports/CompetitorGapReport/CompetitorGapReport.spec.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/CompetitorGapReport.spec.tsx
@@ -1,0 +1,178 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import {
+  MemoryRouter, Routes, Route 
+} from 'react-router-dom';
+import { CompetitorGapReport } from './CompetitorGapReport';
+
+vi.mock('./useCompetitorGap', () => ({useCompetitorGap: vi.fn()}));
+vi.mock('../../../hooks/usePrintMode', () => ({usePrintMode: vi.fn(() => ({ isPrintMode: false })),}));
+vi.mock('../../../hooks/useBrandConfig', () => ({useBrandConfig: vi.fn()}));
+
+import { useCompetitorGap } from './useCompetitorGap';
+import { useBrandConfig } from '../../../hooks/useBrandConfig';
+
+const mockGap = useCompetitorGap as ReturnType<typeof vi.fn>;
+const mockBrand = useBrandConfig as ReturnType<typeof vi.fn>;
+
+const POPULATED_DATA = {
+  competitor: 'Adidas',
+  rollup: {
+    competitor: 'Adidas',
+    outranked_keywords: [
+      {
+        keyword: 'best running shoes',
+        their_best_rank: 1,
+        our_best_rank: 3,
+        rank_delta: 2,
+        providers: ['openai', 'perplexity'],
+      },
+    ],
+    exclusive_sources: [
+      {
+        keyword: 'best running shoes',
+        url: 'https://example.com/shoes',
+        domain: 'example.com',
+        priority: 'high' as const,
+        citation_count: 9,
+        provider_count: 3,
+        providers: ['openai', 'perplexity', 'gemini'],
+        lift_score: 6.91,
+      },
+    ],
+    outreach_targets: [
+      {
+        keyword: 'best running shoes',
+        url: 'https://example.com/shoes',
+        domain: 'example.com',
+        priority: 'high' as const,
+        citation_count: 9,
+        provider_count: 3,
+        providers: ['openai', 'perplexity', 'gemini'],
+        lift_score: 6.91,
+      },
+    ],
+  },
+  keywordsAnalyzed: 4,
+  loading: false,
+  error: null,
+  ready: true,
+};
+
+function renderAt(path: string, competitors: string[] = ['Adidas', 'Asics']) {
+  mockBrand.mockReturnValue({
+    config: {
+      tracked_brands: {
+        first_party: ['Nike'],
+        competitors 
+      } 
+    },
+    presets: {},
+    loading: false,
+    error: null,
+  });
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/reports/competitor" element={<CompetitorGapReport />} />
+        <Route
+          path="/reports/competitor/:competitor"
+          element={<CompetitorGapReport />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CompetitorGapReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGap.mockReturnValue(POPULATED_DATA);
+  });
+
+  it('renders the report H1 with the selected competitor', () => {
+    renderAt('/reports/competitor/Adidas');
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Competitor Gap.*Adidas/i 
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the outranked keyword in the table', () => {
+    renderAt('/reports/competitor/Adidas');
+    const matches = screen.getAllByText('best running shoes');
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it('renders the their-rank value for the outranked row', () => {
+    renderAt('/reports/competitor/Adidas');
+    expect(screen.getByText('#1')).toBeInTheDocument();
+  });
+
+  it('renders the our-rank value for the outranked row', () => {
+    renderAt('/reports/competitor/Adidas');
+    expect(screen.getByText('#3')).toBeInTheDocument();
+  });
+
+  it('renders the rank delta with a + sign', () => {
+    renderAt('/reports/competitor/Adidas');
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('renders the outreach target domain', () => {
+    renderAt('/reports/competitor/Adidas');
+    expect(screen.getByText('example.com')).toBeInTheDocument();
+  });
+
+  it('renders the lift score on the outreach card', () => {
+    renderAt('/reports/competitor/Adidas');
+    expect(screen.getByText('6.91')).toBeInTheDocument();
+  });
+
+  it('renders a competitor switcher populated with every configured competitor', () => {
+    renderAt('/reports/competitor/Adidas');
+    const select = screen.getByLabelText(/Competitor:/i) as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toContain('Adidas');
+    expect(optionValues).toContain('Asics');
+  });
+
+  it('renders the empty-state when no competitors are configured', () => {
+    renderAt('/reports/competitor', []);
+    const matches = screen.getAllByText(/no competitors configured/i);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it('renders loading placeholders when the rollup is loading', () => {
+    mockGap.mockReturnValue({
+      ...POPULATED_DATA,
+      rollup: null,
+      loading: true,
+      error: null,
+      ready: false,
+    });
+    renderAt('/reports/competitor/Adidas');
+    expect(screen.getByText(/Loading rollup/i)).toBeInTheDocument();
+  });
+
+  it('renders error message when the rollup hook reports an error', () => {
+    mockGap.mockReturnValue({
+      ...POPULATED_DATA,
+      rollup: null,
+      loading: false,
+      error: 'Backend exploded',
+      ready: true,
+    });
+    renderAt('/reports/competitor/Adidas');
+    // The error propagates to all three sections (each renders its own
+    // error placeholder).
+    const matches = screen.getAllByText('Backend exploded');
+    expect(matches.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/Reports/CompetitorGapReport/CompetitorGapReport.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/CompetitorGapReport.tsx
@@ -1,0 +1,154 @@
+import { useEffect } from 'react';
+import {
+  useNavigate, useParams 
+} from 'react-router-dom';
+import { usePrintMode } from '../../../hooks/usePrintMode';
+import { useBrandConfig } from '../../../hooks/useBrandConfig';
+import {
+  ReportLayout, SectionPlaceholder 
+} from '../layout';
+import { useCompetitorGap } from './useCompetitorGap';
+import { HeadlineSection } from './sections/HeadlineSection';
+import { OutrankedKeywordsSection } from './sections/OutrankedKeywordsSection';
+import { OutreachTargetsSection } from './sections/OutreachTargetsSection';
+
+/**
+ * Competitor Gap report. Per-competitor printable layout aimed at a
+ * content / PR strategist deciding where to invest outreach budget.
+ *
+ * URL shapes:
+ *   /reports/competitor                      -> auto-redirects to first
+ *                                                configured competitor.
+ *   /reports/competitor/:competitor          -> per-competitor rollup.
+ *
+ * Sources data from `/reports/competitor` (PR G), composed via the
+ * `useCompetitorGap` hook which narrows the discriminated union from
+ * the api client into a flat `currentRollup` shape that the section
+ * components can consume directly.
+ */
+export function CompetitorGapReport() {
+  const params = useParams<{ competitor?: string }>();
+  const navigate = useNavigate();
+  const { config } = useBrandConfig();
+
+  const configuredCompetitors = config?.tracked_brands?.competitors ?? [];
+  const selected = params.competitor
+    ? decodeURIComponent(params.competitor)
+    : null;
+
+  // Auto-pick the first configured competitor when the URL has no
+  // selection. Same UX as the Keyword Deep Dive report's keyword
+  // auto-pick behavior.
+  useEffect(() => {
+    if (!selected && configuredCompetitors.length > 0) {
+      navigate(
+        `/reports/competitor/${encodeURIComponent(configuredCompetitors[0])}`,
+        { replace: true },
+      );
+    }
+  }, [selected, configuredCompetitors, navigate]);
+
+  // If the URL competitor doesn't match any configured one (deleted,
+  // bookmark from before a config change, etc.), redirect home rather
+  // than render a confusing empty state.
+  useEffect(() => {
+    if (
+      selected
+      && configuredCompetitors.length > 0
+      && !configuredCompetitors.includes(selected)
+    ) {
+      navigate('/reports/competitor', { replace: true });
+    }
+  }, [selected, configuredCompetitors, navigate]);
+
+  const data = useCompetitorGap(selected);
+
+  usePrintMode({ ready: Boolean(selected) && data.ready });
+
+  if (configuredCompetitors.length === 0) {
+    return (
+      <ReportLayout
+        title="Competitor Gap"
+        subtitle="No competitors configured. Add competitors in Settings > Brand Tracking to populate this report."
+      >
+        <SectionPlaceholder
+          variant="empty"
+          message="No competitors configured. Add competitors in Settings > Brand Tracking, then re-open this report."
+        />
+      </ReportLayout>
+    );
+  }
+
+  if (!selected) {
+    return (
+      <ReportLayout
+        title="Competitor Gap"
+        subtitle="Loading competitor selection…"
+      >
+        <SectionPlaceholder variant="loading" message="Selecting competitor…" />
+      </ReportLayout>
+    );
+  }
+
+  return (
+    <ReportLayout
+      title={`Competitor Gap — ${selected}`}
+      subtitle="Where this competitor outranks us, who cites them but not us, and the outreach targets ordered by visibility lift."
+      actions={(
+        <CompetitorSwitcher
+          selected={selected}
+          competitors={configuredCompetitors}
+          onChange={(next) => {
+            navigate(`/reports/competitor/${encodeURIComponent(next)}`);
+          }}
+        />
+      )}
+    >
+      <HeadlineSection
+        competitor={selected}
+        rollup={data.rollup}
+        keywordsAnalyzed={data.keywordsAnalyzed}
+        loading={data.loading}
+        error={data.error}
+      />
+      <OutrankedKeywordsSection
+        rollup={data.rollup}
+        loading={data.loading}
+        error={data.error}
+      />
+      <OutreachTargetsSection
+        rollup={data.rollup}
+        loading={data.loading}
+        error={data.error}
+      />
+    </ReportLayout>
+  );
+}
+
+function CompetitorSwitcher({
+  selected,
+  competitors,
+  onChange,
+}: {
+  readonly selected: string;
+  readonly competitors: ReadonlyArray<string>;
+  readonly onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <label htmlFor="competitor-select" className="text-gray-600 dark:text-gray-400">
+        Competitor:
+      </label>
+      <select
+        id="competitor-select"
+        value={selected}
+        onChange={(e) => onChange(e.target.value)}
+        className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+      >
+        {competitors.map((c) => (
+          <option key={c} value={c}>{c}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/src/components/Reports/CompetitorGapReport/index.ts
+++ b/web/src/components/Reports/CompetitorGapReport/index.ts
@@ -1,0 +1,2 @@
+export { CompetitorGapReport } from './CompetitorGapReport';
+export { useCompetitorGap } from './useCompetitorGap';

--- a/web/src/components/Reports/CompetitorGapReport/sections/HeadlineSection.spec.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/sections/HeadlineSection.spec.tsx
@@ -1,0 +1,153 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { HeadlineSection } from './HeadlineSection';
+import type { CompetitorRollup } from '../../../../api/reports';
+
+function buildSource(priority: 'high' | 'medium' | 'low'): CompetitorRollup['exclusive_sources'][number] {
+  return {
+    keyword: 'kw',
+    url: `https://${priority}.com`,
+    domain: `${priority}.com`,
+    priority,
+    citation_count: 5,
+    provider_count: 2,
+    providers: ['openai', 'g'],
+    lift_score: 3.4,
+  };
+}
+
+function buildRollup(overrides: Partial<CompetitorRollup> = {}): CompetitorRollup {
+  return {
+    competitor: 'Adidas',
+    outranked_keywords: [],
+    exclusive_sources: [],
+    outreach_targets: [],
+    ...overrides,
+  };
+}
+
+describe('HeadlineSection — count derivation', () => {
+  it('renders the outranked-keyword count from the rollup', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={buildRollup({
+          outranked_keywords: [
+            {
+              keyword: 'a',
+              their_best_rank: 1,
+              our_best_rank: 3,
+              rank_delta: 2,
+              providers: ['openai'],
+            },
+            {
+              keyword: 'b',
+              their_best_rank: 2,
+              our_best_rank: 5,
+              rank_delta: 3,
+              providers: ['perplexity'],
+            },
+          ],
+        })}
+        keywordsAnalyzed={20}
+        loading={false}
+        error={null}
+      />,
+    );
+    const label = screen.getByText('Outranked keywords').parentElement;
+    expect(label).toHaveTextContent('2');
+  });
+
+  it('renders the exclusive-source count from the rollup', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={buildRollup({exclusive_sources: [buildSource('high'), buildSource('medium')],})}
+        keywordsAnalyzed={20}
+        loading={false}
+        error={null}
+      />,
+    );
+    const label = screen.getByText('Exclusive sources').parentElement;
+    expect(label).toHaveTextContent('2');
+  });
+
+  it('counts only high-priority sources for the high-lift metric', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={buildRollup({
+          exclusive_sources: [
+            buildSource('high'),
+            buildSource('high'),
+            buildSource('medium'),
+            buildSource('low'),
+          ],
+        })}
+        keywordsAnalyzed={20}
+        loading={false}
+        error={null}
+      />,
+    );
+    const label = screen.getByText('High-lift targets').parentElement;
+    expect(label).toHaveTextContent('2');
+  });
+
+  it('renders the keywords-analyzed count in the subhead', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={buildRollup()}
+        keywordsAnalyzed={42}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/Across 42 tracked keywords/)).toBeInTheDocument();
+  });
+});
+
+describe('HeadlineSection — placeholder states', () => {
+  it('renders loading placeholder when loading is true', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={null}
+        keywordsAnalyzed={0}
+        loading
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/Loading rollup/i)).toBeInTheDocument();
+  });
+
+  it('renders error message when error is set', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={null}
+        keywordsAnalyzed={0}
+        loading={false}
+        error="boom"
+      />,
+    );
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no rollup data and not loading', () => {
+    render(
+      <HeadlineSection
+        competitor="Adidas"
+        rollup={null}
+        keywordsAnalyzed={0}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/Run an analysis/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/CompetitorGapReport/sections/HeadlineSection.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/sections/HeadlineSection.tsx
@@ -1,0 +1,115 @@
+import type { CompetitorRollup } from '../../../../api/reports';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly competitor: string;
+  readonly rollup: CompetitorRollup | null;
+  readonly keywordsAnalyzed: number;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Three-number headline: how many keywords this competitor outranks
+ * us on, how many sources cite them but not us, and the count of
+ * "high lift" outreach targets in their list. Lifts are filtered
+ * with priority = 'high' so the metric reflects work that actually
+ * matters.
+ */
+export function HeadlineSection({
+  competitor, rollup, keywordsAnalyzed, loading, error,
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="loading" message="Loading rollup…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!rollup) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder
+          variant="empty"
+          message="No rollup data yet. Run an analysis to populate."
+        />
+      </ReportSection>
+    );
+  }
+
+  const outrankedCount = rollup.outranked_keywords.length;
+  const exclusiveCount = rollup.exclusive_sources.length;
+  const highLiftCount = rollup.exclusive_sources.filter(
+    (s) => s.priority === 'high',
+  ).length;
+
+  return (
+    <ReportSection title="Headline">
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        Across {keywordsAnalyzed} tracked keywords, vs <strong>{competitor}</strong>:
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Metric
+          label="Outranked keywords"
+          value={outrankedCount}
+          accent={outrankedCount > 0 ? 'negative' : 'neutral'}
+          footnote="Keywords where they beat our best rank"
+        />
+        <Metric
+          label="Exclusive sources"
+          value={exclusiveCount}
+          accent={exclusiveCount > 0 ? 'negative' : 'neutral'}
+          footnote="Sources citing them but not us"
+        />
+        <Metric
+          label="High-lift targets"
+          value={highLiftCount}
+          accent={highLiftCount > 0 ? 'positive' : 'neutral'}
+          footnote="High-priority outreach opportunities"
+        />
+      </div>
+    </ReportSection>
+  );
+}
+
+type Accent = 'positive' | 'negative' | 'neutral';
+
+function Metric({
+  label,
+  value,
+  footnote,
+  accent,
+}: {
+  readonly label: string;
+  readonly value: number;
+  readonly footnote: string;
+  readonly accent: Accent;
+}) {
+  const accentClass = accentClassFor(accent);
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800">
+      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className={`text-2xl font-semibold mt-1 ${accentClass}`}>{value}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">{footnote}</p>
+    </div>
+  );
+}
+
+function accentClassFor(accent: Accent): string {
+  if (accent === 'positive') return 'text-emerald-700 dark:text-emerald-400';
+  if (accent === 'negative') return 'text-red-700 dark:text-red-400';
+  return 'text-gray-900 dark:text-white';
+}

--- a/web/src/components/Reports/CompetitorGapReport/sections/OutrankedKeywordsSection.spec.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/sections/OutrankedKeywordsSection.spec.tsx
@@ -1,0 +1,157 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { OutrankedKeywordsSection } from './OutrankedKeywordsSection';
+import type { CompetitorRollup } from '../../../../api/reports';
+
+function buildRollup(rows: CompetitorRollup['outranked_keywords']): CompetitorRollup {
+  return {
+    competitor: 'Adidas',
+    outranked_keywords: rows,
+    exclusive_sources: [],
+    outreach_targets: [],
+  };
+}
+
+describe('OutrankedKeywordsSection — content', () => {
+  it('renders each outranked keyword as a row in the table', () => {
+    render(
+      <OutrankedKeywordsSection
+        rollup={buildRollup([
+          {
+            keyword: 'best running shoes',
+            their_best_rank: 1,
+            our_best_rank: 3,
+            rank_delta: 2,
+            providers: ['openai'],
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('best running shoes')).toBeInTheDocument();
+  });
+
+  it('renders rank values with a # prefix', () => {
+    render(
+      <OutrankedKeywordsSection
+        rollup={buildRollup([
+          {
+            keyword: 'kw',
+            their_best_rank: 2,
+            our_best_rank: 5,
+            rank_delta: 3,
+            providers: ['openai'],
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    expect(screen.getByText('#5')).toBeInTheDocument();
+  });
+
+  it('renders a dash when our_best_rank is null (we never appeared)', () => {
+    render(
+      <OutrankedKeywordsSection
+        rollup={buildRollup([
+          {
+            keyword: 'kw',
+            their_best_rank: 2,
+            our_best_rank: null,
+            rank_delta: null,
+            providers: ['openai'],
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    // Dash should be present in the our-rank cell.
+    const cells = screen.getAllByRole('cell');
+    expect(cells.some((c) => c.textContent === '—')).toBe(true);
+  });
+
+  it('renders the rank delta with a + sign prefix', () => {
+    render(
+      <OutrankedKeywordsSection
+        rollup={buildRollup([
+          {
+            keyword: 'kw',
+            their_best_rank: 1,
+            our_best_rank: 4,
+            rank_delta: 3,
+            providers: ['openai'],
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('+3')).toBeInTheDocument();
+  });
+
+  it('renders the providers list joined by commas', () => {
+    render(
+      <OutrankedKeywordsSection
+        rollup={buildRollup([
+          {
+            keyword: 'kw',
+            their_best_rank: 1,
+            our_best_rank: 3,
+            rank_delta: 2,
+            providers: ['openai', 'perplexity'],
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('openai, perplexity')).toBeInTheDocument();
+  });
+});
+
+describe('OutrankedKeywordsSection — empty + placeholder states', () => {
+  it('renders a friendly empty message when no keywords are outranked', () => {
+    render(
+      <OutrankedKeywordsSection
+        rollup={buildRollup([])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByText(/Maintain current investment/i),
+    ).toBeInTheDocument();
+  });
+
+  it('returns null when rollup is null', () => {
+    const { container } = render(
+      <OutrankedKeywordsSection
+        rollup={null}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders loading placeholder when loading is true', () => {
+    render(
+      <OutrankedKeywordsSection rollup={null} loading error={null} />,
+    );
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  });
+
+  it('renders error message when error is set', () => {
+    render(
+      <OutrankedKeywordsSection rollup={null} loading={false} error="boom" />,
+    );
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/CompetitorGapReport/sections/OutrankedKeywordsSection.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/sections/OutrankedKeywordsSection.tsx
@@ -1,0 +1,108 @@
+import type { CompetitorRollup } from '../../../../api/reports';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly rollup: CompetitorRollup | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Keywords where this competitor outranks every first-party brand,
+ * sorted by rank delta descending so the biggest gaps anchor the
+ * top of the table — those are the keywords where the strategist
+ * would invest first.
+ */
+export function OutrankedKeywordsSection({
+  rollup, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Outranked keywords">
+        <SectionPlaceholder variant="loading" message="Loading…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Outranked keywords">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!rollup) return null;
+  if (rollup.outranked_keywords.length === 0) {
+    return (
+      <ReportSection
+        title="Outranked keywords"
+        subtitle="No keywords where this competitor beats us right now."
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Maintain current investment on the keywords already covered.
+        </p>
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Outranked keywords"
+      subtitle="Keywords where this competitor's best rank beats every first-party brand. Largest gap to us first."
+    >
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>Keyword</Th>
+              <Th>Their rank</Th>
+              <Th>Our rank</Th>
+              <Th>Delta</Th>
+              <Th>Providers</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {rollup.outranked_keywords.map((row) => (
+              <tr key={row.keyword}>
+                <Td className="font-medium">{row.keyword}</Td>
+                <Td>#{row.their_best_rank}</Td>
+                <Td>{row.our_best_rank ? `#${row.our_best_rank}` : '—'}</Td>
+                <Td>
+                  <span className="text-red-700 dark:text-red-400 font-mono font-semibold">
+                    {row.rank_delta === null ? '—' : `+${row.rank_delta}`}
+                  </span>
+                </Td>
+                <Td className="text-xs">{row.providers.join(', ') || '—'}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}

--- a/web/src/components/Reports/CompetitorGapReport/sections/OutreachTargetsSection.spec.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/sections/OutreachTargetsSection.spec.tsx
@@ -1,0 +1,207 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { OutreachTargetsSection } from './OutreachTargetsSection';
+import type { CompetitorRollup } from '../../../../api/reports';
+
+type Source = CompetitorRollup['outreach_targets'][number];
+
+function buildSource(overrides: Partial<Source> = {}): Source {
+  return {
+    keyword: 'best running shoes',
+    url: 'https://example.com/post',
+    domain: 'example.com',
+    priority: 'high',
+    citation_count: 5,
+    provider_count: 2,
+    providers: ['openai', 'gemini'],
+    lift_score: 3.4,
+    ...overrides,
+  };
+}
+
+function buildRollup(targets: Source[]): CompetitorRollup {
+  return {
+    competitor: 'Adidas',
+    outranked_keywords: [],
+    exclusive_sources: [],
+    outreach_targets: targets,
+  };
+}
+
+describe('OutreachTargetsSection — card content', () => {
+  it('renders the domain as the card heading', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({ domain: 'mydomain.com' })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByRole('heading', {
+        level: 3,
+        name: 'mydomain.com' 
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the URL beneath the domain heading', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({ url: 'https://example.com/specific-post' })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('https://example.com/specific-post')).toBeInTheDocument();
+  });
+
+  it('renders the lift_score formatted to two decimal places', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({ lift_score: 6.91 })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('6.91')).toBeInTheDocument();
+  });
+
+  it('renders citation_count and provider_count as separate metrics', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({
+          citation_count: 12,
+          provider_count: 4,
+        })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+});
+
+
+describe('OutreachTargetsSection — priority badges', () => {
+  it('renders the high priority badge label', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({ priority: 'high' })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('high')).toBeInTheDocument();
+  });
+
+  it('renders the medium priority badge label', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({ priority: 'medium' })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('medium')).toBeInTheDocument();
+  });
+
+  it('renders the low priority badge label', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([buildSource({ priority: 'low' })])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('low')).toBeInTheDocument();
+  });
+});
+
+
+describe('OutreachTargetsSection — multi-target rendering', () => {
+  it('renders one card per target', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([
+          buildSource({
+            url: 'https://a.com/x',
+            domain: 'a.com' 
+          }),
+          buildSource({
+            url: 'https://b.com/y',
+            domain: 'b.com' 
+          }),
+          buildSource({
+            url: 'https://c.com/z',
+            domain: 'c.com' 
+          }),
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(3);
+  });
+
+  it('uses URL+keyword composite key so duplicate-URL different-keyword targets co-exist', () => {
+    // Both targets share the same URL but reference different keywords —
+    // they should both render rather than collide on the React key.
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([
+          buildSource({
+            url: 'https://shared.com',
+            keyword: 'shoes' 
+          }),
+          buildSource({
+            url: 'https://shared.com',
+            keyword: 'boots' 
+          }),
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(2);
+  });
+});
+
+describe('OutreachTargetsSection — empty + placeholder states', () => {
+  it('renders friendly empty copy when targets list is empty', () => {
+    render(
+      <OutreachTargetsSection
+        rollup={buildRollup([])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByText(/No outreach targets identified/i),
+    ).toBeInTheDocument();
+  });
+
+  it('returns null when rollup is null', () => {
+    const { container } = render(
+      <OutreachTargetsSection rollup={null} loading={false} error={null} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders loading placeholder when loading is true', () => {
+    render(<OutreachTargetsSection rollup={null} loading error={null} />);
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  });
+
+  it('renders error message when error is set', () => {
+    render(
+      <OutreachTargetsSection rollup={null} loading={false} error="boom" />,
+    );
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/CompetitorGapReport/sections/OutreachTargetsSection.tsx
+++ b/web/src/components/Reports/CompetitorGapReport/sections/OutreachTargetsSection.tsx
@@ -1,0 +1,128 @@
+import type { CompetitorRollup } from '../../../../api/reports';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly rollup: CompetitorRollup | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Outreach targets — the prioritised list of sources that cite this
+ * competitor but not first-party brands. The lift score is already
+ * computed server-side; we just render it. Top targets get their own
+ * page because each card is meaty (URL, domain, providers) and
+ * pagination across them is what the strategist will pin to a wall.
+ */
+export function OutreachTargetsSection({
+  rollup, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Top outreach targets">
+        <SectionPlaceholder variant="loading" message="Loading…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Top outreach targets">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!rollup) return null;
+  if (rollup.outreach_targets.length === 0) {
+    return (
+      <ReportSection
+        title="Top outreach targets"
+        subtitle="No outreach targets identified."
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Either no sources cite this competitor without first-party
+          coverage, or the citation-gap analysis hasn&apos;t run yet.
+        </p>
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Top outreach targets"
+      subtitle="Sources to pitch first. Lift = provider coverage scaled by citation count. Higher lift means a single placement moves more keywords."
+      startNewPage
+    >
+      <div className="space-y-3">
+        {rollup.outreach_targets.map((target) => (
+          <TargetCard key={`${target.url}::${target.keyword}`} target={target} />
+        ))}
+      </div>
+    </ReportSection>
+  );
+}
+
+function TargetCard({target,}: {readonly target: CompetitorRollup['outreach_targets'][number];}) {
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800 avoid-break-inside">
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            {target.domain}
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {target.url}
+          </p>
+        </div>
+        <PriorityBadge priority={target.priority} />
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-3 text-xs">
+        <Metric label="Lift" value={target.lift_score.toFixed(2)} />
+        <Metric label="Citations" value={target.citation_count.toString()} />
+        <Metric label="Providers" value={target.provider_count.toString()} />
+        <Metric label="Keyword" value={target.keyword} />
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}) {
+  return (
+    <div>
+      <p className="font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+        {label}
+      </p>
+      <p className="text-gray-900 dark:text-white mt-0.5 truncate">{value}</p>
+    </div>
+  );
+}
+
+function PriorityBadge({priority,}: {readonly priority: 'high' | 'medium' | 'low';}) {
+  const styles = priorityStyles(priority);
+  return (
+    <span
+      className={`flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold uppercase ${styles}`}
+    >
+      {priority}
+    </span>
+  );
+}
+
+function priorityStyles(priority: 'high' | 'medium' | 'low'): string {
+  if (priority === 'high') {
+    return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300';
+  }
+  if (priority === 'medium') {
+    return 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300';
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+}

--- a/web/src/components/Reports/CompetitorGapReport/useCompetitorGap.spec.ts
+++ b/web/src/components/Reports/CompetitorGapReport/useCompetitorGap.spec.ts
@@ -1,0 +1,95 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCompetitorGap } from './useCompetitorGap';
+
+vi.mock('../../../hooks/useCompetitorRollup', () => ({useCompetitorRollup: vi.fn()}));
+
+import { useCompetitorRollup } from '../../../hooks/useCompetitorRollup';
+
+const mockHook = useCompetitorRollup as ReturnType<typeof vi.fn>;
+
+const SINGLE_DATA = {
+  generated_at: '2026-05-15T07:00:00Z',
+  keywords_analyzed: 4,
+  competitor: 'Adidas',
+  rollup: {
+    competitor: 'Adidas',
+    outranked_keywords: [],
+    exclusive_sources: [],
+    outreach_targets: [],
+  },
+};
+
+describe('useCompetitorGap', () => {
+  const fetchCompetitorRollup = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHook.mockReturnValue({
+      data: SINGLE_DATA,
+      loading: false,
+      error: null,
+      fetchCompetitorRollup,
+    });
+  });
+
+  it('fetches the rollup with default keyword limit when competitor is set', () => {
+    renderHook(() => useCompetitorGap('Adidas'));
+    expect(fetchCompetitorRollup).toHaveBeenCalledWith('Adidas', 50);
+  });
+
+  it('skips the fetch when competitor is null', () => {
+    renderHook(() => useCompetitorGap(null));
+    expect(fetchCompetitorRollup).not.toHaveBeenCalled();
+  });
+
+  it('exposes the narrowed rollup field for single-competitor responses', () => {
+    const { result } = renderHook(() => useCompetitorGap('Adidas'));
+    expect(result.current.rollup?.competitor).toBe('Adidas');
+  });
+
+  it('returns null rollup for all-competitors response shape', () => {
+    mockHook.mockReturnValue({
+      data: {
+        generated_at: '2026-05-15T07:00:00Z',
+        keywords_analyzed: 4,
+        competitors: ['Adidas'],
+        rollups: [],
+      },
+      loading: false,
+      error: null,
+      fetchCompetitorRollup,
+    });
+    const { result } = renderHook(() => useCompetitorGap('Adidas'));
+    expect(result.current.rollup).toBeNull();
+  });
+
+  it('reports ready=true once the rollup has loaded for a competitor', () => {
+    const { result } = renderHook(() => useCompetitorGap('Adidas'));
+    expect(result.current.ready).toBe(true);
+  });
+
+  it('reports ready=true even when no competitor is selected (no fetch fires)', () => {
+    mockHook.mockReturnValue({
+      data: null,
+      loading: false,
+      error: null,
+      fetchCompetitorRollup,
+    });
+    const { result } = renderHook(() => useCompetitorGap(null));
+    expect(result.current.ready).toBe(true);
+  });
+
+  it('reports ready=false while the rollup is loading', () => {
+    mockHook.mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+      fetchCompetitorRollup,
+    });
+    const { result } = renderHook(() => useCompetitorGap('Adidas'));
+    expect(result.current.ready).toBe(false);
+  });
+});

--- a/web/src/components/Reports/CompetitorGapReport/useCompetitorGap.ts
+++ b/web/src/components/Reports/CompetitorGapReport/useCompetitorGap.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { useCompetitorRollup } from '../../../hooks/useCompetitorRollup';
+import { useReportReady } from '../layout/useReportReady';
+import {
+  isSingleCompetitorResponse,
+  type CompetitorRollup,
+} from '../../../api/reports';
+
+const DEFAULT_KEYWORD_LIMIT = 50;
+
+/**
+ * Composes the single backend slice that powers the Competitor Gap
+ * report. Re-fires the fetch whenever the selected competitor changes
+ * so navigating between competitors via the selector dropdown reloads
+ * the rollup automatically.
+ *
+ * The `competitor` argument is `null` when the report is in its
+ * "no selection" state — the hook short-circuits the fetch in that
+ * case so we don't spin up a network call until the user picks a
+ * target.
+ */
+export function useCompetitorGap(competitor: string | null) {
+  const rollup = useCompetitorRollup();
+  const { fetchCompetitorRollup } = rollup;
+
+  useEffect(() => {
+    if (competitor) {
+      fetchCompetitorRollup(competitor, DEFAULT_KEYWORD_LIMIT);
+    }
+  }, [competitor, fetchCompetitorRollup]);
+
+  // Translate the discriminated union into a single, ergonomic
+  // `currentRollup` field so report sections don't have to re-narrow
+  // the union themselves.
+  const currentRollup: CompetitorRollup | null
+    = rollup.data && isSingleCompetitorResponse(rollup.data)
+      ? rollup.data.rollup
+      : null;
+
+  // When the selected competitor is unset we don't fetch, so the slice
+  // is trivially "ready" — gating only matters once a target is picked.
+  const slice = competitor
+    ? rollup
+    : {
+      loading: false,
+      data: {},
+      error: null 
+    };
+  const ready = useReportReady([slice]);
+
+  return {
+    competitor,
+    rollup: currentRollup,
+    keywordsAnalyzed: rollup.data?.keywords_analyzed ?? 0,
+    loading: rollup.loading,
+    error: rollup.error,
+    ready,
+  };
+}
+
+export type CompetitorGapData = ReturnType<typeof useCompetitorGap>;

--- a/web/src/components/Reports/ReportsLandingView.spec.tsx
+++ b/web/src/components/Reports/ReportsLandingView.spec.tsx
@@ -61,10 +61,16 @@ describe('ReportsLandingView', () => {
     expect(link).toHaveAttribute('href', '/reports/executive-summary');
   });
 
-  it('marks the one unbuilt report as Coming soon and not as a link', () => {
+  it('renders Competitor Gap as a working link to /reports/competitor', () => {
     renderLanding();
-    const comingSoonBadges = screen.getAllByText(/coming soon/i);
-    expect(comingSoonBadges).toHaveLength(1);
+    const link = screen.getByRole('link', { name: /competitor gap/i });
+    expect(link).toHaveAttribute('href', '/reports/competitor');
+  });
+
+  it('lists every report as available with a working link', () => {
+    renderLanding();
+    const comingSoonBadges = screen.queryAllByText(/coming soon/i);
+    expect(comingSoonBadges).toHaveLength(0);
   });
 
   it('shows the executive and marketing-lead audiences', () => {

--- a/web/src/components/Reports/ReportsLandingView.tsx
+++ b/web/src/components/Reports/ReportsLandingView.tsx
@@ -40,8 +40,8 @@ const REPORT_CATALOG: readonly ReportEntry[] = [
     description:
       'For each tracked competitor: keywords where they outrank you, citation sources unique to them, and a prioritized outreach list ranked by potential visibility lift.',
     audience: 'Content / PR strategist',
-    path: null,
-    status: 'coming-soon',
+    path: '/reports/competitor',
+    status: 'available',
   },
   {
     id: 'content-action-plan',

--- a/web/src/components/Reports/ReportsRouter.tsx
+++ b/web/src/components/Reports/ReportsRouter.tsx
@@ -30,6 +30,10 @@ const ExecutiveSummaryReport = lazy(() =>
   import('./ExecutiveSummaryReport').then((m) => ({default: m.ExecutiveSummaryReport,})),
 );
 
+const CompetitorGapReport = lazy(() =>
+  import('./CompetitorGapReport').then((m) => ({default: m.CompetitorGapReport,})),
+);
+
 interface Props {readonly keywords: ReadonlyArray<Keyword>;}
 
 function ReportFallback() {
@@ -80,6 +84,14 @@ export function ReportsRouter({ keywords }: Props) {
           <Route
             path="/reports/executive-summary"
             element={<ExecutiveSummaryReport />}
+          />
+          <Route
+            path="/reports/competitor"
+            element={<CompetitorGapReport />}
+          />
+          <Route
+            path="/reports/competitor/:competitor"
+            element={<CompetitorGapReport />}
           />
           <Route path="*" element={<Navigate to="/reports" replace />} />
         </Routes>

--- a/web/src/components/Reports/index.ts
+++ b/web/src/components/Reports/index.ts
@@ -4,3 +4,4 @@ export { KeywordDeepDiveReport } from './KeywordDeepDiveReport';
 export { ContentActionPlanReport } from './ContentActionPlanReport';
 export { BrandVisibilityReport } from './BrandVisibilityReport';
 export { ExecutiveSummaryReport } from './ExecutiveSummaryReport';
+export { CompetitorGapReport } from './CompetitorGapReport';

--- a/web/src/hooks/useCompetitorRollup.spec.ts
+++ b/web/src/hooks/useCompetitorRollup.spec.ts
@@ -1,0 +1,128 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import {
+  renderHook, act 
+} from '@testing-library/react';
+import { useCompetitorRollup } from './useCompetitorRollup';
+
+vi.mock('../infrastructure', async () => {
+  const actual = await vi.importActual('../infrastructure');
+  return {
+    ...actual,
+    API_BASE_URL: 'https://api.test.com',
+    authenticatedFetch: vi.fn(),
+  };
+});
+
+import { authenticatedFetch } from '../infrastructure';
+
+const mockFetch = authenticatedFetch as ReturnType<typeof vi.fn>;
+
+const SINGLE_RESPONSE = {
+  generated_at: '2026-05-15T07:00:00Z',
+  keywords_analyzed: 4,
+  competitor: 'Adidas',
+  rollup: {
+    competitor: 'Adidas',
+    outranked_keywords: [],
+    exclusive_sources: [],
+    outreach_targets: [],
+  },
+};
+
+const ALL_RESPONSE = {
+  generated_at: '2026-05-15T07:00:00Z',
+  keywords_analyzed: 4,
+  competitors: ['Adidas', 'Asics'],
+  rollups: [
+    {
+      competitor: 'Adidas',
+      outranked_keywords: [],
+      exclusive_sources: [],
+      outreach_targets: [],
+    },
+  ],
+};
+
+function mockOk(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+describe('useCompetitorRollup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null data before fetch', () => {
+    const { result } = renderHook(() => useCompetitorRollup());
+    expect(result.current.data).toBeNull();
+  });
+
+  it('passes the competitor name in the URL when provided', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Adidas');
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('competitor=Adidas');
+  });
+
+  it('omits competitor param when not provided', async () => {
+    mockFetch.mockResolvedValue(mockOk(ALL_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).not.toContain('competitor=');
+  });
+
+  it('stores the parsed single-competitor response', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Adidas');
+    });
+    expect(result.current.data).toStrictEqual(SINGLE_RESPONSE);
+  });
+
+  it('stores the parsed all-competitors response', async () => {
+    mockFetch.mockResolvedValue(mockOk(ALL_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    expect(result.current.data).toStrictEqual(ALL_RESPONSE);
+  });
+
+  it('records the error message when the response is not OK', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({}),
+    } as unknown as Response);
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Unknown');
+    });
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('rejects responses missing both rollup and rollups fields', async () => {
+    mockFetch.mockResolvedValue(mockOk({ unrelated: 'shape' }));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    expect(result.current.error).toBeTruthy();
+  });
+});

--- a/web/src/hooks/useCompetitorRollup.ts
+++ b/web/src/hooks/useCompetitorRollup.ts
@@ -1,0 +1,87 @@
+import {
+  useState, useCallback,
+} from 'react';
+import {
+  API_BASE_URL,
+  authenticatedFetch,
+  getErrorMessage,
+  ApiRequestError,
+} from '../infrastructure';
+import type { CompetitorReportResponse } from '../api/reports';
+
+interface BackendErrorResponse {error: string;}
+
+function isBackendErrorResponse(data: unknown): data is BackendErrorResponse {
+  return typeof data === 'object'
+    && data !== null
+    && 'error' in data
+    && typeof (data as BackendErrorResponse).error === 'string';
+}
+
+function isCompetitorReportResponse(
+  data: unknown,
+): data is CompetitorReportResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  if ('error' in data) return false;
+  // Single-competitor variant has `rollup`; all-competitors has `rollups`.
+  return 'rollup' in data || 'rollups' in data;
+}
+
+/**
+ * Imperative hook for the competitor rollup endpoint. Pairs with the
+ * Competitor Gap report (a follow-up PR) and any ad-hoc lookups in
+ * the dashboard.
+ *
+ * Imperative rather than auto-fetching so the caller (the report
+ * component) can trigger a fresh load when the selected competitor
+ * changes without re-mounting.
+ */
+export function useCompetitorRollup() {
+  const [data, setData] = useState<CompetitorReportResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCompetitorRollup = useCallback(async (
+    competitor?: string,
+    keywordLimit = 50,
+  ): Promise<CompetitorReportResponse | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ keyword_limit: keywordLimit.toString() });
+      if (competitor) params.append('competitor', competitor);
+      const response = await authenticatedFetch(
+        `${API_BASE_URL}/reports/competitor?${params}`,
+      );
+      if (!response.ok) {
+        throw new ApiRequestError(
+          'Failed to fetch competitor rollup',
+          response.status,
+        );
+      }
+      const json: unknown = await response.json();
+      if (isBackendErrorResponse(json)) {
+        throw new ApiRequestError(json.error);
+      }
+      if (!isCompetitorReportResponse(json)) {
+        throw new ApiRequestError('Invalid response format');
+      }
+      setData(json);
+      return json;
+    } catch (err) {
+      const message = getErrorMessage(err, 'visibility');
+      setError(message);
+      console.error('[competitorRollup] Error:', err);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    data,
+    loading,
+    error,
+    fetchCompetitorRollup,
+  };
+}


### PR DESCRIPTION
Adds the Competitor Gap report (Report 3 of 5). Depends on /reports/competitor endpoint from #46. Stacks on #44. Completes the 5-report series.