### PR TITLE
fix(crawler): remove slider CAPTCHA bypass, rely on Web Bot Auth

### DIFF
--- a/lambda/shared/browser_tools.py
+++ b/lambda/shared/browser_tools.py
@@ -154,8 +154,25 @@ class SimpleBrowserTools:
             # Wait for dynamic content
             self.page.wait_for_timeout(3000)
             
-            # Check for and handle slider challenges
-            self._handle_slider_challenge()
+            # Detect (don't bypass) CAPTCHA challenges. The crawler runs
+            # against an Amazon Bedrock AgentCore Browser configured with
+            # `browserSigning: { enabled: true }` (Web Bot Auth — see CDK
+            # `CrawlerBrowser` and the AWS blog post on the protocol). For
+            # domains that allow verified bots this typically prevents
+            # CAPTCHAs from being shown at all. For domains that still
+            # block our agent, we record the page as blocked and move on
+            # — we do NOT attempt to programmatically solve or bypass the
+            # challenge.
+            if self._detect_captcha_block():
+                logger.warning(
+                    f"CAPTCHA-protected page; recording as blocked: {url}"
+                )
+                return {
+                    "status": "blocked",
+                    "url": url,
+                    "block_reason": "captcha",
+                    "timestamp": datetime.utcnow().isoformat() + 'Z',
+                }
             
             title = self.page.title()
             
@@ -174,108 +191,41 @@ class SimpleBrowserTools:
                 "error": str(e)
             }
     
-    def _handle_slider_challenge(self) -> bool:
+    def _detect_captcha_block(self) -> bool:
         """
-        Detect and attempt to complete slider verification challenges.
-        
-        Returns True if a slider was found and completed, False otherwise.
+        Return True if the current page is a CAPTCHA / bot-challenge wall.
+
+        Detection only — never solves or bypasses. The crawler relies on
+        Amazon Bedrock AgentCore Browser's Web Bot Auth signing (configured
+        in the CDK) to reduce CAPTCHA encounters on domains that allow
+        verified bots. When a domain still gates us behind a CAPTCHA, we
+        respect that decision and record the page as blocked.
+
+        See: https://aws.amazon.com/blogs/machine-learning/reduce-captchas-for-ai-agents-browsing-the-web-with-web-bot-auth-preview-in-amazon-bedrock-agentcore-browser/
         """
         try:
-            # Check for common slider challenge indicators in page content
-            page_text = self.page.evaluate("() => document.body.innerText").lower()
-            
-            slider_indicators = [
-                'slide right to secure',
-                'slide to verify',
-                'slide right to access',
-                'drag the slider',
-                'slide to unlock',
-            ]
-            
-            has_slider = any(indicator in page_text for indicator in slider_indicators)
-            
-            if not has_slider:
-                return False
-            
-            logger.info("Slider challenge detected, attempting to complete...")
-            
-            # Common slider selectors used by various CAPTCHA providers
-            slider_selectors = [
-                # Generic arrow/slider buttons
-                'button[aria-label*="slide"]',
-                'div[class*="slider"] button',
-                'div[class*="slider"] span',
-                '[class*="slide-btn"]',
-                '[class*="slider-button"]',
-                # TripAdvisor specific patterns
-                'button svg[viewBox]',
-                'div[class*="captcha"] button',
-                # Arrow buttons
-                'button:has(svg)',
-            ]
-            
-            slider_element = None
-            for selector in slider_selectors:
-                try:
-                    element = self.page.query_selector(selector)
-                    if element and element.is_visible():
-                        slider_element = element
-                        logger.info(f"Found slider element with selector: {selector}")
-                        break
-                except Exception:
-                    continue
-            
-            if not slider_element:
-                logger.warning("Slider challenge detected but could not find slider element")
-                return False
-            
-            # Get the bounding box of the slider
-            box = slider_element.bounding_box()
-            if not box:
-                logger.warning("Could not get slider bounding box")
-                return False
-            
-            # Calculate drag distance (slide to the right)
-            start_x = box['x'] + box['width'] / 2
-            start_y = box['y'] + box['height'] / 2
-            
-            # Drag 300 pixels to the right (typical slider width)
-            end_x = start_x + 300
-            
-            logger.info(f"Dragging slider from ({start_x}, {start_y}) to ({end_x}, {start_y})")
-            
-            # Perform the drag with human-like movement
-            self.page.mouse.move(start_x, start_y)
-            self.page.wait_for_timeout(100)
-            self.page.mouse.down()
-            self.page.wait_for_timeout(50)
-            
-            # Move in steps for more natural movement
-            steps = 10
-            for i in range(1, steps + 1):
-                intermediate_x = start_x + (end_x - start_x) * i / steps
-                self.page.mouse.move(intermediate_x, start_y)
-                self.page.wait_for_timeout(30)
-            
-            self.page.mouse.up()
-            
-            # Wait for verification to complete
-            self.page.wait_for_timeout(2000)
-            
-            # Check if we're still on a challenge page
-            new_page_text = self.page.evaluate("() => document.body.innerText").lower()
-            still_has_slider = any(indicator in new_page_text for indicator in slider_indicators)
-            
-            if still_has_slider:
-                logger.warning("Slider challenge still present after attempt")
-                return False
-            
-            logger.info("Slider challenge completed successfully")
-            return True
-            
-        except Exception as e:
-            logger.error(f"Error handling slider challenge: {e}")
+            page_text = self.page.evaluate(
+                "() => document.body.innerText"
+            ).lower()
+        except Exception as exc:
+            logger.warning(f"Could not read page text for CAPTCHA detection: {exc}")
             return False
+
+        # Common phrasings that indicate a CAPTCHA / verification wall.
+        # Matched conservatively so a site that mentions "captcha" in
+        # documentation isn't false-flagged.
+        indicators = (
+            'slide to verify',
+            'slide right to secure',
+            'slide right to access',
+            'drag the slider',
+            'slide to unlock',
+            'verify you are human',
+            'prove you are not a robot',
+            'i am not a robot',
+            'please complete the security check',
+        )
+        return any(indicator in page_text for indicator in indicators)
     
     def extract_page_content(self) -> Dict:
         """Extract main content from the current page."""

--- a/lambda/shared/test_captcha_detection.py
+++ b/lambda/shared/test_captcha_detection.py
@@ -1,0 +1,181 @@
+"""
+Tests for the CAPTCHA detection logic in `browser_tools.SimpleBrowserTools`.
+
+Behaviour pinned by these tests:
+
+- The crawler DETECTS CAPTCHA-protected pages and reports them as
+  `status: "blocked", block_reason: "captcha"`.
+- The crawler does NOT solve, drag, or otherwise bypass the challenge.
+  The legitimate path is Web Bot Auth on Amazon Bedrock AgentCore Browser
+  (configured in CDK as `browserSigning: { enabled: true }`).
+- Detection covers the wording families seen in the wild (slide-to-verify,
+  human-verification, recaptcha-style "I am not a robot") with conservative
+  matching to avoid false positives.
+
+The live browser interaction can't run in unit tests; we mock the
+Playwright `page` and verify the public surface of `navigate_to_url` plus
+the `_detect_captcha_block` predicate directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# browser_tools imports playwright + bedrock_agentcore at module scope. Stub
+# them so the test runner doesn't need the real layer installed.
+_fake_playwright = types.ModuleType('playwright')
+_fake_sync_api = types.ModuleType('playwright.sync_api')
+for _name in ('Browser', 'BrowserContext', 'Page'):
+    setattr(_fake_sync_api, _name, object)
+_fake_sync_api.sync_playwright = lambda: None
+_fake_playwright.sync_api = _fake_sync_api
+sys.modules.setdefault('playwright', _fake_playwright)
+sys.modules.setdefault('playwright.sync_api', _fake_sync_api)
+
+_fake_boto3 = types.ModuleType('boto3')
+_fake_boto3.resource = lambda *a, **kw: MagicMock()
+_fake_boto3.client = lambda *a, **kw: MagicMock()
+sys.modules.setdefault('boto3', _fake_boto3)
+
+# Stub the BedrockAgentCore SDK shape browser_tools imports lazily.
+_fake_bac = types.ModuleType('bedrock_agentcore')
+_fake_bac_tools = types.ModuleType('bedrock_agentcore.tools')
+_fake_bac_browser = types.ModuleType('bedrock_agentcore.tools.browser_client')
+_fake_bac_browser.BrowserClient = object
+_fake_bac_utils = types.ModuleType('bedrock_agentcore._utils')
+_fake_bac_endpoints = types.ModuleType('bedrock_agentcore._utils.endpoints')
+_fake_bac_endpoints.get_control_plane_endpoint = lambda *_a, **_k: 'https://example.invalid'
+sys.modules.setdefault('bedrock_agentcore', _fake_bac)
+sys.modules.setdefault('bedrock_agentcore.tools', _fake_bac_tools)
+sys.modules.setdefault('bedrock_agentcore.tools.browser_client', _fake_bac_browser)
+sys.modules.setdefault('bedrock_agentcore._utils', _fake_bac_utils)
+sys.modules.setdefault('bedrock_agentcore._utils.endpoints', _fake_bac_endpoints)
+
+sys.path.insert(0, os.path.dirname(__file__))
+import browser_tools  # type: ignore[import-not-found]
+importlib.reload(browser_tools)
+
+
+@pytest.fixture
+def tools_with_page():
+    """Build a SimpleBrowserTools-like object with a mocked Playwright page."""
+    tools = browser_tools.SimpleBrowserTools.__new__(
+        browser_tools.SimpleBrowserTools,
+    )
+    tools.page = MagicMock()
+    return tools
+
+
+# --- _detect_captcha_block ---------------------------------------------
+
+
+def test_detects_slide_to_verify_phrasing(tools_with_page):
+    tools_with_page.page.evaluate.return_value = (
+        'Welcome. Please slide to verify before continuing.'
+    )
+    assert tools_with_page._detect_captcha_block() is True
+
+
+def test_detects_drag_the_slider_phrasing(tools_with_page):
+    tools_with_page.page.evaluate.return_value = (
+        'Bot check: drag the slider to confirm.'
+    )
+    assert tools_with_page._detect_captcha_block() is True
+
+
+def test_detects_recaptcha_style_human_verification(tools_with_page):
+    tools_with_page.page.evaluate.return_value = (
+        'Verify you are human to access the next page.'
+    )
+    assert tools_with_page._detect_captcha_block() is True
+
+
+def test_detects_i_am_not_a_robot_checkbox_text(tools_with_page):
+    tools_with_page.page.evaluate.return_value = (
+        'Please tick: I am not a robot.'
+    )
+    assert tools_with_page._detect_captcha_block() is True
+
+
+def test_returns_false_for_normal_content(tools_with_page):
+    tools_with_page.page.evaluate.return_value = (
+        'The 10 best hotels in Barcelona for families travelling with kids.'
+    )
+    assert tools_with_page._detect_captcha_block() is False
+
+
+def test_returns_false_when_page_evaluate_raises(tools_with_page):
+    class PageEvalError(Exception):
+        pass
+    tools_with_page.page.evaluate.side_effect = PageEvalError('connection lost')
+    # The crawler should err on the side of "not a CAPTCHA" rather than
+    # mark a page as blocked because we couldn't read it.
+    assert tools_with_page._detect_captcha_block() is False
+
+
+def test_match_is_case_insensitive(tools_with_page):
+    tools_with_page.page.evaluate.return_value = (
+        'PROVE YOU ARE NOT A ROBOT.'
+    )
+    assert tools_with_page._detect_captcha_block() is True
+
+
+# --- navigate_to_url --------------------------------------------------
+
+
+def test_navigate_returns_blocked_status_when_captcha_detected(tools_with_page):
+    tools_with_page.page.evaluate.return_value = 'slide to verify and continue'
+    result = tools_with_page.navigate_to_url('https://example.com/blocked')
+    assert result['status'] == 'blocked'
+
+
+def test_navigate_records_captcha_as_block_reason(tools_with_page):
+    tools_with_page.page.evaluate.return_value = 'slide to verify and continue'
+    result = tools_with_page.navigate_to_url('https://example.com/blocked')
+    assert result['block_reason'] == 'captcha'
+
+
+def test_navigate_records_blocked_url_in_result(tools_with_page):
+    tools_with_page.page.evaluate.return_value = 'slide to verify and continue'
+    result = tools_with_page.navigate_to_url('https://example.com/blocked')
+    assert result['url'] == 'https://example.com/blocked'
+
+
+def test_navigate_succeeds_on_normal_page(tools_with_page):
+    tools_with_page.page.evaluate.return_value = 'Normal article content here.'
+    tools_with_page.page.title.return_value = 'A regular page'
+    result = tools_with_page.navigate_to_url('https://example.com/article')
+    assert result['status'] == 'success'
+    assert result['title'] == 'A regular page'
+
+
+def test_navigate_does_not_attempt_to_drag_or_solve_on_captcha(tools_with_page):
+    tools_with_page.page.evaluate.return_value = 'slide to verify'
+    tools_with_page.navigate_to_url('https://example.com/blocked')
+    # Regression guard: the bypass code attempted to drag the mouse to
+    # solve the CAPTCHA. Verify no mouse interaction is invoked here.
+    assert tools_with_page.page.mouse.down.called is False
+    assert tools_with_page.page.mouse.up.called is False
+
+
+def test_handle_slider_challenge_method_is_removed():
+    # Regression guard: the previous bypass method should no longer exist
+    # on the class. If reintroduced this test fails so the change can be
+    # caught at review.
+    assert not hasattr(
+        browser_tools.SimpleBrowserTools, '_handle_slider_challenge',
+    )
+
+
+def test_compute_slider_drag_distance_method_is_removed():
+    # Regression guard for the dynamic drag-distance helper proposed in
+    # PR #33 (audit #31). Should not be present.
+    assert not hasattr(
+        browser_tools.SimpleBrowserTools, '_compute_slider_drag_distance',
+    )


### PR DESCRIPTION
Removes the slider CAPTCHA bypass from `browser_tools.py` and replaces it with a detect-and-record-as-blocked path. The legitimate Web Bot Auth signing is already configured on the AgentCore browser in CDK (`browserSigning: { enabled: true }`); see [the AWS blog post on Web Bot Auth](https://aws.amazon.com/blogs/machine-learning/reduce-captchas-for-ai-agents-browsing-the-web-with-web-bot-auth-preview-in-amazon-bedrock-agentcore-browser/).

Companion PR: #33 (already cleaned — slider commit dropped from that branch).

See commit message for the full rationale (CFAA, DMCA §1201, ToS, repo scope) and behaviour change notes.