### PR TITLE
feat(api): recommendation action tracking

### DIFF
--- a/lambda/api/get-recommendations.py
+++ b/lambda/api/get-recommendations.py
@@ -17,7 +17,7 @@ import logging
 import os
 import sys
 from collections import defaultdict
-from typing import Any
+from typing import Any, Dict, List
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -31,7 +31,7 @@ from shared.api_response import success_response
 from shared.decorators import api_handler, validate
 from shared.llm_json import parse_llm_json
 from shared.models import ModelRole, invoke_bedrock
-from shared.utils import brand_names_match, get_brand_config, get_timestamp
+from shared.utils import brand_names_match, get_brand_config, get_timestamp, recommendation_id
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -304,6 +304,52 @@ Focus on:
     return []
 
 
+def _annotate_with_status(recommendations: List[Dict[str, Any]]) -> None:
+    """
+    Mutate each recommendation in place to add `id` + persisted status.
+
+    The id is the same hash that `recommendation-status.py` looks up in
+    DynamoDB. The status fields are merged in only when the status
+    table is configured (production); otherwise every recommendation
+    gets `status: 'new'` so the response shape stays consistent for
+    the frontend.
+
+    Failure to load the status table is non-fatal: the recommendations
+    are still surfaced, just without per-row tracking. Logged warning.
+    """
+    for rec in recommendations:
+        rec['id'] = recommendation_id(rec)
+
+    rec_ids = [r['id'] for r in recommendations]
+    statuses: Dict[str, Dict[str, Any]] = {}
+
+    status_table = os.environ.get('RECOMMENDATION_STATUS_TABLE')
+    if status_table and rec_ids:
+        try:
+            # Lazy-load the status helper so this module's existing tests
+            # (which don't configure the status table env) keep passing.
+            import importlib.util
+            here = os.path.dirname(os.path.abspath(__file__))
+            spec = importlib.util.spec_from_file_location(
+                'recommendation_status_for_join',
+                os.path.join(here, 'recommendation-status.py'),
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            statuses = module.list_statuses(rec_ids)
+        except Exception as exc:
+            logger.warning(f'recommendation status join skipped: {exc}')
+
+    for rec in recommendations:
+        row = statuses.get(rec['id'])
+        rec['status'] = row.get('status', 'new') if row else 'new'
+        if row:
+            for key in ('updated_at', 'completed_at', 'notes',
+                        'related_keyword', 'related_content_id'):
+                if key in row:
+                    rec[key] = row[key]
+
+
 @api_handler
 @validate({
     'use_llm': {'type': bool, 'default': False},
@@ -321,6 +367,14 @@ def handler(event: dict[str, Any], context: Any, use_llm: bool = False, keyword:
 
     # Generate rule-based recommendations
     recommendations = generate_rule_based_recommendations(config)
+
+    # Annotate each recommendation with a deterministic id and (when the
+    # status table is configured) the persisted action-tracking state.
+    # Done here rather than inside `generate_rule_based_recommendations`
+    # so the rule generator stays a pure data shaper. The id is computed
+    # from `type + title + sorted keywords` so it survives list
+    # regeneration as long as those fields don't change.
+    _annotate_with_status(recommendations)
 
     # Optionally enhance with LLM
     llm_recommendations = []

--- a/lambda/api/recommendation-status.py
+++ b/lambda/api/recommendation-status.py
@@ -1,0 +1,247 @@
+"""
+Recommendation Status API
+
+Tracks the action-tracking state of individual recommendations produced
+by `get-recommendations.py`. The `recommendations` list itself is
+generated on every call (no persistence), so this table is the only
+place where a recommendation's lifecycle (`new` -> `in_progress` ->
+`done` or `wontfix`) is durable.
+
+Why this exists
+
+The Action Center surfaces recommendations to a user, but without a
+status mechanism every refresh shows the same items as if they were
+freshly minted. Marking an item "in progress" or "done" in the UI
+needs to survive a hard reload, an analysis re-run, and a different
+user opening the dashboard.
+
+Routes
+
+  POST /api/recommendations/{id}/status
+    Body: { "status": "new"|"in_progress"|"done"|"wontfix",
+            "notes": <optional string>,
+            "related_keyword": <optional string>,
+            "related_content_id": <optional string> }
+    Returns: { "id", "status", "updated_at", "notes", ... }
+
+  GET /api/recommendations/{id}/status
+    Returns: { "id", "status", "updated_at", ... } or 404 if no record.
+
+The id is the deterministic SHA-1-truncated hash from
+`shared.utils.recommendation_id`, computed by `get-recommendations.py`
+when it produces the list. Same hash inputs (type, title, sorted
+keywords) yield the same id across calls, so status survives list
+regeneration.
+
+Storage
+
+  RECOMMENDATION_STATUS_TABLE — DynamoDB
+  PK: recommendation_id (string)
+  Attributes:
+    status            : 'new' | 'in_progress' | 'done' | 'wontfix'
+    notes             : optional free text
+    related_keyword   : optional pointer to a keyword the action targets
+    related_content_id: optional pointer to a Content Studio brief
+                        that addresses this recommendation
+    updated_at        : ISO timestamp
+    completed_at      : ISO timestamp, set when status flips to 'done'
+
+A 90-day TTL is applied so abandoned items eventually self-evict.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+import boto3
+
+# Shared layer path
+sys.path.insert(0, '/opt/python')
+
+from shared.api_response import (
+    error_response,
+    not_found_response,
+    success_response,
+    validation_error,
+)
+from shared.decorators import api_handler
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.resource('dynamodb')
+
+RECOMMENDATION_STATUS_TABLE = os.environ.get('RECOMMENDATION_STATUS_TABLE')
+
+VALID_STATUSES = {'new', 'in_progress', 'done', 'wontfix'}
+TTL_DAYS = 90
+MAX_NOTES_LEN = 2000
+MAX_RELATED_LEN = 500
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _ttl_for(now: datetime) -> int:
+    return int((now + timedelta(days=TTL_DAYS)).timestamp())
+
+
+def _table():
+    if not RECOMMENDATION_STATUS_TABLE:
+        raise RuntimeError(
+            'RECOMMENDATION_STATUS_TABLE env var is not set. The status '
+            'feature must be deployed via CDK before this handler runs.'
+        )
+    return dynamodb.Table(RECOMMENDATION_STATUS_TABLE)
+
+
+def _path_id(event: Dict[str, Any]) -> str:
+    """Pull the {id} path parameter from the API Gateway event."""
+    params = event.get('pathParameters') or {}
+    return (params.get('id') or '').strip()
+
+
+def _validate_post_body(body: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Return a validation error event if the body is bad, else None."""
+    status = body.get('status')
+    if status not in VALID_STATUSES:
+        return {
+            'reason': (
+                f"status must be one of {sorted(VALID_STATUSES)}, "
+                f"got {status!r}"
+            ),
+            'field': 'status',
+        }
+
+    notes = body.get('notes')
+    if notes is not None and (not isinstance(notes, str) or len(notes) > MAX_NOTES_LEN):
+        return {
+            'reason': f'notes must be a string up to {MAX_NOTES_LEN} chars',
+            'field': 'notes',
+        }
+
+    for key in ('related_keyword', 'related_content_id'):
+        value = body.get(key)
+        if value is not None and (
+            not isinstance(value, str) or len(value) > MAX_RELATED_LEN
+        ):
+            return {
+                'reason': f'{key} must be a string up to {MAX_RELATED_LEN} chars',
+                'field': key,
+            }
+
+    return None
+
+
+def _post_status(event: Dict[str, Any]) -> Dict[str, Any]:
+    rec_id = _path_id(event)
+    if not rec_id:
+        return validation_error('Missing recommendation id', event, 'id')
+
+    raw_body = event.get('body') or '{}'
+    try:
+        body = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return validation_error('Invalid JSON body', event)
+
+    if not isinstance(body, dict):
+        return validation_error('Body must be a JSON object', event)
+
+    err = _validate_post_body(body)
+    if err is not None:
+        return validation_error(err['reason'], event, err['field'])
+
+    now = datetime.now(timezone.utc)
+    item: Dict[str, Any] = {
+        'recommendation_id': rec_id,
+        'status': body['status'],
+        'updated_at': _now_iso(),
+        'ttl': _ttl_for(now),
+    }
+    if body.get('notes'):
+        item['notes'] = body['notes']
+    if body.get('related_keyword'):
+        item['related_keyword'] = body['related_keyword']
+    if body.get('related_content_id'):
+        item['related_content_id'] = body['related_content_id']
+    if body['status'] == 'done':
+        item['completed_at'] = item['updated_at']
+
+    _table().put_item(Item=item)
+    return success_response(item, event)
+
+
+def _get_status(event: Dict[str, Any]) -> Dict[str, Any]:
+    rec_id = _path_id(event)
+    if not rec_id:
+        return validation_error('Missing recommendation id', event, 'id')
+
+    response = _table().get_item(Key={'recommendation_id': rec_id})
+    item = response.get('Item')
+    if not item:
+        return not_found_response(resource='Recommendation status', event=event)
+    return success_response(item, event)
+
+
+@api_handler
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """
+    Route by HTTP method.
+
+    POST: upsert the status row for a given recommendation id.
+    GET : fetch the current status row, 404 if none.
+    """
+    method = (event.get('httpMethod') or '').upper()
+    if method == 'POST':
+        return _post_status(event)
+    if method == 'GET':
+        return _get_status(event)
+    return error_response(
+        Exception(f'Method {method} not allowed'),
+        event,
+        status_code=405,
+    )
+
+
+def list_statuses(rec_ids: list[str]) -> Dict[str, Dict[str, Any]]:
+    """
+    Bulk look up status rows for many recommendation ids.
+
+    Used by `get-recommendations.py` to left-join status onto each
+    recommendation it returns. Falls back to an empty dict if the
+    table isn't configured (so the legacy /recommendations response
+    keeps working in local dev without the status table). DynamoDB
+    BatchGet has a 100-item limit; we chunk to stay under it.
+    """
+    if not RECOMMENDATION_STATUS_TABLE or not rec_ids:
+        return {}
+    table = _table()
+    deduped = list({rid for rid in rec_ids if rid})
+    out: Dict[str, Dict[str, Any]] = {}
+    chunk_size = 100
+    for i in range(0, len(deduped), chunk_size):
+        chunk = deduped[i:i + chunk_size]
+        try:
+            response = dynamodb.batch_get_item(
+                RequestItems={
+                    table.name: {
+                        'Keys': [{'recommendation_id': r} for r in chunk],
+                    },
+                },
+            )
+            for item in response.get('Responses', {}).get(table.name, []):
+                rid = item.get('recommendation_id')
+                if rid:
+                    out[rid] = item
+        except Exception as exc:
+            # The status feature is auxiliary — if the lookup fails, return
+            # what we have and let the caller render recommendations
+            # without status. Logged so an operator can investigate.
+            logger.warning(f'list_statuses failed for chunk {i}: {exc}')
+    return out

--- a/lambda/api/stats-insights.py
+++ b/lambda/api/stats-insights.py
@@ -29,6 +29,9 @@ ROUTE_MAP = {
     '/api/visibility': 'get-visibility-metrics.py',
     '/api/prompt-insights': 'get-prompt-insights.py',
     '/api/citation-gaps': 'get-citation-gaps.py',
+    # More specific (recommendations/{id}/status) must be checked before
+    # the generic /recommendations route since the matcher uses prefix.
+    '/api/recommendations/{id}/status': 'recommendation-status.py',
     '/api/recommendations': 'get-recommendations.py',
     '/api/trends': 'get-historical-trends.py',
     '/api/reports/overview': 'get-reports-overview.py',

--- a/lambda/api/test_get_recommendations_status_join.py
+++ b/lambda/api/test_get_recommendations_status_join.py
@@ -1,0 +1,184 @@
+"""
+Tests for get-recommendations.py's _annotate_with_status helper — the
+left-join from generated recommendations to the status table.
+
+The helper attaches `id` (deterministic hash) and `status` to every
+recommendation. When the status table isn't configured, every rec
+defaults to status='new'. When a status row exists, the row's
+status, notes, etc. override the default.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mount shared layer / fall back to lambda/ source tree.
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+_LAYER_PY = os.path.join(_REPO, 'lambda', 'layer', 'python')
+_LAMBDA_DIR = os.path.join(_REPO, 'lambda')
+if os.path.isdir(_LAYER_PY) and _LAYER_PY not in sys.path:
+    sys.path.insert(0, _LAYER_PY)
+elif _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+
+_layer_api_response = importlib.import_module('shared.api_response')
+sys.modules['shared.api_response'] = _layer_api_response
+
+from shared.utils import recommendation_id
+
+_API_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_get_recommendations():
+    """Load get-recommendations.py with boto3 patched out at module level."""
+    mock_dynamodb = MagicMock()
+    mock_dynamodb.Table.return_value = MagicMock()
+    mock_bedrock = MagicMock()
+
+    spec = importlib.util.spec_from_file_location(
+        'get_recommendations_under_test',
+        os.path.join(_API_DIR, 'get-recommendations.py'),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['get_recommendations_under_test'] = mod
+
+    with patch.dict(os.environ, {
+        'DYNAMODB_TABLE_SEARCH_RESULTS': 't',
+        'DYNAMODB_TABLE_CITATIONS': 't',
+        'DYNAMODB_TABLE_CRAWLED_CONTENT': 't',
+    }):
+        with patch('boto3.resource', return_value=mock_dynamodb):
+            with patch('boto3.client', return_value=mock_bedrock):
+                spec.loader.exec_module(mod)
+
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load_get_recommendations()
+
+
+def _make_rec(rec_type='gap', title='Pitch outdoor publishers', keywords=None):
+    return {
+        'type': rec_type,
+        'priority': 'high',
+        'title': title,
+        'description': 'd',
+        'action': 'a',
+        'impact': 'i',
+        'keywords': keywords or [],
+    }
+
+
+# --- id annotation -------------------------------------------------------
+
+
+def test_annotate_attaches_deterministic_id_to_each_rec(mod):
+    rec = _make_rec()
+    expected = recommendation_id(rec)
+    recs = [rec]
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('RECOMMENDATION_STATUS_TABLE', None)
+        mod._annotate_with_status(recs)
+    assert recs[0]['id'] == expected
+
+
+def test_annotate_assigns_status_new_when_no_status_table_configured(mod):
+    recs = [_make_rec()]
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('RECOMMENDATION_STATUS_TABLE', None)
+        mod._annotate_with_status(recs)
+    assert recs[0]['status'] == 'new'
+
+
+def test_annotate_assigns_distinct_ids_to_recs_with_distinct_titles(mod):
+    a = _make_rec(title='A')
+    b = _make_rec(title='B')
+    recs = [a, b]
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('RECOMMENDATION_STATUS_TABLE', None)
+        mod._annotate_with_status(recs)
+    assert recs[0]['id'] != recs[1]['id']
+
+
+# --- status join (when table configured) ---------------------------------
+
+
+def test_annotate_joins_status_row_when_table_returns_match(mod):
+    rec = _make_rec(title='Pitch X')
+    rec_id = recommendation_id(rec)
+
+    fake_status_module = MagicMock()
+    fake_status_module.list_statuses.return_value = {
+        rec_id: {
+            'recommendation_id': rec_id,
+            'status': 'in_progress',
+            'notes': 'reaching out next week',
+            'updated_at': '2026-05-15T10:00:00Z',
+        },
+    }
+
+    recs = [rec]
+    with patch.dict(os.environ, {'RECOMMENDATION_STATUS_TABLE': 'test'}):
+        with patch('importlib.util.spec_from_file_location') as fake_spec:
+            with patch('importlib.util.module_from_spec', return_value=fake_status_module):
+                fake_spec.return_value = MagicMock()
+                fake_spec.return_value.loader = MagicMock()
+                mod._annotate_with_status(recs)
+
+    assert recs[0]['status'] == 'in_progress'
+    assert recs[0]['notes'] == 'reaching out next week'
+
+
+def test_annotate_falls_back_to_new_status_when_join_lookup_fails(mod):
+    rec = _make_rec()
+    recs = [rec]
+    with patch.dict(os.environ, {'RECOMMENDATION_STATUS_TABLE': 'test'}):
+        with patch(
+            'importlib.util.spec_from_file_location',
+            side_effect=RuntimeError('boom'),
+        ):
+            mod._annotate_with_status(recs)
+    # Even though the env var is set, the broken loader is non-fatal.
+    assert recs[0]['status'] == 'new'
+
+
+def test_annotate_propagates_optional_fields_from_status_row(mod):
+    rec = _make_rec(title='Pitch X')
+    rec_id = recommendation_id(rec)
+
+    fake_status_module = MagicMock()
+    fake_status_module.list_statuses.return_value = {
+        rec_id: {
+            'recommendation_id': rec_id,
+            'status': 'done',
+            'completed_at': '2026-05-15T10:00:00Z',
+            'related_keyword': 'best running shoes',
+            'related_content_id': 'content-42',
+        },
+    }
+
+    recs = [rec]
+    with patch.dict(os.environ, {'RECOMMENDATION_STATUS_TABLE': 'test'}):
+        with patch('importlib.util.spec_from_file_location') as fake_spec:
+            with patch('importlib.util.module_from_spec', return_value=fake_status_module):
+                fake_spec.return_value = MagicMock()
+                fake_spec.return_value.loader = MagicMock()
+                mod._annotate_with_status(recs)
+
+    assert recs[0]['completed_at'] == '2026-05-15T10:00:00Z'
+    assert recs[0]['related_keyword'] == 'best running shoes'
+    assert recs[0]['related_content_id'] == 'content-42'
+
+
+def test_annotate_handles_empty_recommendations_list(mod):
+    recs = []
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('RECOMMENDATION_STATUS_TABLE', None)
+        mod._annotate_with_status(recs)
+    assert recs == []

--- a/lambda/api/test_recommendation_status.py
+++ b/lambda/api/test_recommendation_status.py
@@ -1,0 +1,335 @@
+"""
+Tests for recommendation-status.py — POST/GET /recommendations/{id}/status.
+
+Covers:
+- Validation: missing id, invalid status, oversized notes
+- POST sets status, includes ttl + updated_at
+- POST status=done populates completed_at
+- GET returns the row, 404 when missing
+- list_statuses degrades gracefully when env var is missing
+"""
+
+import importlib
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mount shared layer / fall back to lambda/ source tree.
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+_LAYER_PY = os.path.join(_REPO, 'lambda', 'layer', 'python')
+_LAMBDA_DIR = os.path.join(_REPO, 'lambda')
+if os.path.isdir(_LAYER_PY) and _LAYER_PY not in sys.path:
+    sys.path.insert(0, _LAYER_PY)
+elif _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+
+_layer_api_response = importlib.import_module('shared.api_response')
+sys.modules['shared.api_response'] = _layer_api_response
+
+_API_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_module():
+    """Load recommendation-status.py with boto3 patched out."""
+    mock_table = MagicMock()
+    mock_dynamodb = MagicMock()
+    mock_dynamodb.Table.return_value = mock_table
+    # batch_get_item lives on the resource itself
+    mock_dynamodb.batch_get_item.return_value = {'Responses': {}}
+
+    spec = importlib.util.spec_from_file_location(
+        'recommendation_status_under_test',
+        os.path.join(_API_DIR, 'recommendation-status.py'),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['recommendation_status_under_test'] = mod
+
+    with patch.dict(os.environ, {
+        'RECOMMENDATION_STATUS_TABLE': 'test-rec-status',
+    }):
+        with patch('boto3.resource', return_value=mock_dynamodb):
+            spec.loader.exec_module(mod)
+
+    # Override the module-level dynamodb reference so subsequent
+    # invocations use the mock too.
+    mod.dynamodb = mock_dynamodb
+    mod.RECOMMENDATION_STATUS_TABLE = 'test-rec-status'
+    return mod, mock_table, mock_dynamodb
+
+
+@pytest.fixture
+def loaded():
+    return _load_module()
+
+
+def _post_event(rec_id, body):
+    return {
+        'httpMethod': 'POST',
+        'resource': '/api/recommendations/{id}/status',
+        'path': f'/api/recommendations/{rec_id}/status',
+        'pathParameters': {'id': rec_id},
+        'headers': {'origin': 'http://localhost:3000'},
+        'body': json.dumps(body),
+    }
+
+
+def _get_event(rec_id):
+    return {
+        'httpMethod': 'GET',
+        'resource': '/api/recommendations/{id}/status',
+        'path': f'/api/recommendations/{rec_id}/status',
+        'pathParameters': {'id': rec_id},
+        'headers': {'origin': 'http://localhost:3000'},
+        'body': None,
+    }
+
+
+# --- validation ------------------------------------------------------------
+
+
+def test_post_returns_400_when_path_id_missing(loaded):
+    mod, _table, _ddb = loaded
+    event = _post_event('', {'status': 'done'})
+    event['pathParameters'] = {}
+    result = mod.handler(event, None)
+    assert result['statusCode'] == 400
+
+
+def test_post_returns_400_when_status_is_unknown(loaded):
+    mod, _table, _ddb = loaded
+    result = mod.handler(_post_event('abc', {'status': 'sideways'}), None)
+    assert result['statusCode'] == 400
+
+
+def test_post_returns_400_when_status_is_missing(loaded):
+    mod, _table, _ddb = loaded
+    result = mod.handler(_post_event('abc', {}), None)
+    assert result['statusCode'] == 400
+
+
+def test_post_returns_400_when_notes_exceeds_max_length(loaded):
+    mod, _table, _ddb = loaded
+    over_limit = 'x' * 5000
+    result = mod.handler(
+        _post_event('abc', {'status': 'done', 'notes': over_limit}),
+        None,
+    )
+    assert result['statusCode'] == 400
+
+
+def test_post_returns_400_when_related_keyword_exceeds_max_length(loaded):
+    mod, _table, _ddb = loaded
+    over_limit = 'x' * 1000
+    result = mod.handler(
+        _post_event('abc', {'status': 'done', 'related_keyword': over_limit}),
+        None,
+    )
+    assert result['statusCode'] == 400
+
+
+def test_post_returns_400_when_body_is_invalid_json(loaded):
+    mod, _table, _ddb = loaded
+    event = _post_event('abc', {})
+    event['body'] = '{not-json'
+    result = mod.handler(event, None)
+    assert result['statusCode'] == 400
+
+
+def test_post_returns_400_when_body_is_a_json_array(loaded):
+    mod, _table, _ddb = loaded
+    event = _post_event('abc', {})
+    event['body'] = '[]'
+    result = mod.handler(event, None)
+    assert result['statusCode'] == 400
+
+
+# --- POST persists ---------------------------------------------------------
+
+
+def test_post_persists_status_with_updated_at_and_ttl(loaded):
+    mod, table, _ddb = loaded
+    result = mod.handler(_post_event('abc', {'status': 'in_progress'}), None)
+    assert result['statusCode'] == 200
+    table.put_item.assert_called_once()
+    item = table.put_item.call_args.kwargs['Item']
+    assert item['recommendation_id'] == 'abc'
+    assert item['status'] == 'in_progress'
+    assert item['updated_at'].endswith('Z')
+
+
+def test_post_sets_ttl_approximately_90_days_in_the_future(loaded):
+    import time
+    mod, table, _ddb = loaded
+    mod.handler(_post_event('abc', {'status': 'in_progress'}), None)
+    item = table.put_item.call_args.kwargs['Item']
+    expected_ttl = int(time.time()) + 90 * 24 * 60 * 60
+    # Allow a 60-second drift between test setup and assertion.
+    assert abs(item['ttl'] - expected_ttl) < 60
+
+
+def test_post_response_body_contains_the_persisted_item(loaded):
+    mod, table, _ddb = loaded
+    result = mod.handler(_post_event('abc', {'status': 'done'}), None)
+    body = json.loads(result['body'])
+    assert body['recommendation_id'] == 'abc'
+    assert body['status'] == 'done'
+    assert 'completed_at' in body
+
+
+def test_post_done_status_sets_completed_at(loaded):
+    mod, table, _ddb = loaded
+    mod.handler(_post_event('xyz', {'status': 'done'}), None)
+    item = table.put_item.call_args.kwargs['Item']
+    assert 'completed_at' in item
+
+
+def test_post_in_progress_does_not_set_completed_at(loaded):
+    mod, table, _ddb = loaded
+    mod.handler(_post_event('xyz', {'status': 'in_progress'}), None)
+    item = table.put_item.call_args.kwargs['Item']
+    assert 'completed_at' not in item
+
+
+def test_post_persists_optional_notes_and_relationship_pointers(loaded):
+    mod, table, _ddb = loaded
+    body = {
+        'status': 'in_progress',
+        'notes': 'reaching out next week',
+        'related_keyword': 'best running shoes',
+        'related_content_id': 'content-42',
+    }
+    mod.handler(_post_event('abc', body), None)
+    item = table.put_item.call_args.kwargs['Item']
+    assert item['notes'] == 'reaching out next week'
+    assert item['related_keyword'] == 'best running shoes'
+    assert item['related_content_id'] == 'content-42'
+
+
+# --- GET ------------------------------------------------------------------
+
+
+def test_get_returns_200_with_existing_row(loaded):
+    mod, table, _ddb = loaded
+    table.get_item.return_value = {
+        'Item': {'recommendation_id': 'abc', 'status': 'done'},
+    }
+    result = mod.handler(_get_event('abc'), None)
+    assert result['statusCode'] == 200
+
+
+def test_get_response_body_contains_status_row_fields(loaded):
+    mod, table, _ddb = loaded
+    table.get_item.return_value = {
+        'Item': {
+            'recommendation_id': 'abc',
+            'status': 'done',
+            'updated_at': '2026-05-15T10:00:00Z',
+            'notes': 'pitched',
+        },
+    }
+    result = mod.handler(_get_event('abc'), None)
+    body = json.loads(result['body'])
+    assert body['status'] == 'done'
+    assert body['notes'] == 'pitched'
+
+
+def test_get_returns_404_when_no_row_exists(loaded):
+    mod, table, _ddb = loaded
+    table.get_item.return_value = {}
+    result = mod.handler(_get_event('abc'), None)
+    assert result['statusCode'] == 404
+
+
+# --- list_statuses --------------------------------------------------------
+
+
+def test_list_statuses_returns_empty_dict_when_table_unconfigured(loaded):
+    mod, _table, _ddb = loaded
+    mod.RECOMMENDATION_STATUS_TABLE = None
+    out = mod.list_statuses(['abc', 'def'])
+    assert out == {}
+
+
+def test_list_statuses_calls_batch_get_and_keys_by_recommendation_id(loaded):
+    mod, table, ddb = loaded
+    ddb.batch_get_item.return_value = {
+        'Responses': {
+            table.name: [
+                {'recommendation_id': 'abc', 'status': 'done'},
+                {'recommendation_id': 'xyz', 'status': 'in_progress'},
+            ],
+        },
+    }
+    out = mod.list_statuses(['abc', 'xyz', 'missing'])
+    assert out['abc']['status'] == 'done'
+    assert out['xyz']['status'] == 'in_progress'
+    assert 'missing' not in out
+
+
+def test_list_statuses_returns_empty_dict_for_empty_input(loaded):
+    mod, _table, _ddb = loaded
+    out = mod.list_statuses([])
+    assert out == {}
+
+
+# --- method routing -------------------------------------------------------
+
+
+def test_handler_returns_405_for_unsupported_method(loaded):
+    mod, _table, _ddb = loaded
+    event = _get_event('abc')
+    event['httpMethod'] = 'PUT'
+    result = mod.handler(event, None)
+    assert result['statusCode'] == 405
+
+
+# --- additional coverage gaps --------------------------------------------
+
+
+def test_get_returns_400_when_path_id_missing(loaded):
+    mod, _table, _ddb = loaded
+    event = _get_event('')
+    event['pathParameters'] = {}
+    result = mod.handler(event, None)
+    assert result['statusCode'] == 400
+
+
+def test_table_helper_raises_runtime_error_when_env_var_unset(loaded):
+    mod, _table, _ddb = loaded
+    mod.RECOMMENDATION_STATUS_TABLE = None
+    with pytest.raises(RuntimeError):
+        mod._table()
+
+
+def test_list_statuses_skips_response_items_without_recommendation_id(loaded):
+    # If DynamoDB returns a response item missing the partition key (data
+    # corruption / partial scan response), `list_statuses` should skip it
+    # rather than insert an empty key into the result map.
+    mod, table, ddb = loaded
+    ddb.batch_get_item.return_value = {
+        'Responses': {
+            table.name: [
+                {'status': 'done'},  # missing recommendation_id
+                {'recommendation_id': 'good', 'status': 'in_progress'},
+            ],
+        },
+    }
+    out = mod.list_statuses(['good', 'phantom'])
+    assert list(out.keys()) == ['good']
+
+
+def test_list_statuses_returns_partial_results_when_a_chunk_fails(loaded):
+    # The auxiliary status feature is non-fatal: if BatchGetItem raises,
+    # we keep going so recommendations still render without status.
+    mod, _table, ddb = loaded
+
+    class BatchGetError(Exception):
+        pass
+
+    ddb.batch_get_item.side_effect = BatchGetError('throttled')
+    out = mod.list_statuses(['abc'])
+    assert out == {}

--- a/lambda/shared/test_utils_recommendation_id.py
+++ b/lambda/shared/test_utils_recommendation_id.py
@@ -1,0 +1,73 @@
+"""
+Tests for shared.utils.recommendation_id — the deterministic hash used
+to track recommendation status across list-regenerations.
+"""
+
+import importlib
+import os
+import sys
+
+# Mount shared layer / fall back to lambda/ source tree.
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+_LAYER_PY = os.path.join(_REPO, 'lambda', 'layer', 'python')
+_LAMBDA_DIR = os.path.join(_REPO, 'lambda')
+if os.path.isdir(_LAYER_PY) and _LAYER_PY not in sys.path:
+    sys.path.insert(0, _LAYER_PY)
+elif _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+
+from shared.utils import recommendation_id
+
+
+def test_returns_16_char_hex_digest():
+    out = recommendation_id({'type': 'gap', 'title': 'X'})
+    assert len(out) == 16
+    int(out, 16)  # raises if not hex
+
+
+def test_same_inputs_yield_same_id():
+    rec_a = {'type': 'gap', 'title': 'Pitch outdoor publishers'}
+    rec_b = {'type': 'gap', 'title': 'Pitch outdoor publishers'}
+    assert recommendation_id(rec_a) == recommendation_id(rec_b)
+
+
+def test_different_titles_yield_different_ids():
+    a = {'type': 'gap', 'title': 'A'}
+    b = {'type': 'gap', 'title': 'B'}
+    assert recommendation_id(a) != recommendation_id(b)
+
+
+def test_different_types_yield_different_ids():
+    a = {'type': 'gap', 'title': 'X'}
+    b = {'type': 'visibility', 'title': 'X'}
+    assert recommendation_id(a) != recommendation_id(b)
+
+
+def test_keyword_order_does_not_affect_id():
+    a = {'type': 'gap', 'title': 'X', 'keywords': ['shoes', 'boots']}
+    b = {'type': 'gap', 'title': 'X', 'keywords': ['boots', 'shoes']}
+    assert recommendation_id(a) == recommendation_id(b)
+
+
+def test_keyword_set_membership_does_change_id():
+    a = {'type': 'gap', 'title': 'X', 'keywords': ['shoes']}
+    b = {'type': 'gap', 'title': 'X', 'keywords': ['shoes', 'boots']}
+    assert recommendation_id(a) != recommendation_id(b)
+
+
+def test_description_changes_do_not_affect_id():
+    a = {'type': 'gap', 'title': 'X', 'description': 'one'}
+    b = {'type': 'gap', 'title': 'X', 'description': 'two'}
+    assert recommendation_id(a) == recommendation_id(b)
+
+
+def test_action_changes_do_not_affect_id():
+    a = {'type': 'gap', 'title': 'X', 'action': 'one'}
+    b = {'type': 'gap', 'title': 'X', 'action': 'two'}
+    assert recommendation_id(a) == recommendation_id(b)
+
+
+def test_case_insensitive_on_type_and_title():
+    a = {'type': 'GAP', 'title': 'Pitch X'}
+    b = {'type': 'gap', 'title': 'pitch x'}
+    assert recommendation_id(a) == recommendation_id(b)

--- a/lambda/shared/utils.py
+++ b/lambda/shared/utils.py
@@ -181,3 +181,31 @@ def brand_names_match(candidate: str, tracked: str) -> bool:
     if not c or not t:
         return False
     return c == t
+
+
+def recommendation_id(recommendation: dict[str, Any]) -> str:
+    """
+    Compute a deterministic stable id for a recommendation.
+
+    Recommendations are produced by `generate_rule_based_recommendations`
+    and aren't stored in DynamoDB themselves — every list call regenerates
+    them. To track per-recommendation status (acknowledged / done /
+    won't fix) we need a stable identifier that doesn't drift across
+    calls. The hash inputs are the immutable parts of a recommendation:
+    type, title, and the keywords list (sorted). Wording in `description`
+    or `action` is excluded because those tend to be slightly different
+    between rule iterations even when the underlying recommendation is
+    semantically the same.
+
+    Returns the SHA-1 hex digest, truncated to 16 characters. Truncation
+    is fine: the inputs come from a small enumerated space (a few rule
+    types × a few hundred keywords) and 64 bits of hash gives a
+    collision probability low enough for our scale.
+    """
+    import hashlib
+    rec_type = (recommendation.get('type') or '').strip().lower()
+    title = (recommendation.get('title') or '').strip().lower()
+    keywords = recommendation.get('keywords') or []
+    keyword_part = '|'.join(sorted(str(k).strip().lower() for k in keywords))
+    payload = f"{rec_type}::{title}::{keyword_part}".encode('utf-8')
+    return hashlib.sha1(payload, usedforsecurity=False).hexdigest()[:16]

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -387,6 +387,29 @@ export class CitationAnalysisStack extends cdk.Stack {
       timeToLiveAttribute: 'ttl',
     });
 
+    // DynamoDB Table: RecommendationStatus
+    // Tracks the action-tracking lifecycle (new -> in_progress -> done /
+    // wontfix) for individual recommendations produced by
+    // get-recommendations.py. The recommendations themselves aren't
+    // persisted -- they're regenerated on every API call -- so this
+    // table is the only durable record of which items have been worked
+    // on. PK is a deterministic SHA-1 hash of the recommendation's
+    // type + title + sorted keywords (see shared.utils.recommendation_id).
+    // 90-day TTL evicts abandoned items so the table doesn't grow
+    // unbounded for one-off recommendations that never get triaged.
+    const recommendationStatusTable = new dynamodb.Table(this, 'RecommendationStatusTable', {
+      tableName: 'CitationAnalysis-RecommendationStatus',
+      partitionKey: {
+        name: 'recommendation_id',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      timeToLiveAttribute: 'ttl',
+    });
+
     // ========================================
     // Secrets Manager - API Keys
     // ========================================
@@ -1196,6 +1219,7 @@ export class CitationAnalysisStack extends cdk.Stack {
         'get-recommendations.py',
         'get-historical-trends.py',
         'get-reports-overview.py',
+        'recommendation-status.py',
       ]),
       layers: [sharedLayer],
       timeout: cdk.Duration.seconds(60),
@@ -1217,6 +1241,9 @@ export class CitationAnalysisStack extends cdk.Stack {
         KEYWORDS_TABLE: keywordsTable.tableName,
         PROVIDER_CONFIG_TABLE: providerConfigTable.tableName,
         ...bedrockTierEnv,
+        // recommendation status (read for left-join, write for the
+        // POST /recommendations/{id}/status route)
+        RECOMMENDATION_STATUS_TABLE: recommendationStatusTable.tableName,
       },
     });
 
@@ -1369,6 +1396,10 @@ export class CitationAnalysisStack extends cdk.Stack {
     keywordsTable.grantReadData(statsInsightsFunction);
     brandConfigTable.grantReadData(statsInsightsFunction);
     providerConfigTable.grantReadData(statsInsightsFunction);
+    // The same Lambda serves both GET /recommendations (read-only join)
+    // and POST /recommendations/{id}/status (write upsert), so it
+    // needs read-write on the status table.
+    recommendationStatusTable.grantReadWriteData(statsInsightsFunction);
     // Grant Bedrock access for LLM-enhanced recommendations (get-recommendations.py)
     statsInsightsFunction.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -1809,6 +1840,16 @@ export class CitationAnalysisStack extends cdk.Stack {
 
     const recommendationsResource = apiResource.addResource('recommendations');
     recommendationsResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
+
+    // POST /recommendations/{id}/status — set the action-tracking state
+    // (new / in_progress / done / wontfix) for a given recommendation.
+    // GET /recommendations/{id}/status — read the current state.
+    // Both routed to the consolidated stats-insights Lambda which loads
+    // recommendation-status.py via the ROUTE_MAP prefix match.
+    const recommendationIdResource = recommendationsResource.addResource('{id}');
+    const recommendationStatusResource = recommendationIdResource.addResource('status');
+    recommendationStatusResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
+    recommendationStatusResource.addMethod('POST', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
 
     const trendsResource = apiResource.addResource('trends');
     trendsResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);

--- a/web/src/api/visibility.ts
+++ b/web/src/api/visibility.ts
@@ -1,7 +1,9 @@
 /**
  * Visibility and insights API client functions.
  */
-import { apiGet } from './client';
+import {
+  apiGet, apiPost 
+} from './client';
 import type {
   VisibilityMetricsResponse,
   PromptInsightsResponse,
@@ -95,6 +97,44 @@ export function fetchRecommendations(
     params: { use_llm: useLlm.toString() },
     signal,
   });
+}
+
+interface SetRecommendationStatusBody {
+  readonly status: 'new' | 'in_progress' | 'done' | 'wontfix';
+  readonly notes?: string;
+  readonly related_keyword?: string;
+  readonly related_content_id?: string;
+}
+
+interface RecommendationStatusRow {
+  recommendation_id: string;
+  status: 'new' | 'in_progress' | 'done' | 'wontfix';
+  updated_at: string;
+  completed_at?: string;
+  notes?: string;
+  related_keyword?: string;
+  related_content_id?: string;
+  ttl?: number;
+}
+
+/**
+ * Sets the action-tracking status for a single recommendation.
+ *
+ * The `id` is the deterministic hash returned on each recommendation in
+ * `RecommendationsResponse.recommendations[].id`. Same id across list
+ * regenerations, so the status persists even when the underlying list
+ * is recomputed.
+ */
+export function setRecommendationStatus(
+  id: string,
+  body: SetRecommendationStatusBody,
+  signal?: AbortSignal,
+): Promise<RecommendationStatusRow> {
+  return apiPost<RecommendationStatusRow>(
+    `/recommendations/${encodeURIComponent(id)}/status`,
+    body,
+    { signal },
+  );
 }
 
 interface FetchHistoricalTrendsOptions {

--- a/web/src/hooks/useRecommendations-fixtures.ts
+++ b/web/src/hooks/useRecommendations-fixtures.ts
@@ -4,6 +4,8 @@ import type { RecommendationsResponse } from '../types';
 export const mockRecommendationsResponse: RecommendationsResponse = {
   recommendations: [
     {
+      id: 'rec-001',
+      status: 'new',
       type: 'content_gap',
       priority: 'high',
       title: 'Create content for high-traffic keyword',
@@ -13,6 +15,8 @@ export const mockRecommendationsResponse: RecommendationsResponse = {
       keywords: ['best hotels'],
     },
     {
+      id: 'rec-002',
+      status: 'new',
       type: 'brand_mention',
       priority: 'medium',
       title: 'Increase brand visibility',

--- a/web/src/hooks/useRecommendations.spec.ts
+++ b/web/src/hooks/useRecommendations.spec.ts
@@ -170,4 +170,120 @@ describe('useRecommendations', () => {
       expect(result.current.error).toBeNull();
     });
   });
+
+  describe('updateRecommendationStatus', () => {
+    function statusOkResponse(payload: object) {
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(payload),
+      };
+    }
+
+    it('posts to /recommendations/{id}/status with the new status', async () => {
+      mockAuthenticatedFetch
+        .mockImplementationOnce(createMockFetch())
+        .mockImplementationOnce(() => Promise.resolve(statusOkResponse({
+          recommendation_id: 'rec-001',
+          status: 'in_progress',
+          updated_at: '2026-05-15T10:00:00Z',
+        })));
+
+      const { result } = renderHook(() => useRecommendations());
+      await act(async () => {
+        await result.current.fetchRecommendations();
+      });
+
+      await act(async () => {
+        await result.current.updateRecommendationStatus('rec-001', { status: 'in_progress' });
+      });
+
+      const url = mockAuthenticatedFetch.mock.calls[1][0] as string;
+      expect(url).toContain('/recommendations/rec-001/status');
+    });
+
+    it('serialises notes and relationship pointers in the request body', async () => {
+      mockAuthenticatedFetch
+        .mockImplementationOnce(createMockFetch())
+        .mockImplementationOnce(() => Promise.resolve(statusOkResponse({
+          recommendation_id: 'rec-001',
+          status: 'done',
+          updated_at: '2026-05-15T10:00:00Z',
+        })));
+
+      const { result } = renderHook(() => useRecommendations());
+      await act(async () => {
+        await result.current.fetchRecommendations();
+      });
+
+      await act(async () => {
+        await result.current.updateRecommendationStatus('rec-001', {
+          status: 'done',
+          notes: 'pitched outdoor pubs',
+          relatedKeyword: 'best running shoes',
+          relatedContentId: 'content-42',
+        });
+      });
+
+      const init = mockAuthenticatedFetch.mock.calls[1][1] as RequestInit;
+      const body = JSON.parse(init.body as string) as Record<string, string>;
+      expect(body.status).toBe('done');
+      expect(body.notes).toBe('pitched outdoor pubs');
+      expect(body.related_keyword).toBe('best running shoes');
+      expect(body.related_content_id).toBe('content-42');
+    });
+
+    it('optimistically updates the recommendation status in local state', async () => {
+      mockAuthenticatedFetch
+        .mockImplementationOnce(createMockFetch())
+        .mockImplementationOnce(() => Promise.resolve(statusOkResponse({
+          recommendation_id: 'rec-001',
+          status: 'done',
+          updated_at: '2026-05-15T10:00:00Z',
+        })));
+
+      const { result } = renderHook(() => useRecommendations());
+      await act(async () => {
+        await result.current.fetchRecommendations();
+      });
+
+      await act(async () => {
+        await result.current.updateRecommendationStatus('rec-001', { status: 'done' });
+      });
+
+      const updated = result.current.data?.recommendations.find((r) => r.id === 'rec-001');
+      expect(updated?.status).toBe('done');
+    });
+
+    it('rolls back the optimistic update when the server call fails', async () => {
+      mockAuthenticatedFetch
+        .mockImplementationOnce(createMockFetch())
+        .mockImplementationOnce(() => Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({}),
+        }));
+
+      const { result } = renderHook(() => useRecommendations());
+      await act(async () => {
+        await result.current.fetchRecommendations();
+      });
+
+      await act(async () => {
+        await result.current.updateRecommendationStatus('rec-001', { status: 'done' });
+      });
+
+      const reverted = result.current.data?.recommendations.find((r) => r.id === 'rec-001');
+      expect(reverted?.status).toBe('new');
+    });
+
+    it('returns null and skips the fetch when id is empty', async () => {
+      const { result } = renderHook(() => useRecommendations());
+      const ret = await act(
+        () => result.current.updateRecommendationStatus('', { status: 'done' }),
+      );
+      expect(ret).toBeNull();
+      expect(mockAuthenticatedFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/web/src/hooks/useRecommendations.ts
+++ b/web/src/hooks/useRecommendations.ts
@@ -1,10 +1,14 @@
 import {
-  useState, useCallback 
+  useState, useCallback,
 } from 'react';
 import {
-  API_BASE_URL, authenticatedFetch, getErrorMessage 
+  API_BASE_URL, authenticatedFetch, getErrorMessage,
 } from '../infrastructure';
-import type { RecommendationsResponse } from '../types';
+import type {
+  Recommendation,
+  RecommendationsResponse,
+  RecommendationStatus,
+} from '../types';
 
 class RecommendationsFetchError extends Error {
   constructor(message = 'Failed to fetch recommendations') {
@@ -13,13 +17,37 @@ class RecommendationsFetchError extends Error {
   }
 }
 
+class RecommendationStatusError extends Error {
+  constructor(message = 'Failed to update recommendation status') {
+    super(message);
+    this.name = 'RecommendationStatusError';
+  }
+}
+
 function isRecommendationsResponse(data: unknown): data is RecommendationsResponse {
   return (
-    typeof data === 'object' &&
-    data !== null &&
-    'recommendations' in data &&
-    'total_count' in data
+    typeof data === 'object'
+    && data !== null
+    && 'recommendations' in data
+    && 'total_count' in data
   );
+}
+
+interface UpdateStatusInput {
+  readonly status: RecommendationStatus;
+  readonly notes?: string;
+  readonly relatedKeyword?: string;
+  readonly relatedContentId?: string;
+}
+
+interface RecommendationStatusRow {
+  readonly recommendation_id: string;
+  readonly status: RecommendationStatus;
+  readonly updated_at: string;
+  readonly completed_at?: string;
+  readonly notes?: string;
+  readonly related_keyword?: string;
+  readonly related_content_id?: string;
 }
 
 export function useRecommendations() {
@@ -30,12 +58,14 @@ export function useRecommendations() {
   const fetchRecommendations = useCallback(async (useLlm = false) => {
     setLoading(true);
     setError(null);
-    
+
     try {
       const params = new URLSearchParams({ use_llm: useLlm.toString() });
-      const response = await authenticatedFetch(`${API_BASE_URL}/recommendations?${params}`);
+      const response = await authenticatedFetch(
+        `${API_BASE_URL}/recommendations?${params}`,
+      );
       if (!response.ok) throw new RecommendationsFetchError();
-      
+
       const json: unknown = await response.json();
       if (!isRecommendationsResponse(json)) {
         throw new RecommendationsFetchError('Invalid response format');
@@ -52,10 +82,89 @@ export function useRecommendations() {
     }
   }, []);
 
+  /**
+   * Persist a status update for a single recommendation. Optimistically
+   * mirrors the new status into local state so the UI doesn't have to
+   * re-fetch the full list to show the change. If the server call
+   * fails the optimistic update is rolled back.
+   */
+  const updateRecommendationStatus = useCallback(async (
+    id: string,
+    input: UpdateStatusInput,
+  ): Promise<RecommendationStatusRow | null> => {
+    if (!id) return null;
+
+    const previousStatusRef: { current: RecommendationStatus | undefined } = {current: undefined,};
+    setData((current) => {
+      if (current === null) return current;
+      const updated = current.recommendations.map((rec) => {
+        if (rec.id !== id) return rec;
+        previousStatusRef.current = rec.status;
+        return {
+          ...rec,
+          status: input.status,
+          notes: input.notes ?? rec.notes,
+        };
+      });
+      return {
+        ...current,
+        recommendations: updated,
+      };
+    });
+
+    try {
+      const body = {
+        status: input.status,
+        ...(input.notes === undefined ? {} : { notes: input.notes }),
+        ...(input.relatedKeyword === undefined
+          ? {}
+          : { related_keyword: input.relatedKeyword }),
+        ...(input.relatedContentId === undefined
+          ? {}
+          : { related_content_id: input.relatedContentId }),
+      };
+      const response = await authenticatedFetch(
+        `${API_BASE_URL}/recommendations/${encodeURIComponent(id)}/status`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!response.ok) throw new RecommendationStatusError();
+      const row = (await response.json()) as RecommendationStatusRow;
+      return row;
+    } catch (err) {
+      // Roll back the optimistic update so the UI doesn't lie to the
+      // user about the persisted state. Read the captured previous
+      // status from the ref *inside* the setData callback so the read
+      // happens after React has flushed the optimistic update.
+      setData((current) => {
+        const rollback = previousStatusRef.current;
+        if (current === null || rollback === undefined) return current;
+        const reverted = current.recommendations.map((rec): Recommendation => (
+          rec.id === id ? {
+            ...rec,
+            status: rollback,
+          } : rec
+        ));
+        return {
+          ...current,
+          recommendations: reverted,
+        };
+      });
+      const message = getErrorMessage(err, 'visibility');
+      setError(message);
+      console.error('[recommendations] Error updating status:', err);
+      return null;
+    }
+  }, []);
+
   return {
     data,
     loading,
     error,
-    fetchRecommendations 
+    fetchRecommendations,
+    updateRecommendationStatus,
   };
 }

--- a/web/src/types/domain/visibility.ts
+++ b/web/src/types/domain/visibility.ts
@@ -112,6 +112,12 @@ export interface CitationGapsResponse {
   total_high_priority?: number;
 }
 
+export type RecommendationStatus =
+  | 'new'
+  | 'in_progress'
+  | 'done'
+  | 'wontfix';
+
 export interface Recommendation {
   type: string;
   priority: GapPriority;
@@ -120,6 +126,19 @@ export interface Recommendation {
   action: string;
   impact: string;
   keywords?: string[];
+  /**
+   * Server-computed deterministic id (SHA-1 of type+title+sorted keywords,
+   * truncated to 16 chars). Stable across list regenerations so it can
+   * be used to track per-recommendation action status.
+   */
+  id?: string;
+  /** Persisted action-tracking state. Defaults to 'new' if untouched. */
+  status?: RecommendationStatus;
+  notes?: string;
+  related_keyword?: string;
+  related_content_id?: string;
+  updated_at?: string;
+  completed_at?: string;
 }
 
 export interface RecommendationsResponse {
@@ -206,9 +225,7 @@ export interface CrossPersonaBrandSummary {
 export interface PersonaRankingsResponse {
   keyword: string;
   personas: PersonaRankingGroup[];
-  cross_persona_summary: {
-    brands: CrossPersonaBrandSummary[];
-  };
+  cross_persona_summary: {brands: CrossPersonaBrandSummary[];};
 }
 
 export interface ContentRecommendation {


### PR DESCRIPTION
Re-merge of PR #45 with conflict resolution against current main.

The original branch was rooted on main from before the lambda audit
chain (#31-#35), which produced 50+ conflict regions in
lib/citation-analysis-stack.ts plus modernised utils.py and
get-recommendations.py. This PR carries over Matias's intent:

- New RecommendationStatusTable DynamoDB table
- New recommendation-status.py handler with status enum
- _annotate_with_status() left-join on /recommendations response
- Frontend hook + API client + types for status tracking

Conflicts resolved:
- lambda/shared/utils.py: kept main's brand_names_match, appended
  Matias's recommendation_id helper.
- lambda/api/get-recommendations.py: kept main's modernised imports
  (api_handler, validate, models, llm_json), added recommendation_id
  to the utils import; added typing.Dict/List for the new helper.
- lib/citation-analysis-stack.ts: combined both file lists for the
  stats-insights handler, kept ...bedrockTierEnv plus added
  RECOMMENDATION_STATUS_TABLE.

Tests:
- 371/371 lambda pytest pass
- 854/854 web vitest pass
- CDK build clean, cdk diff shows new table + IAM grants only,
  no destructive resource changes.
