### PR TITLE
feat(web): Brand Visibility report (re-merge of #42)

### DIFF
--- a/web/src/components/Reports/BrandVisibilityReport/BrandVisibilityReport.spec.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/BrandVisibilityReport.spec.tsx
@@ -1,0 +1,240 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import {
+  render, screen,
+} from '@testing-library/react';
+import {
+  MemoryRouter, Routes, Route 
+} from 'react-router-dom';
+import { BrandVisibilityReport } from './BrandVisibilityReport';
+import type { Keyword } from '../../../types';
+
+vi.mock('./useBrandVisibilityReport', () => ({useBrandVisibilityReport: vi.fn()}));
+vi.mock('../../../hooks/usePrintMode', () => ({usePrintMode: vi.fn(() => ({ isPrintMode: false })),}));
+
+import { useBrandVisibilityReport } from './useBrandVisibilityReport';
+
+const mockUse = useBrandVisibilityReport as ReturnType<typeof vi.fn>;
+
+const KEYWORDS: Keyword[] = [
+  {
+    id: '1',
+    keyword: 'best running shoes',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: '2',
+    keyword: 'best hiking boots',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+const PER_KEYWORD_DATA = {
+  keyword: 'best running shoes',
+  visibility: {
+    keyword: 'best running shoes',
+    timestamp: '2026-05-10T00:00:00Z',
+    total_brands: 4,
+    total_mentions: 20,
+    brands: [
+      {
+        name: 'Nike',
+        visibility_score: 80,
+        provider_count: 4,
+        providers: ['openai', 'perplexity', 'gemini', 'claude'],
+        total_mentions: 12,
+        best_rank: 1,
+        avg_sentiment: 0.5,
+        share_of_voice: 60,
+        classification: 'first_party' as const,
+      },
+    ],
+    first_party: [],
+    competitors: [],
+    others: [],
+    summary: {
+      first_party_avg_score: 80,
+      competitor_avg_score: 50,
+      first_party_total_sov: 60,
+      competitor_total_sov: 40,
+    },
+  },
+  visibilityLoading: false,
+  visibilityError: null,
+  trends: {
+    period_type: 'day',
+    days_analyzed: 30,
+    data_points: 30,
+    trend_data: [],
+    trend_direction: 'stable',
+    summary: {
+      current_score: 80,
+      previous_score: 78,
+      change: 2,
+      change_percent: 2.5,
+      average_score: 79,
+      max_score: 82,
+      min_score: 76,
+    },
+  },
+  trendsLoading: false,
+  trendsError: null,
+  ready: true,
+};
+
+const ALL_KEYWORDS_DATA = {
+  keyword: null,
+  visibility: null,
+  visibilityLoading: false,
+  visibilityError: null,
+  trends: {
+    period_type: 'day',
+    days_analyzed: 30,
+    data_points: 0,
+    trend_data: [],
+    trend_direction: 'stable',
+    summary: {
+      current_score: 0,
+      previous_score: 0,
+      change: 0,
+      change_percent: 0,
+      average_score: 0,
+      max_score: 0,
+      min_score: 0,
+    },
+    keyword_trends: [
+      {
+        keyword: 'best running shoes',
+        trend_direction: 'improving',
+        current_score: 80,
+        change: 8,
+        change_percent: 11.1,
+      },
+      {
+        keyword: 'best hiking boots',
+        trend_direction: 'declining',
+        current_score: 30,
+        change: -10,
+        change_percent: -25,
+      },
+    ],
+    overall: {
+      improving_count: 1,
+      declining_count: 1,
+      stable_count: 0,
+      avg_score: 55,
+    },
+  },
+  trendsLoading: false,
+  trendsError: null,
+  ready: true,
+};
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/reports/visibility"
+          element={<BrandVisibilityReport keywords={KEYWORDS} />}
+        />
+        <Route
+          path="/reports/visibility/:keyword"
+          element={<BrandVisibilityReport keywords={KEYWORDS} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('BrandVisibilityReport — per-keyword variant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUse.mockReturnValue(PER_KEYWORD_DATA);
+  });
+
+  it('renders the report H1', () => {
+    renderAt('/reports/visibility/best%20running%20shoes');
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Brand Visibility/i 
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the per-keyword subtitle with the selected keyword', () => {
+    renderAt('/reports/visibility/best%20running%20shoes');
+    const matches = screen.getAllByText(/best running shoes/i);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it('renders a brand row from visibility data', () => {
+    renderAt('/reports/visibility/best%20running%20shoes');
+    expect(screen.getByText('Nike')).toBeInTheDocument();
+  });
+
+  it('renders the gap-to-competitor headline metric', () => {
+    renderAt('/reports/visibility/best%20running%20shoes');
+    expect(screen.getByText('+30.0')).toBeInTheDocument();
+  });
+});
+
+describe('BrandVisibilityReport — all-keywords variant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUse.mockReturnValue(ALL_KEYWORDS_DATA);
+  });
+
+  it('renders the cross-keyword subtitle', () => {
+    renderAt('/reports/visibility');
+    expect(screen.getByText(/Cross-keyword visibility overview/i)).toBeInTheDocument();
+  });
+
+  it('renders the improving / declining / stable counts from overall aggregates', () => {
+    renderAt('/reports/visibility');
+    // Fixture: improving=1, declining=1. The labels "Improving" and
+    // "Declining" appear twice — once as paragraph metric labels in the
+    // headline, once as h3 column titles in MoversSection. Disambiguate
+    // by tag: the metric panel uses a <p>, the column uses an <h3>.
+    const labels = screen.getAllByText('Improving');
+    const metricLabel = labels.find((el) => el.tagName === 'P');
+    expect(metricLabel?.parentElement).toHaveTextContent('1');
+  });
+
+  it('renders the average score from overall aggregates', () => {
+    renderAt('/reports/visibility');
+    // Fixture: avg_score=55 -> "55.0" formatted.
+    expect(screen.getByText('55.0')).toBeInTheDocument();
+  });
+
+  it('renders the per-keyword leaderboard rows for every tracked keyword', () => {
+    renderAt('/reports/visibility');
+    const shoesMatches = screen.getAllByText('best running shoes');
+    const bootsMatches = screen.getAllByText('best hiking boots');
+    expect(shoesMatches.length).toBeGreaterThan(0);
+    expect(bootsMatches.length).toBeGreaterThan(0);
+  });
+
+  it('orders the leaderboard by current_score descending', () => {
+    renderAt('/reports/visibility');
+    // Fixture: shoes=80, boots=30 — shoes should appear above boots in the table.
+    // Filter to rows that contain a keyword cell.
+    const tables = screen.getAllByRole('table');
+    const leaderboard = tables[tables.length - 1];
+    const text = leaderboard.textContent ?? '';
+    expect(text.indexOf('best running shoes')).toBeLessThan(
+      text.indexOf('best hiking boots'),
+    );
+  });
+
+  it('renders the keyword scope selector populated with All + every tracked keyword', () => {
+    renderAt('/reports/visibility');
+    const select = screen.getByLabelText(/scope/i) as HTMLSelectElement;
+    const optionTexts = Array.from(select.options).map((o) => o.textContent);
+    expect(optionTexts).toContain('All keywords');
+    expect(optionTexts).toContain('best running shoes');
+    expect(optionTexts).toContain('best hiking boots');
+  });
+});

--- a/web/src/components/Reports/BrandVisibilityReport/BrandVisibilityReport.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/BrandVisibilityReport.tsx
@@ -1,0 +1,155 @@
+import { useEffect } from 'react';
+import {
+  useNavigate, useParams 
+} from 'react-router-dom';
+import { usePrintMode } from '../../../hooks/usePrintMode';
+import {
+  ReportLayout, ReportKeywordSelector 
+} from '../layout';
+import type { Keyword } from '../../../types';
+import { useBrandVisibilityReport } from './useBrandVisibilityReport';
+import { PerKeywordHeadlineSection } from './sections/PerKeywordHeadlineSection';
+import { BrandRankingsSection } from './sections/BrandRankingsSection';
+import { TrendHistorySection } from './sections/TrendHistorySection';
+import { CrossKeywordHeadlineSection } from './sections/CrossKeywordHeadlineSection';
+import { PerKeywordTableSection } from './sections/PerKeywordTableSection';
+import { MoversSection } from './sections/MoversSection';
+
+interface Props {readonly keywords: ReadonlyArray<Keyword>;}
+
+/**
+ * Brand Visibility report. Two URL shapes:
+ *   - `/reports/visibility` — all-keywords overview
+ *   - `/reports/visibility/:keyword` — per-keyword deep cut
+ *
+ * The presence of `:keyword` is the mode switch. A keyword selector at
+ * the top lets the user jump between modes from inside the report (it's
+ * print-hidden so the PDF doesn't carry the dropdown).
+ *
+ * The marketing-lead audience reads this for "are we winning, level, or
+ * losing", so the per-keyword variant is anchored on the gap to
+ * competitor average and the all-keywords variant on improving vs
+ * declining counts.
+ */
+export function BrandVisibilityReport({ keywords }: Props) {
+  const params = useParams<{ keyword?: string }>();
+  const navigate = useNavigate();
+
+  const selected = params.keyword ? decodeURIComponent(params.keyword) : null;
+
+  // Auto-redirect: if the user navigated to /reports/visibility/:keyword
+  // with a slug that no longer matches any tracked keyword, fall back to
+  // the all-keywords overview rather than render a confusing empty state.
+  useEffect(() => {
+    if (
+      selected
+      && keywords.length > 0
+      && !keywords.some((k) => k.keyword === selected)
+    ) {
+      navigate('/reports/visibility', { replace: true });
+    }
+  }, [selected, keywords, navigate]);
+
+  const data = useBrandVisibilityReport(selected);
+
+  usePrintMode({ ready: data.ready });
+
+  const subtitle = selected
+    ? `Per-keyword visibility for "${selected}"`
+    : 'Cross-keyword visibility overview';
+
+  return (
+    <ReportLayout
+      title="Brand Visibility"
+      subtitle={subtitle}
+      actions={(
+        <KeywordSwitcher
+          selected={selected}
+          keywords={keywords}
+          onChange={(next) => {
+            if (next === null) {
+              navigate('/reports/visibility');
+            } else {
+              navigate(`/reports/visibility/${encodeURIComponent(next)}`);
+            }
+          }}
+        />
+      )}
+    >
+      {selected ? (
+        <>
+          <PerKeywordHeadlineSection
+            visibility={data.visibility}
+            trends={data.trends}
+            loading={data.visibilityLoading || data.trendsLoading}
+            error={data.visibilityError ?? data.trendsError}
+          />
+          <BrandRankingsSection
+            visibility={data.visibility}
+            loading={data.visibilityLoading}
+            error={data.visibilityError}
+          />
+          <TrendHistorySection
+            trends={data.trends}
+            loading={data.trendsLoading}
+            error={data.trendsError}
+          />
+        </>
+      ) : (
+        <>
+          <CrossKeywordHeadlineSection
+            trends={data.trends}
+            loading={data.trendsLoading}
+            error={data.trendsError}
+          />
+          <MoversSection
+            trends={data.trends}
+            loading={data.trendsLoading}
+            error={data.trendsError}
+          />
+          <PerKeywordTableSection
+            trends={data.trends}
+            loading={data.trendsLoading}
+            error={data.trendsError}
+          />
+        </>
+      )}
+    </ReportLayout>
+  );
+}
+
+function KeywordSwitcher({
+  selected,
+  keywords,
+  onChange,
+}: {
+  readonly selected: string | null;
+  readonly keywords: ReadonlyArray<Keyword>;
+  readonly onChange: (next: string | null) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <label htmlFor="visibility-mode" className="text-gray-600 dark:text-gray-400">
+        Scope:
+      </label>
+      <select
+        id="visibility-mode"
+        value={selected ?? '__all__'}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(v === '__all__' ? null : v);
+        }}
+        className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+      >
+        <option value="__all__">All keywords</option>
+        {keywords.map((k) => (
+          <option key={k.keyword} value={k.keyword}>{k.keyword}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// Re-exported for the case where someone wants a bare per-keyword selector
+// elsewhere. Keeps the import surface small and tree-shakeable.
+export { ReportKeywordSelector };

--- a/web/src/components/Reports/BrandVisibilityReport/index.ts
+++ b/web/src/components/Reports/BrandVisibilityReport/index.ts
@@ -1,0 +1,2 @@
+export { BrandVisibilityReport } from './BrandVisibilityReport';
+export { useBrandVisibilityReport } from './useBrandVisibilityReport';

--- a/web/src/components/Reports/BrandVisibilityReport/sections/BrandRankingsSection.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/BrandRankingsSection.tsx
@@ -1,0 +1,139 @@
+import type { VisibilityMetricsResponse } from '../../../../types';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly visibility: VisibilityMetricsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const MAX_BRANDS = 15;
+
+/**
+ * Per-keyword brand rankings: every brand the AI engines mentioned for this
+ * keyword, with score, share of voice, best rank, mentions, providers, and
+ * classification. First-party rows are tinted to make them visually
+ * distinguishable from competitor and other-third-party rows in print.
+ */
+export function BrandRankingsSection({
+  visibility, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Brand rankings">
+        <SectionPlaceholder variant="loading" message="Loading brand rankings…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Brand rankings">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!visibility) return null;
+
+  const brands = visibility.brands.slice(0, MAX_BRANDS);
+  if (brands.length === 0) {
+    return (
+      <ReportSection title="Brand rankings">
+        <SectionPlaceholder
+          variant="empty"
+          message="No brand mentions extracted for this keyword."
+        />
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection
+      title="Brand rankings"
+      subtitle="All brands the AI engines mentioned for this keyword. First-party rows are highlighted."
+    >
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>Brand</Th>
+              <Th>Score</Th>
+              <Th>Share of voice</Th>
+              <Th>Best rank</Th>
+              <Th>Mentions</Th>
+              <Th>Providers</Th>
+              <Th>Type</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {brands.map((brand) => (
+              <tr
+                key={brand.name}
+                className={brand.classification === 'first_party' ? 'bg-emerald-50 dark:bg-emerald-950/20' : ''}
+              >
+                <Td className="font-medium">{brand.name}</Td>
+                <Td>{brand.visibility_score.toFixed(1)}</Td>
+                <Td>{brand.share_of_voice.toFixed(1)}%</Td>
+                <Td>{brand.best_rank ?? '—'}</Td>
+                <Td>{brand.total_mentions}</Td>
+                <Td>{brand.provider_count}</Td>
+                <Td>
+                  <ClassificationBadge classification={brand.classification} />
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}
+
+function ClassificationBadge({classification,}: {readonly classification: 'first_party' | 'competitor' | 'other';}) {
+  const styles = badgeStyles(classification);
+  const label = classification === 'first_party'
+    ? 'first-party'
+    : classification;
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${styles}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function badgeStyles(c: 'first_party' | 'competitor' | 'other'): string {
+  if (c === 'first_party') {
+    return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300';
+  }
+  if (c === 'competitor') {
+    return 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300';
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+}

--- a/web/src/components/Reports/BrandVisibilityReport/sections/CrossKeywordHeadlineSection.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/CrossKeywordHeadlineSection.tsx
@@ -1,0 +1,84 @@
+import type { HistoricalTrendsResponse } from '../../../../types';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * All-keywords overview header — improving / declining / stable counts plus
+ * the average score. Reads from `/trends` (no keyword) which already
+ * computes these aggregates server-side.
+ */
+export function CrossKeywordHeadlineSection({
+  trends, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="loading" message="Loading aggregate trends…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  const overall = trends?.overall;
+  if (!overall) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder
+          variant="empty"
+          message="No aggregate trend data yet. Run an analysis to populate."
+        />
+      </ReportSection>
+    );
+  }
+
+  return (
+    <ReportSection title="Headline">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <Metric label="Average score" value={overall.avg_score.toFixed(1)} />
+        <Metric label="Improving" value={overall.improving_count.toString()} accent="positive" />
+        <Metric label="Declining" value={overall.declining_count.toString()} accent="negative" />
+        <Metric label="Stable" value={overall.stable_count.toString()} />
+      </div>
+    </ReportSection>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  accent = 'neutral',
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly accent?: 'positive' | 'negative' | 'neutral';
+}) {
+  const accentClass = accentClassFor(accent);
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800">
+      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className={`text-2xl font-semibold mt-1 ${accentClass}`}>{value}</p>
+    </div>
+  );
+}
+
+function accentClassFor(accent: 'positive' | 'negative' | 'neutral'): string {
+  if (accent === 'positive') return 'text-emerald-700 dark:text-emerald-400';
+  if (accent === 'negative') return 'text-red-700 dark:text-red-400';
+  return 'text-gray-900 dark:text-white';
+}

--- a/web/src/components/Reports/BrandVisibilityReport/sections/MoversSection.spec.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/MoversSection.spec.tsx
@@ -1,0 +1,215 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen, within 
+} from '@testing-library/react';
+import { MoversSection } from './MoversSection';
+import type { HistoricalTrendsResponse } from '../../../../types';
+
+function directionFor(change: number): 'improving' | 'declining' | 'stable' {
+  if (change > 0) return 'improving';
+  if (change < 0) return 'declining';
+  return 'stable';
+}
+
+function buildTrend(
+  rows: Array<{
+    keyword: string;
+    change: number 
+  }>,
+): HistoricalTrendsResponse {
+  return {
+    period_type: 'day',
+    days_analyzed: 30,
+    data_points: 0,
+    trend_data: [],
+    trend_direction: 'stable',
+    summary: {
+      current_score: 0,
+      previous_score: 0,
+      change: 0,
+      change_percent: 0,
+      average_score: 0,
+      max_score: 0,
+      min_score: 0,
+    },
+    keyword_trends: rows.map((r) => ({
+      keyword: r.keyword,
+      trend_direction: directionFor(r.change),
+      current_score: 50 + r.change,
+      change: r.change,
+      change_percent: r.change * 2,
+    })),
+    overall: {
+      improving_count: rows.filter((r) => r.change > 0).length,
+      declining_count: rows.filter((r) => r.change < 0).length,
+      stable_count: rows.filter((r) => r.change === 0).length,
+      avg_score: 50,
+    },
+  };
+}
+
+describe('MoversSection — improver list', () => {
+  it('lists keywords with positive change in the Improving column', () => {
+    render(
+      <MoversSection
+        trends={buildTrend([
+          {
+            keyword: 'up-a',
+            change: 3 
+          },
+          {
+            keyword: 'down-a',
+            change: -2 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const improvingHeading = screen.getByRole('heading', { name: 'Improving' });
+    const column = improvingHeading.closest('div');
+    expect(column).not.toBeNull();
+    expect(within(column as HTMLElement).getByText('up-a')).toBeInTheDocument();
+    expect(within(column as HTMLElement).queryByText('down-a')).not.toBeInTheDocument();
+  });
+
+  it('orders improvers by change descending', () => {
+    render(
+      <MoversSection
+        trends={buildTrend([
+          {
+            keyword: 'small-up',
+            change: 1 
+          },
+          {
+            keyword: 'big-up',
+            change: 9 
+          },
+          {
+            keyword: 'medium-up',
+            change: 5 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const improvingHeading = screen.getByRole('heading', { name: 'Improving' });
+    const column = improvingHeading.closest('div');
+    const items = within(column as HTMLElement).getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('big-up');
+    expect(items[1]).toHaveTextContent('medium-up');
+    expect(items[2]).toHaveTextContent('small-up');
+  });
+
+  it('caps each direction at five entries', () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      keyword: `up-${i}`,
+      change: i + 1,
+    }));
+    render(
+      <MoversSection
+        trends={buildTrend(rows)}
+        loading={false}
+        error={null}
+      />,
+    );
+    const improvingHeading = screen.getByRole('heading', { name: 'Improving' });
+    const column = improvingHeading.closest('div');
+    expect(within(column as HTMLElement).getAllByRole('listitem')).toHaveLength(5);
+  });
+});
+
+describe('MoversSection — decliner list and empty handling', () => {
+  it('orders decliners by change ascending (most negative first)', () => {
+    render(
+      <MoversSection
+        trends={buildTrend([
+          {
+            keyword: 'small-down',
+            change: -1 
+          },
+          {
+            keyword: 'big-down',
+            change: -9 
+          },
+          {
+            keyword: 'medium-down',
+            change: -5 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const decliningHeading = screen.getByRole('heading', { name: 'Declining' });
+    const column = decliningHeading.closest('div');
+    const items = within(column as HTMLElement).getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('big-down');
+    expect(items[1]).toHaveTextContent('medium-down');
+    expect(items[2]).toHaveTextContent('small-down');
+  });
+
+  it('shows the "no improvers" empty copy when only decliners exist', () => {
+    render(
+      <MoversSection
+        trends={buildTrend([
+          {
+            keyword: 'down-a',
+            change: -3 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(
+      screen.getByText(/No keywords moved in this direction/i),
+    ).toBeInTheDocument();
+  });
+
+  it('returns null (no section rendered) when keyword_trends is empty', () => {
+    const { container } = render(
+      <MoversSection
+        trends={buildTrend([])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when no keyword has a non-zero change', () => {
+    const { container } = render(
+      <MoversSection
+        trends={buildTrend([
+          {
+            keyword: 'flat-a',
+            change: 0 
+          },
+          {
+            keyword: 'flat-b',
+            change: 0 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('MoversSection — placeholder states', () => {
+  it('renders loading placeholder when loading is true', () => {
+    render(<MoversSection trends={null} loading error={null} />);
+    expect(screen.getByText(/Computing movers/i)).toBeInTheDocument();
+  });
+
+  it('renders error message when error is set', () => {
+    render(<MoversSection trends={null} loading={false} error="boom" />);
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/BrandVisibilityReport/sections/MoversSection.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/MoversSection.tsx
@@ -1,0 +1,129 @@
+import type { HistoricalTrendsResponse } from '../../../../types';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const TOP_N = 5;
+
+/**
+ * Top improvers and top decliners side by side. The aggregator endpoint
+ * (PR D) will eventually provide these directly; until then we sort the
+ * `keyword_trends` array client-side by `change`. Five rows on each side
+ * is the print-friendly default — enough to spot a campaign-level pattern
+ * without bleeding onto a second page.
+ */
+export function MoversSection({
+  trends, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Top movers">
+        <SectionPlaceholder variant="loading" message="Computing movers…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Top movers">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  const rows = trends?.keyword_trends ?? [];
+  if (rows.length === 0) return null;
+
+  const improvers = [...rows]
+    .filter((r) => r.change > 0)
+    .sort((a, b) => b.change - a.change)
+    .slice(0, TOP_N);
+  const decliners = [...rows]
+    .filter((r) => r.change < 0)
+    .sort((a, b) => a.change - b.change)
+    .slice(0, TOP_N);
+
+  if (improvers.length === 0 && decliners.length === 0) return null;
+
+  return (
+    <ReportSection
+      title="Top movers"
+      subtitle="Keywords that shifted the most in the period. The improvers list is where momentum is paying off; the decliners list is where to investigate."
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <MoverColumn
+          title="Improving"
+          accent="positive"
+          rows={improvers}
+        />
+        <MoverColumn
+          title="Declining"
+          accent="negative"
+          rows={decliners}
+        />
+      </div>
+    </ReportSection>
+  );
+}
+
+function MoverColumn({
+  title,
+  accent,
+  rows,
+}: {
+  readonly title: string;
+  readonly accent: 'positive' | 'negative';
+  readonly rows: ReadonlyArray<{
+    keyword: string;
+    current_score: number;
+    change: number;
+    change_percent: number;
+  }>;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">
+          {title}
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          No keywords moved in this direction.
+        </p>
+      </div>
+    );
+  }
+
+  const accentClass = accent === 'positive'
+    ? 'text-emerald-700 dark:text-emerald-400'
+    : 'text-red-700 dark:text-red-400';
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 avoid-break-inside">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+        {title}
+      </h3>
+      <ul className="space-y-2">
+        {rows.map((row) => (
+          <li
+            key={row.keyword}
+            className="flex items-baseline justify-between gap-3 text-sm"
+          >
+            <span className="text-gray-700 dark:text-gray-300 truncate">
+              {row.keyword}
+            </span>
+            <span className={`font-mono font-semibold flex-shrink-0 ${accentClass}`}>
+              {row.change > 0 ? '+' : ''}
+              {row.change.toFixed(1)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/Reports/BrandVisibilityReport/sections/PerKeywordHeadlineSection.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/PerKeywordHeadlineSection.tsx
@@ -1,0 +1,119 @@
+import type {
+  VisibilityMetricsResponse,
+  HistoricalTrendsResponse,
+} from '../../../../types';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly visibility: VisibilityMetricsResponse | null;
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Per-keyword headline metrics: first-party score, share of voice, gap to
+ * competitor average. These three numbers tell the marketing-lead reader
+ * "are we ahead, level, or behind" before they read anything else in the
+ * report.
+ */
+export function PerKeywordHeadlineSection({
+  visibility, trends, loading, error,
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="loading" message="Loading visibility…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  if (!visibility) {
+    return (
+      <ReportSection title="Headline">
+        <SectionPlaceholder
+          variant="empty"
+          message="No visibility data found for this keyword."
+        />
+      </ReportSection>
+    );
+  }
+
+  const { summary } = visibility;
+  const fpScore = summary.first_party_avg_score;
+  const compScore = summary.competitor_avg_score;
+  const gap = (fpScore - compScore).toFixed(1);
+  const gapAccent: 'positive' | 'negative' = fpScore >= compScore ? 'positive' : 'negative';
+  const change = trends?.summary.change ?? 0;
+  const changeText = formatChangeFootnote(change);
+
+  return (
+    <ReportSection title="Headline">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Metric
+          label="First-party visibility"
+          value={`${fpScore.toFixed(1)}`}
+          accent="neutral"
+          footnote={changeText}
+        />
+        <Metric
+          label="Share of voice"
+          value={`${summary.first_party_total_sov.toFixed(1)}%`}
+          accent="neutral"
+          footnote={`Competitor SOV: ${summary.competitor_total_sov.toFixed(1)}%`}
+        />
+        <Metric
+          label="Gap to competitor avg"
+          value={`${gap.startsWith('-') ? '' : '+'}${gap}`}
+          accent={gapAccent}
+          footnote={`Competitor avg: ${compScore.toFixed(1)}`}
+        />
+      </div>
+    </ReportSection>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  footnote,
+  accent,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly footnote: string;
+  readonly accent: 'positive' | 'negative' | 'neutral';
+}) {
+  const accentClass = accentClassFor(accent);
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800">
+      <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className={`text-2xl font-semibold mt-1 ${accentClass}`}>{value}</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">{footnote}</p>
+    </div>
+  );
+}
+
+function accentClassFor(accent: 'positive' | 'negative' | 'neutral'): string {
+  if (accent === 'positive') return 'text-emerald-700 dark:text-emerald-400';
+  if (accent === 'negative') return 'text-red-700 dark:text-red-400';
+  return 'text-gray-900 dark:text-white';
+}
+
+function formatChangeFootnote(change: number): string {
+  if (change === 0) return 'No 30-day change';
+  const sign = change > 0 ? '+' : '';
+  return `${sign}${change.toFixed(1)} over 30 days`;
+}

--- a/web/src/components/Reports/BrandVisibilityReport/sections/PerKeywordTableSection.spec.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/PerKeywordTableSection.spec.tsx
@@ -1,0 +1,210 @@
+import {
+  describe, it, expect,
+} from 'vitest';
+import {
+  render, screen 
+} from '@testing-library/react';
+import { PerKeywordTableSection } from './PerKeywordTableSection';
+import type { HistoricalTrendsResponse } from '../../../../types';
+
+function directionFor(change: number): 'improving' | 'declining' | 'stable' {
+  if (change > 0) return 'improving';
+  if (change < 0) return 'declining';
+  return 'stable';
+}
+
+function buildTrend(
+  rows: Array<{
+    keyword: string;
+    current_score: number;
+    change: number 
+  }>,
+): HistoricalTrendsResponse {
+  return {
+    period_type: 'day',
+    days_analyzed: 30,
+    data_points: 0,
+    trend_data: [],
+    trend_direction: 'stable',
+    summary: {
+      current_score: 0,
+      previous_score: 0,
+      change: 0,
+      change_percent: 0,
+      average_score: 0,
+      max_score: 0,
+      min_score: 0,
+    },
+    keyword_trends: rows.map((r) => ({
+      keyword: r.keyword,
+      trend_direction: directionFor(r.change),
+      current_score: r.current_score,
+      change: r.change,
+      change_percent: r.change * 2,
+    })),
+  };
+}
+
+describe('PerKeywordTableSection — ordering', () => {
+  it('orders rows by current_score descending', () => {
+    render(
+      <PerKeywordTableSection
+        trends={buildTrend([
+          {
+            keyword: 'low',
+            current_score: 20,
+            change: 0 
+          },
+          {
+            keyword: 'high',
+            current_score: 80,
+            change: 0 
+          },
+          {
+            keyword: 'mid',
+            current_score: 50,
+            change: 0 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('high');
+    expect(rows[2]).toHaveTextContent('mid');
+    expect(rows[3]).toHaveTextContent('low');
+  });
+});
+
+describe('PerKeywordTableSection — mover highlight', () => {
+  it('applies the positive-mover class when change >= +5', () => {
+    render(
+      <PerKeywordTableSection
+        trends={buildTrend([
+          {
+            keyword: 'big-up',
+            current_score: 60,
+            change: 6 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const row = screen.getByText('big-up').closest('tr');
+    expect(row?.className).toContain('emerald');
+  });
+
+  it('applies the negative-mover class when change <= -5', () => {
+    render(
+      <PerKeywordTableSection
+        trends={buildTrend([
+          {
+            keyword: 'big-down',
+            current_score: 40,
+            change: -7 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const row = screen.getByText('big-down').closest('tr');
+    expect(row?.className).toContain('red');
+  });
+
+  it('does NOT highlight rows with change magnitude below the +/-5 threshold', () => {
+    render(
+      <PerKeywordTableSection
+        trends={buildTrend([
+          {
+            keyword: 'tiny-up',
+            current_score: 50,
+            change: 3 
+          },
+          {
+            keyword: 'tiny-down',
+            current_score: 50,
+            change: -3 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    const upRow = screen.getByText('tiny-up').closest('tr');
+    const downRow = screen.getByText('tiny-down').closest('tr');
+    expect(upRow?.className).not.toContain('emerald');
+    expect(downRow?.className).not.toContain('red');
+  });
+});
+
+describe('PerKeywordTableSection — empty + placeholder states', () => {
+  it('returns null when keyword_trends is empty', () => {
+    const { container } = render(
+      <PerKeywordTableSection
+        trends={buildTrend([])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders loading placeholder when loading is true', () => {
+    render(
+      <PerKeywordTableSection trends={null} loading error={null} />,
+    );
+    expect(
+      screen.getByText(/Loading per-keyword rankings/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders error message when error is set', () => {
+    render(
+      <PerKeywordTableSection
+        trends={null}
+        loading={false}
+        error="Network down"
+      />,
+    );
+    expect(screen.getByText('Network down')).toBeInTheDocument();
+  });
+});
+
+describe('PerKeywordTableSection — change formatting', () => {
+  it('prefixes positive changes with a plus sign', () => {
+    render(
+      <PerKeywordTableSection
+        trends={buildTrend([
+          {
+            keyword: 'kw',
+            current_score: 60,
+            change: 4 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('+4.0')).toBeInTheDocument();
+  });
+
+  it('renders negative changes with a minus sign', () => {
+    render(
+      <PerKeywordTableSection
+        trends={buildTrend([
+          {
+            keyword: 'kw',
+            current_score: 40,
+            change: -4 
+          },
+        ])}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText('-4.0')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Reports/BrandVisibilityReport/sections/PerKeywordTableSection.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/PerKeywordTableSection.tsx
@@ -1,0 +1,136 @@
+import type { HistoricalTrendsResponse } from '../../../../types';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Per-keyword leaderboard for the all-keywords variant. Sorted by current
+ * score descending so the strongest performers anchor the top of the page.
+ *
+ * Movers (`change` rows where the magnitude is >= 5 points) are highlighted
+ * with a positive/negative tint so a reader can spot the keywords that
+ * actually shifted in the period without computing the deltas themselves.
+ */
+const MOVE_THRESHOLD = 5;
+
+export function PerKeywordTableSection({
+  trends, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Per-keyword leaderboard">
+        <SectionPlaceholder variant="loading" message="Loading per-keyword rankings…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Per-keyword leaderboard">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  const rows = trends?.keyword_trends ?? [];
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const sorted = [...rows].sort((a, b) => b.current_score - a.current_score);
+
+  return (
+    <ReportSection
+      title="Per-keyword leaderboard"
+      subtitle="Current score and 30-day change for every tracked keyword. Sorted strongest to weakest. Movers (≥5 points) are highlighted."
+    >
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>Keyword</Th>
+              <Th>Score</Th>
+              <Th>Change</Th>
+              <Th>%</Th>
+              <Th>Direction</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {sorted.map((row) => (
+              <tr key={row.keyword} className={moverRowClass(row.change)}>
+                <Td className="font-medium">{row.keyword}</Td>
+                <Td>{row.current_score.toFixed(1)}</Td>
+                <Td>
+                  {row.change > 0 ? '+' : ''}
+                  {row.change.toFixed(1)}
+                </Td>
+                <Td>
+                  {row.change_percent > 0 ? '+' : ''}
+                  {row.change_percent.toFixed(1)}%
+                </Td>
+                <Td>
+                  <DirectionBadge direction={row.trend_direction} />
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function moverRowClass(change: number): string {
+  if (Math.abs(change) < MOVE_THRESHOLD) return '';
+  if (change > 0) return 'bg-emerald-50 dark:bg-emerald-950/20';
+  return 'bg-red-50 dark:bg-red-950/20';
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}
+
+function DirectionBadge({direction,}: {readonly direction: 'improving' | 'declining' | 'stable';}) {
+  const styles = directionStyles(direction);
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium uppercase tracking-wide ${styles}`}
+    >
+      {direction}
+    </span>
+  );
+}
+
+function directionStyles(d: 'improving' | 'declining' | 'stable'): string {
+  if (d === 'improving') {
+    return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300';
+  }
+  if (d === 'declining') {
+    return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300';
+  }
+  return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+}

--- a/web/src/components/Reports/BrandVisibilityReport/sections/TrendHistorySection.tsx
+++ b/web/src/components/Reports/BrandVisibilityReport/sections/TrendHistorySection.tsx
@@ -1,0 +1,106 @@
+import type {
+  HistoricalTrendsResponse, TrendDataPoint 
+} from '../../../../types';
+import {
+  ReportSection, SectionPlaceholder 
+} from '../../layout';
+
+interface Props {
+  readonly trends: HistoricalTrendsResponse | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const MAX_ROWS = 14;
+
+/**
+ * Sampled trend history for the per-keyword report. The raw `trend_data`
+ * can hold up to 30 rows for a 30-day window; printing all 30 wastes a
+ * full page on a near-flat curve. Sampling evenly to ≤14 rows keeps the
+ * shape readable in print without losing inflection points.
+ */
+export function TrendHistorySection({
+  trends, loading, error 
+}: Props) {
+  if (loading) {
+    return (
+      <ReportSection title="Trend history">
+        <SectionPlaceholder variant="loading" message="Loading trend history…" />
+      </ReportSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <ReportSection title="Trend history">
+        <SectionPlaceholder variant="error" message={error} />
+      </ReportSection>
+    );
+  }
+
+  const points = trends?.trend_data ?? [];
+  if (points.length === 0) return null;
+
+  const sampled = sampleEvenly(points, MAX_ROWS);
+
+  return (
+    <ReportSection
+      title="Trend history"
+      subtitle={`Visibility score across the last ${trends?.days_analyzed ?? 30} days. Sampled to ${sampled.length} rows for print.`}
+      startNewPage
+    >
+      <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <Th>Period</Th>
+              <Th>Score</Th>
+              <Th>Best rank</Th>
+              <Th>Mentions</Th>
+              <Th>Providers</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {sampled.map((p) => (
+              <tr key={p.period}>
+                <Td className="font-mono text-xs">{p.period}</Td>
+                <Td>{p.visibility_score.toFixed(1)}</Td>
+                <Td>{p.best_rank ?? '—'}</Td>
+                <Td>{p.total_mentions}</Td>
+                <Td>{p.provider_count}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReportSection>
+  );
+}
+
+function sampleEvenly(points: TrendDataPoint[], max: number): TrendDataPoint[] {
+  if (points.length <= max) return points;
+  const step = (points.length - 1) / (max - 1);
+  return Array.from({ length: max }, (_, i) => points[Math.round(i * step)]);
+}
+
+function Th({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  className = '',
+}: {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <td className={`px-3 py-2 text-gray-700 dark:text-gray-300 ${className}`}>
+      {children}
+    </td>
+  );
+}

--- a/web/src/components/Reports/BrandVisibilityReport/useBrandVisibilityReport.spec.ts
+++ b/web/src/components/Reports/BrandVisibilityReport/useBrandVisibilityReport.spec.ts
@@ -1,0 +1,80 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBrandVisibilityReport } from './useBrandVisibilityReport';
+
+vi.mock('../../../hooks/useVisibilityMetrics', () => ({useVisibilityMetrics: vi.fn()}));
+vi.mock('../../../hooks/useHistoricalTrends', () => ({useHistoricalTrends: vi.fn()}));
+
+import { useVisibilityMetrics } from '../../../hooks/useVisibilityMetrics';
+import { useHistoricalTrends } from '../../../hooks/useHistoricalTrends';
+
+const mockVisibility = useVisibilityMetrics as ReturnType<typeof vi.fn>;
+const mockTrends = useHistoricalTrends as ReturnType<typeof vi.fn>;
+
+describe('useBrandVisibilityReport', () => {
+  const fetchVisibilityMetrics = vi.fn();
+  const fetchHistoricalTrends = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVisibility.mockReturnValue({
+      data: {
+        keyword: 'shoes',
+        summary: { first_party_avg_score: 50 } 
+      },
+      loading: false,
+      error: null,
+      fetchVisibilityMetrics,
+    });
+    mockTrends.mockReturnValue({
+      data: {
+        trend_data: [],
+        summary: {
+          current_score: 50,
+          change: 0 
+        } 
+      },
+      loading: false,
+      error: null,
+      fetchHistoricalTrends,
+    });
+  });
+
+  it('fetches visibility and trends in per-keyword mode', () => {
+    renderHook(() => useBrandVisibilityReport('best running shoes'));
+    expect(fetchVisibilityMetrics).toHaveBeenCalledWith('best running shoes');
+  });
+
+  it('fetches keyword-scoped trends in per-keyword mode', () => {
+    renderHook(() => useBrandVisibilityReport('best running shoes'));
+    expect(fetchHistoricalTrends).toHaveBeenCalledWith('best running shoes', 'day', 30);
+  });
+
+  it('skips visibility fetch in all-keywords mode to avoid N+1', () => {
+    renderHook(() => useBrandVisibilityReport(null));
+    expect(fetchVisibilityMetrics).not.toHaveBeenCalled();
+  });
+
+  it('fetches cross-keyword trends in all-keywords mode', () => {
+    renderHook(() => useBrandVisibilityReport(null));
+    expect(fetchHistoricalTrends).toHaveBeenCalledWith(undefined, 'day', 30);
+  });
+
+  it('reports ready=true once both slices have settled in per-keyword mode', () => {
+    const { result } = renderHook(() => useBrandVisibilityReport('shoes'));
+    expect(result.current.ready).toBe(true);
+  });
+
+  it('reports ready=false when trends slice is still loading', () => {
+    mockTrends.mockReturnValue({
+      data: null,
+      loading: true,
+      error: null,
+      fetchHistoricalTrends,
+    });
+    const { result } = renderHook(() => useBrandVisibilityReport('shoes'));
+    expect(result.current.ready).toBe(false);
+  });
+});

--- a/web/src/components/Reports/BrandVisibilityReport/useBrandVisibilityReport.ts
+++ b/web/src/components/Reports/BrandVisibilityReport/useBrandVisibilityReport.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import { useVisibilityMetrics } from '../../../hooks/useVisibilityMetrics';
+import { useHistoricalTrends } from '../../../hooks/useHistoricalTrends';
+import { useReportReady } from '../layout/useReportReady';
+
+/**
+ * Brand Visibility data composition.
+ *
+ * Two modes:
+ *   - per-keyword (`keyword` provided): fetches `/visibility?keyword=...` and
+ *     `/trends?keyword=...` for the full per-keyword breakdown + history.
+ *   - all-keywords (`keyword === null`): fetches `/trends` (no keyword) which
+ *     returns `keyword_trends[]` and `overall` aggregates server-side. Skips
+ *     the per-keyword visibility call to avoid N+1 fan-out across many
+ *     keywords; the all-keywords view focuses on rank movement and trend
+ *     direction rather than per-brand SOV detail.
+ *
+ * When the aggregator endpoint (`GET /reports/overview`) ships in a later
+ * PR, the all-keywords mode will switch to it for richer first-party-only
+ * aggregates. Today's `/trends` summary covers improving/declining counts
+ * and average score, which is enough for the v1 of this report.
+ */
+export function useBrandVisibilityReport(keyword: string | null) {
+  const visibility = useVisibilityMetrics();
+  const trends = useHistoricalTrends();
+
+  const { fetchVisibilityMetrics } = visibility;
+  const { fetchHistoricalTrends } = trends;
+
+  useEffect(() => {
+    if (keyword) {
+      fetchVisibilityMetrics(keyword);
+      fetchHistoricalTrends(keyword, 'day', 30);
+    } else {
+      fetchHistoricalTrends(undefined, 'day', 30);
+    }
+  }, [keyword, fetchVisibilityMetrics, fetchHistoricalTrends]);
+
+  // The visibility slice is "settled" trivially in all-keywords mode — we
+  // simply don't fetch it. Treating it as already resolved keeps the
+  // ready-aggregation logic uniform across modes.
+  const visibilitySlice = keyword
+    ? visibility
+    : {
+      loading: false,
+      data: {},
+      error: null 
+    };
+
+  const ready = useReportReady([visibilitySlice, trends]);
+
+  return {
+    keyword,
+    visibility: keyword ? visibility.data : null,
+    visibilityLoading: visibility.loading,
+    visibilityError: visibility.error,
+    trends: trends.data,
+    trendsLoading: trends.loading,
+    trendsError: trends.error,
+    ready,
+  };
+}
+
+export type BrandVisibilityReportData = ReturnType<typeof useBrandVisibilityReport>;

--- a/web/src/components/Reports/ReportsLandingView.spec.tsx
+++ b/web/src/components/Reports/ReportsLandingView.spec.tsx
@@ -49,10 +49,16 @@ describe('ReportsLandingView', () => {
     expect(link).toHaveAttribute('href', '/reports/content-action-plan');
   });
 
-  it('marks the three unbuilt reports as Coming soon and not as links', () => {
+  it('renders Brand Visibility as a working link to /reports/visibility', () => {
+    renderLanding();
+    const link = screen.getByRole('link', { name: /brand visibility/i });
+    expect(link).toHaveAttribute('href', '/reports/visibility');
+  });
+
+  it('marks the two unbuilt reports as Coming soon and not as links', () => {
     renderLanding();
     const comingSoonBadges = screen.getAllByText(/coming soon/i);
-    expect(comingSoonBadges).toHaveLength(3);
+    expect(comingSoonBadges).toHaveLength(2);
   });
 
   it('shows the executive and marketing-lead audiences', () => {

--- a/web/src/components/Reports/ReportsLandingView.tsx
+++ b/web/src/components/Reports/ReportsLandingView.tsx
@@ -31,8 +31,8 @@ const REPORT_CATALOG: readonly ReportEntry[] = [
     description:
       'Visibility score, rank distribution, share of voice vs. configured competitors, sentiment, and trend, scoped to a keyword or to the full keyword set. Highlights regressions in red.',
     audience: 'Marketing lead',
-    path: null,
-    status: 'coming-soon',
+    path: '/reports/visibility',
+    status: 'available',
   },
   {
     id: 'competitor-gap',

--- a/web/src/components/Reports/ReportsRouter.tsx
+++ b/web/src/components/Reports/ReportsRouter.tsx
@@ -22,6 +22,10 @@ const ContentActionPlanReport = lazy(() =>
   import('./ContentActionPlanReport').then((m) => ({default: m.ContentActionPlanReport,})),
 );
 
+const BrandVisibilityReport = lazy(() =>
+  import('./BrandVisibilityReport').then((m) => ({default: m.BrandVisibilityReport,})),
+);
+
 interface Props {readonly keywords: ReadonlyArray<Keyword>;}
 
 function ReportFallback() {
@@ -60,6 +64,14 @@ export function ReportsRouter({ keywords }: Props) {
           <Route
             path="/reports/content-action-plan"
             element={<ContentActionPlanReport />}
+          />
+          <Route
+            path="/reports/visibility"
+            element={<BrandVisibilityReport keywords={keywords} />}
+          />
+          <Route
+            path="/reports/visibility/:keyword"
+            element={<BrandVisibilityReport keywords={keywords} />}
           />
           <Route path="*" element={<Navigate to="/reports" replace />} />
         </Routes>

--- a/web/src/components/Reports/index.ts
+++ b/web/src/components/Reports/index.ts
@@ -2,3 +2,4 @@ export { ReportsRouter } from './ReportsRouter';
 export { ReportsLandingView } from './ReportsLandingView';
 export { KeywordDeepDiveReport } from './KeywordDeepDiveReport';
 export { ContentActionPlanReport } from './ContentActionPlanReport';
+export { BrandVisibilityReport } from './BrandVisibilityReport';


### PR DESCRIPTION
Third report in the planned series, stacked on PR #41 (Content Action Plan). Aimed at marketing leads who need to read "are we winning, level, or losing" both for a single keyword and across the full keyword portfolio.

Why two variants in one report

The marketing-lead question switches grain depending on the context. In a quarterly review they want the cross-keyword overview ("how is the campaign trending overall"). When investigating a regression they want the per-keyword detail ("what happened on `best running shoes` last week"). Splitting those into two reports would force unnecessary context switching; instead the same component reads `:keyword?` from the URL and switches layout. A keyword scope selector at the top of the printable layout (print-hidden) lets the user jump between modes without leaving the page.

What's in this PR

- New routes:
  - `/reports/visibility` (cross-keyword)
  - `/reports/visibility/:keyword` (per-keyword)
- `useBrandVisibilityReport(keyword | null)` composes `useVisibilityMetrics` and `useHistoricalTrends`. When `keyword` is null it skips the visibility fetch entirely to avoid N+1 fan-out; the cross-keyword `/trends` endpoint already returns `keyword_trends[]` and `overall` aggregates server-side, which is enough for the v1 of the all-keywords variant.
- Per-keyword sections:
  - `PerKeywordHeadlineSection` — first-party score, share of voice, gap to competitor average. The three-number "are we winning" headline.
  - `BrandRankingsSection` — every brand the AI engines mentioned for this keyword with score, SOV, best rank, mentions, providers, and classification. First-party rows are tinted.
  - `TrendHistorySection` — sampled (≤14 rows) trend table.
- All-keywords sections:
  - `CrossKeywordHeadlineSection` — improving / declining / stable counts and average score from the overall aggregate.
  - `MoversSection` — top 5 improvers and top 5 decliners side by side. The aggregator endpoint (PR D) will eventually provide these directly; for now we sort `keyword_trends` client-side.
  - `PerKeywordTableSection` — full leaderboard sorted strongest to weakest. Movers (≥5 points absolute change) are highlighted in their direction so a reader can spot inflection points without computing deltas themselves.

Defensive routing

If the URL `/reports/visibility/:keyword` carries a slug that doesn't match any tracked keyword (the user deleted it, the URL was bookmarked from before a config change, etc.), the component redirects to the all-keywords overview rather than render an empty per-keyword view.

Tests

- 6 new vitest cases for `useBrandVisibilityReport` (covers both modes — what's fetched, what's skipped, ready aggregation).
- 8 new vitest cases for `BrandVisibilityReport` covering both the per-keyword variant (H1, subtitle, brand row, gap metric) and the all-keywords variant (subtitle, improving label, leaderboard rows, scope selector).
- ReportsLandingView spec: 3 → 2 coming-soon badges plus a new regression test for the visibility link.
- 739 vitest cases pass overall; type-check / lint / build clean.

Stacks on

- #38 (print-to-PDF infrastructure)
- #40 (Reporting foundation + Keyword Deep Dive)
- #41 (Content Action Plan)

Not in this PR

- Reports 1 / 3, plus the aggregator (`/reports/overview`) and competitor rollup (`/reports/competitor`) endpoints. They follow in the agreed order.

## Description

Please include a summary of the change and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Deployed to AWS account and verified functionality
- [ ] Tested with sample keywords
- [ ] Verified dashboard displays correctly
- [ ] Checked CloudWatch logs for errors

**Test Configuration**:
* AWS Region:
* CDK Version:
* Node.js Version:
* Python Version:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
