### PR TITLE
feat(api): /reports/competitor rollup endpoint (re-merge of #46, rebased).

### DIFF
--- a/lambda/api/get-reports-competitor.py
+++ b/lambda/api/get-reports-competitor.py
@@ -1,0 +1,346 @@
+"""
+Reports Competitor Rollup API
+
+Per-competitor rollup that powers the Competitor Gap print report and
+ad-hoc "where is X eating our lunch" lookups. Combines:
+
+- Outranked keywords: keywords where the competitor's best rank beats
+  every first-party brand's best rank.
+- Exclusive citation sources: URLs that cite this competitor but no
+  first-party brand (a subset of citation gaps, filtered by competitor).
+- Outreach targets: the same exclusive sources sorted by an outreach
+  lift score so a PR strategist can plan a sprint.
+
+Why this exists rather than client-side composition
+
+The competitor view requires a join across keyword * provider * brand
+that the existing /visibility and /citation-gaps endpoints don't surface
+directly. Building this client-side would require iterating every
+configured competitor and every keyword on the frontend with N+1
+visibility/gap calls. Doing it server-side fans out once per request
+and caches naturally per analysis run.
+
+Routes
+
+  GET /api/reports/competitor?competitor=<name>
+    Returns a single competitor's rollup.
+
+  GET /api/reports/competitor
+    Returns the cross-competitor list — every configured competitor's
+    rollup at once. Useful for the report's selector dropdown to know
+    what's available.
+
+Query params
+
+  competitor (str, optional)  — when omitted, all configured competitors.
+  keyword_limit (int, 1-100, default 50) — caps the keyword fan-out.
+                                            Above 50 keywords the call
+                                            blows past the Lambda
+                                            timeout, so we hard-cap.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import math
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+# Shared layer path
+sys.path.insert(0, '/opt/python')
+
+from shared.api_response import success_response, validation_error
+from shared.decorators import api_handler, validate
+from shared.utils import get_brand_config
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.resource('dynamodb')
+
+SEARCH_RESULTS_TABLE = os.environ.get('DYNAMODB_TABLE_SEARCH_RESULTS')
+KEYWORDS_TABLE = os.environ.get('DYNAMODB_TABLE_KEYWORDS')
+
+
+# ----------------------------------------------------------------------
+# Sibling helper loader (same lazy pattern as get-reports-overview).
+# Lazy so module-level boto3 calls in the sibling files don't fire at
+# import time and so unit tests can stub the helpers via the cache.
+# ----------------------------------------------------------------------
+
+_API_DIR = os.path.dirname(os.path.abspath(__file__))
+_sibling_cache: Dict[str, Callable] = {}
+
+
+def _load_sibling(filename: str, attr: str) -> Callable:
+    module_name = filename.replace('-', '_').replace('.py', '_for_competitor')
+    spec = importlib.util.spec_from_file_location(
+        module_name, os.path.join(_API_DIR, filename)
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load sibling module {filename!r}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    fn = getattr(module, attr, None)
+    if fn is None:
+        raise AttributeError(f"{filename} has no attribute {attr!r}")
+    return fn
+
+
+def _gap_helper() -> Callable:
+    """Lazy-load `analyze_citation_gaps` from get-citation-gaps.py."""
+    if 'gap' not in _sibling_cache:
+        _sibling_cache['gap'] = _load_sibling(
+            'get-citation-gaps.py', 'analyze_citation_gaps'
+        )
+    return _sibling_cache['gap']
+
+
+# ----------------------------------------------------------------------
+# Keyword discovery + per-keyword rank lookup
+# ----------------------------------------------------------------------
+
+def _list_tracked_keywords(limit: int) -> List[str]:
+    """
+    Pull tracked keywords from the Keywords table when available, else
+    fall back to a search-results scan. Same trick `get-historical-trends`
+    uses to keep cold-start latency low.
+    """
+    if KEYWORDS_TABLE:
+        table = dynamodb.Table(KEYWORDS_TABLE)
+        response = table.scan(ProjectionExpression='keyword', Limit=500)
+        names = [
+            item.get('keyword', '')
+            for item in response.get('Items', [])
+            if item.get('keyword')
+        ]
+    else:
+        if not SEARCH_RESULTS_TABLE:
+            return []
+        table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+        response = table.scan(ProjectionExpression='keyword', Limit=500)
+        names = [
+            item.get('keyword', '')
+            for item in response.get('Items', [])
+            if item.get('keyword')
+        ]
+    return list(dict.fromkeys(names))[:limit]
+
+
+def _latest_brand_ranks(keyword: str) -> Dict[str, Dict[str, Any]]:
+    """
+    For a keyword, return the latest snapshot's brand ranks indexed by
+    lower-cased brand name. Returns empty dict if no data.
+    """
+    if not SEARCH_RESULTS_TABLE:
+        return {}
+    table = dynamodb.Table(SEARCH_RESULTS_TABLE)
+    response = table.query(
+        KeyConditionExpression=Key('keyword').eq(keyword)
+    )
+    items = response.get('Items', [])
+    if not items:
+        return {}
+
+    latest_ts = max(item.get('timestamp', '') for item in items)
+    latest_items = [item for item in items if item.get('timestamp') == latest_ts]
+
+    aggregated: Dict[str, Dict[str, Any]] = defaultdict(lambda: {
+        'best_rank': 999,
+        'providers': set(),
+        'classification': 'other',
+    })
+    for item in latest_items:
+        provider = item.get('provider', '')
+        for brand in item.get('brands', []) or []:
+            name = (brand.get('name') or '').strip().lower()
+            if not name:
+                continue
+            try:
+                rank = int(brand.get('rank') or 999)
+            except (TypeError, ValueError):
+                rank = 999
+            row = aggregated[name]
+            row['best_rank'] = min(row['best_rank'], rank)
+            row['providers'].add(provider)
+            classification = brand.get('classification')
+            if classification:
+                row['classification'] = classification
+
+    # Convert sets to sorted lists for stable JSON serialization
+    return {
+        name: {
+            'best_rank': data['best_rank'],
+            'providers': sorted(data['providers']),
+            'classification': data['classification'],
+        }
+        for name, data in aggregated.items()
+    }
+
+
+# ----------------------------------------------------------------------
+# Rollup composition
+# ----------------------------------------------------------------------
+
+def _outreach_lift(citation_count: int, provider_count: int) -> float:
+    """
+    Lift heuristic for outreach prioritisation. Sources cited by many
+    providers + many times have higher lift. We use log scaling on
+    citation_count to dampen the very-cited outliers (a single domain
+    with 50 citations should not dwarf 5 domains with 10 each).
+    """
+    return round(provider_count * math.log(max(citation_count, 1) + 1), 2)
+
+
+def _build_competitor_rollup(
+    competitor: str,
+    keywords: List[str],
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Compose one competitor's rollup."""
+    competitor_lc = competitor.lower()
+    first_party = [
+        b.lower() for b in config.get('tracked_brands', {}).get('first_party', [])
+    ]
+
+    outranked: List[Dict[str, Any]] = []
+    exclusive_sources: List[Dict[str, Any]] = []
+
+    for keyword in keywords:
+        ranks = _latest_brand_ranks(keyword)
+        their = ranks.get(competitor_lc)
+        if not their or their['best_rank'] >= 999:
+            continue
+
+        our_best = min(
+            (ranks[fp]['best_rank'] for fp in first_party if fp in ranks),
+            default=999,
+        )
+
+        if their['best_rank'] < our_best:
+            outranked.append({
+                'keyword': keyword,
+                'their_best_rank': their['best_rank'],
+                'our_best_rank': our_best if our_best < 999 else None,
+                'rank_delta': (our_best - their['best_rank'])
+                if our_best < 999 else None,
+                'providers': their['providers'],
+            })
+
+        # Citation gaps for this keyword that name this competitor.
+        try:
+            gap_payload = _gap_helper()(keyword, config)
+        except Exception as exc:
+            logger.warning(f'gap helper failed for {keyword}: {exc}')
+            gap_payload = {}
+
+        for gap in gap_payload.get('gaps', []) or []:
+            named = [b.lower() for b in gap.get('competitor_brands', []) or []]
+            if competitor_lc not in named:
+                continue
+            citation_count = int(gap.get('citation_count', 0) or 0)
+            provider_count = int(gap.get('provider_count', 0) or 0)
+            exclusive_sources.append({
+                'keyword': keyword,
+                'url': gap.get('url'),
+                'domain': gap.get('domain'),
+                'priority': gap.get('priority', 'low'),
+                'citation_count': citation_count,
+                'provider_count': provider_count,
+                'providers': gap.get('providers', []),
+                'lift_score': _outreach_lift(citation_count, provider_count),
+            })
+
+    # Order outranked keywords by the size of the gap to us — biggest
+    # delta first. Order outreach by lift (descending), then priority.
+    outranked.sort(
+        key=lambda r: (r['rank_delta'] if r['rank_delta'] is not None else -1),
+        reverse=True,
+    )
+    priority_order = {'high': 0, 'medium': 1, 'low': 2}
+    exclusive_sources.sort(
+        key=lambda s: (-s['lift_score'], priority_order.get(s['priority'], 2)),
+    )
+
+    return {
+        'competitor': competitor,
+        'outranked_keywords': outranked,
+        'exclusive_sources': exclusive_sources,
+        'outreach_targets': exclusive_sources[:10],
+    }
+
+
+def build_competitor_rollups(
+    config: Dict[str, Any],
+    competitor: Optional[str],
+    keyword_limit: int,
+) -> Dict[str, Any]:
+    """
+    Top-level composer. When `competitor` is provided, returns a single
+    rollup (and includes that competitor in the `competitors` list so
+    the response shape stays uniform). Otherwise iterates every
+    configured competitor.
+    """
+    tracked_brands = config.get('tracked_brands', {})
+    configured = [str(b) for b in tracked_brands.get('competitors', []) or []]
+
+    keywords = _list_tracked_keywords(keyword_limit)
+
+    if competitor:
+        # Validate that the competitor is configured. Returning a 404 on
+        # an unconfigured name is more helpful than silently returning
+        # an empty rollup which the UI would then misinterpret.
+        if competitor.lower() not in {c.lower() for c in configured}:
+            return {
+                'error': f'Unknown competitor: {competitor!r}',
+                'configured_competitors': configured,
+            }
+        return {
+            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'keywords_analyzed': len(keywords),
+            'competitor': competitor,
+            'rollup': _build_competitor_rollup(competitor, keywords, config),
+        }
+
+    rollups = [
+        _build_competitor_rollup(c, keywords, config) for c in configured
+    ]
+    return {
+        'generated_at': datetime.utcnow().isoformat() + 'Z',
+        'keywords_analyzed': len(keywords),
+        'competitors': configured,
+        'rollups': rollups,
+    }
+
+
+# ----------------------------------------------------------------------
+# Lambda entry point
+# ----------------------------------------------------------------------
+
+@api_handler
+@validate({
+    'competitor': {'type': str, 'max_length': 200},
+    'keyword_limit': {'type': int, 'min': 1, 'max': 100, 'default': 50},
+})
+def handler(
+    event: Dict[str, Any],
+    context: Any,
+    competitor: Optional[str] = None,
+    keyword_limit: int = 50,
+) -> Dict[str, Any]:
+    """API handler for GET /api/reports/competitor."""
+    config = get_brand_config()
+    payload = build_competitor_rollups(
+        config, competitor=competitor, keyword_limit=keyword_limit,
+    )
+    if 'error' in payload:
+        return validation_error(payload['error'], event, 'competitor')
+    return success_response(payload, event)

--- a/lambda/api/stats-insights.py
+++ b/lambda/api/stats-insights.py
@@ -35,6 +35,7 @@ ROUTE_MAP = {
     '/api/recommendations': 'get-recommendations.py',
     '/api/trends': 'get-historical-trends.py',
     '/api/reports/overview': 'get-reports-overview.py',
+    '/api/reports/competitor': 'get-reports-competitor.py',
 }
 
 _handlers = HandlerLoader(__file__)

--- a/lambda/api/test_get_reports_competitor.py
+++ b/lambda/api/test_get_reports_competitor.py
@@ -1,0 +1,673 @@
+"""
+Tests for get-reports-competitor.py — the /reports/competitor rollup.
+
+Strategy mirrors test_get_reports_overview.py: load the module after
+mounting the shared layer / lambda source tree, then prime the lazy
+sibling cache and the per-keyword rank lookup with stubs so we never
+touch DynamoDB.
+"""
+
+import importlib
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mount shared layer / fall back to lambda/ source.
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+_LAYER_PY = os.path.join(_REPO, 'lambda', 'layer', 'python')
+_LAMBDA_DIR = os.path.join(_REPO, 'lambda')
+if os.path.isdir(_LAYER_PY) and _LAYER_PY not in sys.path:
+    sys.path.insert(0, _LAYER_PY)
+elif _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+
+_layer_api_response = importlib.import_module('shared.api_response')
+sys.modules['shared.api_response'] = _layer_api_response
+
+_API_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+# ----------------------------------------------------------------------
+# Fakes
+# ----------------------------------------------------------------------
+
+DEFAULT_RANKS = {
+    'best running shoes': {
+        'nike': {'best_rank': 2, 'providers': ['openai'], 'classification': 'first_party'},
+        'adidas': {'best_rank': 1, 'providers': ['openai', 'perplexity'], 'classification': 'competitor'},
+        'asics': {'best_rank': 5, 'providers': ['gemini'], 'classification': 'competitor'},
+    },
+    'best hiking boots': {
+        'nike': {'best_rank': 6, 'providers': ['openai'], 'classification': 'first_party'},
+        'adidas': {'best_rank': 8, 'providers': ['openai'], 'classification': 'competitor'},
+        'merrell': {'best_rank': 1, 'providers': ['claude'], 'classification': 'competitor'},
+    },
+    'untouched': {},
+}
+
+DEFAULT_GAPS = {
+    'best running shoes': {
+        'gaps': [
+            {
+                'url': 'https://example.com/shoes-review',
+                'domain': 'example.com',
+                'priority': 'high',
+                'citation_count': 9,
+                'provider_count': 3,
+                'providers': ['openai', 'perplexity', 'gemini'],
+                'competitor_brands': ['Adidas'],
+            },
+            {
+                'url': 'https://other.com/asics',
+                'domain': 'other.com',
+                'priority': 'medium',
+                'citation_count': 4,
+                'provider_count': 2,
+                'providers': ['gemini', 'claude'],
+                'competitor_brands': ['Asics'],
+            },
+        ],
+    },
+    'best hiking boots': {
+        'gaps': [
+            {
+                'url': 'https://outside.com/merrell',
+                'domain': 'outside.com',
+                'priority': 'high',
+                'citation_count': 12,
+                'provider_count': 4,
+                'providers': ['openai', 'perplexity', 'gemini', 'claude'],
+                'competitor_brands': ['Merrell'],
+            },
+        ],
+    },
+}
+
+
+def _load_module():
+    """Load get-reports-competitor.py with stubs primed in caches."""
+    spec = importlib.util.spec_from_file_location(
+        'get_reports_competitor_under_test',
+        os.path.join(_API_DIR, 'get-reports-competitor.py'),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['get_reports_competitor_under_test'] = mod
+    spec.loader.exec_module(mod)
+
+    mod._sibling_cache['gap'] = lambda keyword, config: DEFAULT_GAPS.get(keyword, {})
+    mod._latest_brand_ranks = lambda keyword: DEFAULT_RANKS.get(keyword, {})
+    mod._list_tracked_keywords = lambda limit: list(DEFAULT_RANKS.keys())[:limit]
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def _load_module_without_stubs():
+    """Load module without priming the helper stubs — for testing the
+    real DynamoDB-backed _list_tracked_keywords / _latest_brand_ranks."""
+    spec = importlib.util.spec_from_file_location(
+        'get_reports_competitor_unstubbed',
+        os.path.join(_API_DIR, 'get-reports-competitor.py'),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['get_reports_competitor_unstubbed'] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def raw_mod():
+    return _load_module_without_stubs()
+
+
+CONFIG = {
+    'tracked_brands': {
+        'first_party': ['Nike'],
+        'competitors': ['Adidas', 'Asics', 'Merrell', 'Brooks'],
+    },
+}
+
+
+def _event(competitor=None, keyword_limit=None):
+    qs = {}
+    if competitor is not None:
+        qs['competitor'] = competitor
+    if keyword_limit is not None:
+        qs['keyword_limit'] = str(keyword_limit)
+    return {
+        'resource': '/api/reports/competitor',
+        'path': '/api/reports/competitor',
+        'httpMethod': 'GET',
+        'headers': {'origin': 'http://localhost:3000'},
+        'queryStringParameters': qs or None,
+    }
+
+
+# --- _outreach_lift -------------------------------------------------------
+
+
+def test_outreach_lift_grows_with_provider_count(mod):
+    a = mod._outreach_lift(citation_count=5, provider_count=1)
+    b = mod._outreach_lift(citation_count=5, provider_count=4)
+    assert b > a
+
+
+def test_outreach_lift_grows_with_citation_count(mod):
+    a = mod._outreach_lift(citation_count=2, provider_count=2)
+    b = mod._outreach_lift(citation_count=20, provider_count=2)
+    assert b > a
+
+
+def test_outreach_lift_handles_zero_citations_without_blowing_up(mod):
+    out = mod._outreach_lift(citation_count=0, provider_count=1)
+    assert out >= 0
+
+
+# --- _build_competitor_rollup --------------------------------------------
+
+
+def test_rollup_picks_keywords_where_competitor_outranks_first_party(mod):
+    keywords = ['best running shoes', 'best hiking boots']
+    rollup = mod._build_competitor_rollup('Adidas', keywords, CONFIG)
+    keywords_outranked = [r['keyword'] for r in rollup['outranked_keywords']]
+    assert 'best running shoes' in keywords_outranked
+
+
+def test_rollup_excludes_keywords_where_first_party_already_wins(mod):
+    keywords = ['best running shoes', 'best hiking boots']
+    rollup = mod._build_competitor_rollup('Adidas', keywords, CONFIG)
+    keywords_outranked = [r['keyword'] for r in rollup['outranked_keywords']]
+    # Adidas is rank 8 on hiking boots, Nike is rank 6 — Adidas does NOT outrank
+    assert 'best hiking boots' not in keywords_outranked
+
+
+def test_rollup_records_their_best_rank_and_our_best_rank(mod):
+    rollup = mod._build_competitor_rollup(
+        'Adidas', ['best running shoes'], CONFIG,
+    )
+    row = rollup['outranked_keywords'][0]
+    # Fixture: Adidas best=1, Nike best=2.
+    assert row['their_best_rank'] == 1
+    assert row['our_best_rank'] == 2
+
+
+def test_rollup_records_rank_delta_as_their_minus_our(mod):
+    rollup = mod._build_competitor_rollup(
+        'Adidas', ['best running shoes'], CONFIG,
+    )
+    row = rollup['outranked_keywords'][0]
+    # delta = our(2) - their(1) = 1
+    assert row['rank_delta'] == 1
+
+
+def test_rollup_records_providers_for_outranked_row(mod):
+    rollup = mod._build_competitor_rollup(
+        'Adidas', ['best running shoes'], CONFIG,
+    )
+    row = rollup['outranked_keywords'][0]
+    assert row['providers'] == ['openai', 'perplexity']
+
+
+def test_rollup_finds_exclusive_sources_for_named_competitor(mod):
+    rollup = mod._build_competitor_rollup(
+        'Adidas',
+        ['best running shoes', 'best hiking boots'],
+        CONFIG,
+    )
+    urls = [s['url'] for s in rollup['exclusive_sources']]
+    assert 'https://example.com/shoes-review' in urls
+
+
+def test_rollup_propagates_priority_and_lift_for_exclusive_source(mod):
+    rollup = mod._build_competitor_rollup(
+        'Adidas', ['best running shoes'], CONFIG,
+    )
+    source = rollup['exclusive_sources'][0]
+    assert source['priority'] == 'high'
+    # provider_count=3, citation_count=9, lift = 3 * log(10) ~= 6.91
+    assert source['lift_score'] > 0
+
+
+def test_rollup_skips_sources_naming_other_competitors(mod):
+    rollup = mod._build_competitor_rollup(
+        'Adidas',
+        ['best running shoes', 'best hiking boots'],
+        CONFIG,
+    )
+    urls = [s['url'] for s in rollup['exclusive_sources']]
+    # Asics-only and Merrell-only sources should not be in Adidas's rollup
+    assert 'https://other.com/asics' not in urls
+    assert 'https://outside.com/merrell' not in urls
+
+
+def test_rollup_orders_outreach_targets_by_lift_score_descending(mod):
+    # Build a fixture with 3 sources of different lift scores so ordering
+    # is meaningfully tested (the default fixture only has 1 per keyword).
+    mod._sibling_cache['gap'] = lambda keyword, config: {
+        'gaps': [
+            {
+                'url': 'https://low.com', 'domain': 'low.com',
+                'priority': 'low', 'citation_count': 1, 'provider_count': 1,
+                'providers': ['openai'], 'competitor_brands': ['Adidas'],
+            },
+            {
+                'url': 'https://high.com', 'domain': 'high.com',
+                'priority': 'high', 'citation_count': 20, 'provider_count': 4,
+                'providers': ['openai', 'p', 'g', 'c'], 'competitor_brands': ['Adidas'],
+            },
+            {
+                'url': 'https://mid.com', 'domain': 'mid.com',
+                'priority': 'medium', 'citation_count': 5, 'provider_count': 2,
+                'providers': ['openai', 'g'], 'competitor_brands': ['Adidas'],
+            },
+        ],
+    } if keyword == 'kw' else {'gaps': []}
+    mod._latest_brand_ranks = lambda keyword: {
+        'adidas': {
+            'best_rank': 1, 'providers': ['openai'],
+            'classification': 'competitor',
+        },
+        'nike': {
+            'best_rank': 5, 'providers': ['openai'],
+            'classification': 'first_party',
+        },
+    }
+    rollup = mod._build_competitor_rollup('Adidas', ['kw'], CONFIG)
+    targets = rollup['outreach_targets']
+    assert targets[0]['url'] == 'https://high.com'
+    assert targets[-1]['url'] == 'https://low.com'
+
+
+def test_rollup_caps_outreach_targets_at_ten_when_more_exist(mod):
+    # Generate 15 distinct sources for one keyword so the cap kicks in.
+    sources = [
+        {
+            'url': f'https://s{i}.com', 'domain': f's{i}.com',
+            'priority': 'high', 'citation_count': i + 1, 'provider_count': 2,
+            'providers': ['openai', 'g'], 'competitor_brands': ['Adidas'],
+        }
+        for i in range(15)
+    ]
+    mod._sibling_cache['gap'] = lambda keyword, config: {'gaps': sources}
+    mod._latest_brand_ranks = lambda keyword: {
+        'adidas': {
+            'best_rank': 1, 'providers': ['openai'],
+            'classification': 'competitor',
+        },
+        'nike': {
+            'best_rank': 5, 'providers': ['openai'],
+            'classification': 'first_party',
+        },
+    }
+    rollup = mod._build_competitor_rollup('Adidas', ['kw'], CONFIG)
+    assert len(rollup['outreach_targets']) == 10
+
+
+# --- build_competitor_rollups (top level) --------------------------------
+
+
+def test_build_returns_404_payload_for_unknown_competitor(mod):
+    payload = mod.build_competitor_rollups(
+        CONFIG, competitor='Unknown', keyword_limit=10,
+    )
+    assert 'error' in payload
+
+
+def test_build_returns_single_rollup_for_known_competitor(mod):
+    payload = mod.build_competitor_rollups(
+        CONFIG, competitor='Adidas', keyword_limit=10,
+    )
+    assert payload['competitor'] == 'Adidas'
+    assert 'rollup' in payload
+
+
+def test_build_returns_all_rollups_when_competitor_omitted(mod):
+    payload = mod.build_competitor_rollups(
+        CONFIG, competitor=None, keyword_limit=10,
+    )
+    competitors_in_payload = [r['competitor'] for r in payload['rollups']]
+    assert competitors_in_payload == ['Adidas', 'Asics', 'Merrell', 'Brooks']
+
+
+def test_build_propagates_configured_competitors_in_top_level_list(mod):
+    payload = mod.build_competitor_rollups(
+        CONFIG, competitor=None, keyword_limit=10,
+    )
+    assert payload['competitors'] == ['Adidas', 'Asics', 'Merrell', 'Brooks']
+
+
+def test_build_records_keywords_analyzed_count(mod):
+    payload = mod.build_competitor_rollups(
+        CONFIG, competitor='Adidas', keyword_limit=2,
+    )
+    assert payload['keywords_analyzed'] == 2
+
+
+# --- handler -------------------------------------------------------------
+
+
+def test_handler_returns_200_for_valid_competitor(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(competitor='Adidas'), None)
+    assert result['statusCode'] == 200
+
+
+def test_handler_returns_single_rollup_payload_for_named_competitor(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(competitor='Adidas'), None)
+    body = json.loads(result['body'])
+    assert body['competitor'] == 'Adidas'
+    assert body['rollup']['competitor'] == 'Adidas'
+
+
+def test_handler_includes_outranked_keywords_in_payload(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(competitor='Adidas'), None)
+    body = json.loads(result['body'])
+    keywords_outranked = [
+        r['keyword'] for r in body['rollup']['outranked_keywords']
+    ]
+    assert 'best running shoes' in keywords_outranked
+
+
+def test_handler_returns_400_for_unconfigured_competitor(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(competitor='Unknown'), None)
+    assert result['statusCode'] == 400
+
+
+def test_handler_rejects_keyword_limit_above_max(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(keyword_limit=999), None)
+    assert result['statusCode'] == 400
+
+
+def test_handler_rejects_keyword_limit_below_min(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(keyword_limit=0), None)
+    assert result['statusCode'] == 400
+
+
+def test_handler_returns_all_rollups_payload_when_competitor_omitted(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(), None)
+    body = json.loads(result['body'])
+    assert 'rollups' in body
+    assert len(body['rollups']) == 4
+
+
+def test_handler_returns_iso_generated_at_with_zulu(mod):
+    with patch.object(mod, 'get_brand_config', return_value=CONFIG):
+        result = mod.handler(_event(competitor='Adidas'), None)
+    body = json.loads(result['body'])
+    assert body['generated_at'].endswith('Z')
+
+
+# --- _load_sibling + cache helpers ----------------------------------------
+
+
+def test_load_sibling_raises_import_error_when_spec_resolution_fails(mod):
+    with patch('importlib.util.spec_from_file_location', return_value=None):
+        with pytest.raises(ImportError):
+            mod._load_sibling('health.py', 'handler')
+
+
+def test_load_sibling_raises_attribute_error_for_missing_attr(mod):
+    with pytest.raises(AttributeError):
+        mod._load_sibling('health.py', 'nonexistent_function')
+
+
+def test_load_sibling_returns_callable_for_valid_attribute(mod):
+    fn = mod._load_sibling('health.py', 'handler')
+    assert callable(fn)
+
+
+def test_gap_helper_populates_cache_on_first_call(mod):
+    mod._sibling_cache.clear()
+    sentinel = object()
+    mod._load_sibling = lambda filename, attr: (
+        (lambda *_a, **_k: sentinel) if attr == 'analyze_citation_gaps'
+        else (_ for _ in ()).throw(AssertionError(f'unexpected {attr!r}'))
+    )
+    assert mod._gap_helper()() is sentinel
+
+
+def test_gap_helper_returns_cached_value_on_subsequent_call(mod):
+    mod._sibling_cache.clear()
+    sentinel = object()
+    mod._load_sibling = lambda *_a, **_k: lambda *_args, **_kwargs: sentinel
+    mod._gap_helper()  # populate cache
+
+    def _explode(*_a, **_k):
+        raise AssertionError('cache miss on second call')
+    mod._load_sibling = _explode
+    assert mod._gap_helper()() is sentinel
+
+
+# --- gap helper exception fallback inside rollup --------------------------
+
+
+class GapHelperError(Exception):
+    """Raised by tests to exercise the rollup's gap-failure fallback."""
+
+
+def test_rollup_continues_when_gap_helper_raises(mod):
+    # When the citation-gap call fails for a keyword, the rollup should
+    # still surface the outranked-keyword data without exclusive sources.
+    def boom(*_a, **_k):
+        raise GapHelperError('gap helper exploded')
+    mod._sibling_cache['gap'] = boom
+    rollup = mod._build_competitor_rollup(
+        'Adidas', ['best running shoes'], CONFIG,
+    )
+    # Outranked is still computed from the rank fixture.
+    assert rollup['outranked_keywords'][0]['keyword'] == 'best running shoes'
+    # Exclusive sources is empty since the gap call failed.
+    assert rollup['exclusive_sources'] == []
+
+
+# --- _list_tracked_keywords -----------------------------------------------
+
+
+def test_list_tracked_keywords_reads_from_keywords_table_when_configured(raw_mod):
+    fake_table = MagicMock()
+    fake_table.scan.return_value = {
+        'Items': [
+            {'keyword': 'shoes'},
+            {'keyword': 'boots'},
+            {'keyword': 'shoes'},  # duplicate to verify de-dup
+        ],
+    }
+    fake_dynamodb = MagicMock()
+    fake_dynamodb.Table.return_value = fake_table
+
+    with patch.object(raw_mod, 'KEYWORDS_TABLE', 'test-keywords'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._list_tracked_keywords(50)
+
+    assert result == ['shoes', 'boots']
+
+
+def test_list_tracked_keywords_falls_back_to_search_results_when_no_keywords_table(raw_mod):
+    fake_table = MagicMock()
+    fake_table.scan.return_value = {
+        'Items': [{'keyword': 'fallback-kw'}],
+    }
+    fake_dynamodb = MagicMock()
+    fake_dynamodb.Table.return_value = fake_table
+
+    with patch.object(raw_mod, 'KEYWORDS_TABLE', None):
+        with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test-search'):
+            with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+                result = raw_mod._list_tracked_keywords(50)
+
+    assert result == ['fallback-kw']
+
+
+def test_list_tracked_keywords_returns_empty_when_no_tables_configured(raw_mod):
+    with patch.object(raw_mod, 'KEYWORDS_TABLE', None):
+        with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', None):
+            result = raw_mod._list_tracked_keywords(50)
+    assert result == []
+
+
+def test_list_tracked_keywords_caps_result_at_limit(raw_mod):
+    fake_table = MagicMock()
+    fake_table.scan.return_value = {
+        'Items': [{'keyword': f'kw-{i}'} for i in range(20)],
+    }
+    fake_dynamodb = MagicMock()
+    fake_dynamodb.Table.return_value = fake_table
+
+    with patch.object(raw_mod, 'KEYWORDS_TABLE', 'test-keywords'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._list_tracked_keywords(5)
+
+    assert len(result) == 5
+
+
+# --- _latest_brand_ranks --------------------------------------------------
+
+
+def _ranks_event(items):
+    """Build a fake DynamoDB query response containing search-result items."""
+    fake_table = MagicMock()
+    fake_table.query.return_value = {'Items': items}
+    fake_dynamodb = MagicMock()
+    fake_dynamodb.Table.return_value = fake_table
+    return fake_dynamodb
+
+
+def test_latest_brand_ranks_returns_empty_when_search_table_unset(raw_mod):
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', None):
+        result = raw_mod._latest_brand_ranks('shoes')
+    assert result == {}
+
+
+def test_latest_brand_ranks_returns_empty_when_query_returns_no_items(raw_mod):
+    fake_dynamodb = _ranks_event([])
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._latest_brand_ranks('shoes')
+    assert result == {}
+
+
+def test_latest_brand_ranks_aggregates_across_providers(raw_mod):
+    items = [
+        {
+            'timestamp': '2026-05-15T00:00:00Z',
+            'provider': 'openai',
+            'brands': [
+                {
+                    'name': 'Nike', 'rank': 2,
+                    'classification': 'first_party',
+                },
+            ],
+        },
+        {
+            'timestamp': '2026-05-15T00:00:00Z',
+            'provider': 'perplexity',
+            'brands': [
+                {
+                    'name': 'Nike', 'rank': 5,
+                    'classification': 'first_party',
+                },
+            ],
+        },
+    ]
+    fake_dynamodb = _ranks_event(items)
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._latest_brand_ranks('shoes')
+
+    nike = result['nike']
+    # Best rank (smallest) across providers wins.
+    assert nike['best_rank'] == 2
+    assert sorted(nike['providers']) == ['openai', 'perplexity']
+
+
+def test_latest_brand_ranks_filters_to_latest_timestamp_only(raw_mod):
+    items = [
+        {
+            'timestamp': '2026-05-14T00:00:00Z',  # older
+            'provider': 'openai',
+            'brands': [
+                {'name': 'Nike', 'rank': 1, 'classification': 'first_party'},
+            ],
+        },
+        {
+            'timestamp': '2026-05-15T00:00:00Z',  # newest — only this counts
+            'provider': 'openai',
+            'brands': [
+                {'name': 'Nike', 'rank': 7, 'classification': 'first_party'},
+            ],
+        },
+    ]
+    fake_dynamodb = _ranks_event(items)
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._latest_brand_ranks('shoes')
+    # Should reflect rank=7 from the newest timestamp, not rank=1 from older.
+    assert result['nike']['best_rank'] == 7
+
+
+def test_latest_brand_ranks_handles_invalid_rank_values_as_999(raw_mod):
+    items = [
+        {
+            'timestamp': '2026-05-15T00:00:00Z',
+            'provider': 'openai',
+            'brands': [
+                {'name': 'Nike', 'rank': 'not-a-number',
+                 'classification': 'first_party'},
+            ],
+        },
+    ]
+    fake_dynamodb = _ranks_event(items)
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._latest_brand_ranks('shoes')
+    assert result['nike']['best_rank'] == 999
+
+
+def test_latest_brand_ranks_skips_brands_with_empty_name(raw_mod):
+    items = [
+        {
+            'timestamp': '2026-05-15T00:00:00Z',
+            'provider': 'openai',
+            'brands': [
+                {'name': '', 'rank': 1},
+                {'name': 'Nike', 'rank': 3, 'classification': 'first_party'},
+            ],
+        },
+    ]
+    fake_dynamodb = _ranks_event(items)
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._latest_brand_ranks('shoes')
+    assert list(result.keys()) == ['nike']
+
+
+def test_latest_brand_ranks_keeps_default_classification_when_missing(raw_mod):
+    # Brands without an explicit `classification` field should keep the
+    # default ('other') rather than overwrite it with a falsy value.
+    items = [
+        {
+            'timestamp': '2026-05-15T00:00:00Z',
+            'provider': 'openai',
+            'brands': [
+                {'name': 'Mystery', 'rank': 1},  # no classification
+            ],
+        },
+    ]
+    fake_dynamodb = _ranks_event(items)
+    with patch.object(raw_mod, 'SEARCH_RESULTS_TABLE', 'test'):
+        with patch.object(raw_mod, 'dynamodb', fake_dynamodb):
+            result = raw_mod._latest_brand_ranks('shoes')
+    assert result['mystery']['classification'] == 'other'

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -1220,6 +1220,7 @@ export class CitationAnalysisStack extends cdk.Stack {
         'get-historical-trends.py',
         'get-reports-overview.py',
         'recommendation-status.py',
+        'get-reports-competitor.py',
       ]),
       layers: [sharedLayer],
       timeout: cdk.Duration.seconds(60),
@@ -1854,16 +1855,18 @@ export class CitationAnalysisStack extends cdk.Stack {
     const trendsResource = apiResource.addResource('trends');
     trendsResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
 
-    // Reports aggregator endpoints
-    // /reports/overview returns the cross-keyword executive-summary rollup
-    // (top movers, improving/declining counts, top recommendations) used
-    // by the Executive Summary print report and the Brand Visibility
-    // all-keywords variant. Routed to the consolidated stats-insights
-    // Lambda so it shares the same hot container as /trends and
-    // /recommendations (which it composes).
+    // Reports aggregator endpoints. /reports/overview returns the
+    // cross-keyword executive-summary rollup; /reports/competitor
+    // returns the per-competitor rollup (outranked keywords,
+    // exclusive citation sources, prioritised outreach list).
+    // Both are routed to the consolidated stats-insights Lambda so
+    // they share the warm container with /trends, /recommendations,
+    // /visibility, and /citation-gaps which they compose.
     const reportsResource = apiResource.addResource('reports');
     const reportsOverviewResource = reportsResource.addResource('overview');
     reportsOverviewResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
+    const reportsCompetitorResource = reportsResource.addResource('competitor');
+    reportsCompetitorResource.addMethod('GET', new apigateway.LambdaIntegration(statsInsightsFunction, integrationOptions), methodOptions);
 
     // Persona Rankings API Route
     const personaRankingsResource = apiResource.addResource('persona-rankings');

--- a/web/src/api/reports.ts
+++ b/web/src/api/reports.ts
@@ -5,6 +5,9 @@
  * return pre-aggregated payloads tailored for the print reports —
  * /reports/overview composes data that would otherwise require multiple
  * round-trips (trends + recommendations) to assemble client-side.
+ * /reports/competitor returns the per-competitor rollup (outranked
+ * keywords, exclusive citation sources, prioritised outreach targets)
+ * consumed by the Competitor Gap print report.
  */
 import { apiGet } from './client';
 import type {
@@ -61,4 +64,79 @@ export function fetchReportsOverview(
   if (params.top !== undefined) query.push(`top=${params.top}`);
   const qs = query.length > 0 ? `?${query.join('&')}` : '';
   return apiGet<ReportsOverviewResponse>(`/reports/overview${qs}`, { signal });
+}
+
+export interface CompetitorOutrankedKeyword {
+  keyword: string;
+  their_best_rank: number;
+  our_best_rank: number | null;
+  rank_delta: number | null;
+  providers: string[];
+}
+
+export interface CompetitorExclusiveSource {
+  keyword: string;
+  url: string;
+  domain: string;
+  priority: 'high' | 'medium' | 'low';
+  citation_count: number;
+  provider_count: number;
+  providers: string[];
+  lift_score: number;
+}
+
+export interface CompetitorRollup {
+  competitor: string;
+  outranked_keywords: CompetitorOutrankedKeyword[];
+  exclusive_sources: CompetitorExclusiveSource[];
+  outreach_targets: CompetitorExclusiveSource[];
+}
+
+export interface CompetitorReportSingleResponse {
+  generated_at: string;
+  keywords_analyzed: number;
+  competitor: string;
+  rollup: CompetitorRollup;
+}
+
+export interface CompetitorReportAllResponse {
+  generated_at: string;
+  keywords_analyzed: number;
+  competitors: string[];
+  rollups: CompetitorRollup[];
+}
+
+export type CompetitorReportResponse =
+  | CompetitorReportSingleResponse
+  | CompetitorReportAllResponse;
+
+export interface CompetitorReportParams {
+  readonly competitor?: string;
+  readonly keywordLimit?: number;
+}
+
+/**
+ * Fetch the competitor rollup. When `competitor` is omitted the server
+ * returns a `rollups[]` payload containing every configured competitor;
+ * when provided, it returns a single `rollup` for that competitor.
+ */
+export function fetchCompetitorRollup(
+  params: CompetitorReportParams = {},
+  signal?: AbortSignal,
+): Promise<CompetitorReportResponse> {
+  const query: string[] = [];
+  if (params.competitor) {
+    query.push(`competitor=${encodeURIComponent(params.competitor)}`);
+  }
+  if (params.keywordLimit !== undefined) {
+    query.push(`keyword_limit=${params.keywordLimit}`);
+  }
+  const qs = query.length > 0 ? `?${query.join('&')}` : '';
+  return apiGet<CompetitorReportResponse>(`/reports/competitor${qs}`, { signal });
+}
+
+export function isSingleCompetitorResponse(
+  response: CompetitorReportResponse,
+): response is CompetitorReportSingleResponse {
+  return 'rollup' in response;
 }

--- a/web/src/hooks/useCompetitorRollup.spec.ts
+++ b/web/src/hooks/useCompetitorRollup.spec.ts
@@ -1,0 +1,190 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import {
+  renderHook, act 
+} from '@testing-library/react';
+import { useCompetitorRollup } from './useCompetitorRollup';
+
+vi.mock('../infrastructure', async () => {
+  const actual = await vi.importActual('../infrastructure');
+  return {
+    ...actual,
+    API_BASE_URL: 'https://api.test.com',
+    authenticatedFetch: vi.fn(),
+  };
+});
+
+import { authenticatedFetch } from '../infrastructure';
+
+const mockFetch = authenticatedFetch as ReturnType<typeof vi.fn>;
+
+const SINGLE_RESPONSE = {
+  generated_at: '2026-05-15T07:00:00Z',
+  keywords_analyzed: 4,
+  competitor: 'Adidas',
+  rollup: {
+    competitor: 'Adidas',
+    outranked_keywords: [],
+    exclusive_sources: [],
+    outreach_targets: [],
+  },
+};
+
+const ALL_RESPONSE = {
+  generated_at: '2026-05-15T07:00:00Z',
+  keywords_analyzed: 4,
+  competitors: ['Adidas', 'Asics'],
+  rollups: [
+    {
+      competitor: 'Adidas',
+      outranked_keywords: [],
+      exclusive_sources: [],
+      outreach_targets: [],
+    },
+  ],
+};
+
+function mockOk(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+describe('useCompetitorRollup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null data before fetch', () => {
+    const { result } = renderHook(() => useCompetitorRollup());
+    expect(result.current.data).toBeNull();
+  });
+
+  it('passes the competitor name in the URL when provided', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Adidas');
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('competitor=Adidas');
+  });
+
+  it('URL-encodes competitor names with special characters', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Brand & Co');
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    // URLSearchParams encodes "Brand & Co" as "Brand+%26+Co" or "Brand+%26+Co"
+    expect(url).toMatch(/competitor=Brand(\+|%20)%26(\+|%20)Co/);
+  });
+
+  it('honors a custom keyword_limit value in the request URL', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Adidas', 75);
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('keyword_limit=75');
+  });
+
+  it('uses default keyword_limit=50 when not specified', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain('keyword_limit=50');
+  });
+
+  it('omits competitor param when not provided', async () => {
+    mockFetch.mockResolvedValue(mockOk(ALL_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).not.toContain('competitor=');
+  });
+
+  it('stores the parsed single-competitor response', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Adidas');
+    });
+    expect(result.current.data).toStrictEqual(SINGLE_RESPONSE);
+  });
+
+  it('returns the parsed payload from the fetch promise', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    const holder: { value: unknown } = { value: null };
+    await act(async () => {
+      holder.value = await result.current.fetchCompetitorRollup('Adidas');
+    });
+    expect(holder.value).toStrictEqual(SINGLE_RESPONSE);
+  });
+
+  it('stores the parsed all-competitors response', async () => {
+    mockFetch.mockResolvedValue(mockOk(ALL_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    expect(result.current.data).toStrictEqual(ALL_RESPONSE);
+  });
+
+  it('records the error message when the response is not OK', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({}),
+    } as unknown as Response);
+    const { result } = renderHook(() => useCompetitorRollup());
+    const holder: { value: unknown } = { value: 'unset' };
+    await act(async () => {
+      holder.value = await result.current.fetchCompetitorRollup('Unknown');
+    });
+    expect(holder.value).toBeNull();
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('rejects responses missing both rollup and rollups fields', async () => {
+    mockFetch.mockResolvedValue(mockOk({ unrelated: 'shape' }));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup();
+    });
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('rejects {error} backend responses with a meaningful error message', async () => {
+    mockFetch.mockResolvedValue(mockOk({ error: 'Unknown competitor' }));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Unknown');
+    });
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.data).toBeNull();
+  });
+
+  it('clears the loading flag once the fetch settles', async () => {
+    mockFetch.mockResolvedValue(mockOk(SINGLE_RESPONSE));
+    const { result } = renderHook(() => useCompetitorRollup());
+    await act(async () => {
+      await result.current.fetchCompetitorRollup('Adidas');
+    });
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/web/src/hooks/useCompetitorRollup.ts
+++ b/web/src/hooks/useCompetitorRollup.ts
@@ -1,0 +1,87 @@
+import {
+  useState, useCallback,
+} from 'react';
+import {
+  API_BASE_URL,
+  authenticatedFetch,
+  getErrorMessage,
+  ApiRequestError,
+} from '../infrastructure';
+import type { CompetitorReportResponse } from '../api/reports';
+
+interface BackendErrorResponse {error: string;}
+
+function isBackendErrorResponse(data: unknown): data is BackendErrorResponse {
+  return typeof data === 'object'
+    && data !== null
+    && 'error' in data
+    && typeof (data as BackendErrorResponse).error === 'string';
+}
+
+function isCompetitorReportResponse(
+  data: unknown,
+): data is CompetitorReportResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  if ('error' in data) return false;
+  // Single-competitor variant has `rollup`; all-competitors has `rollups`.
+  return 'rollup' in data || 'rollups' in data;
+}
+
+/**
+ * Imperative hook for the competitor rollup endpoint. Pairs with the
+ * Competitor Gap report (a follow-up PR) and any ad-hoc lookups in
+ * the dashboard.
+ *
+ * Imperative rather than auto-fetching so the caller (the report
+ * component) can trigger a fresh load when the selected competitor
+ * changes without re-mounting.
+ */
+export function useCompetitorRollup() {
+  const [data, setData] = useState<CompetitorReportResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCompetitorRollup = useCallback(async (
+    competitor?: string,
+    keywordLimit = 50,
+  ): Promise<CompetitorReportResponse | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ keyword_limit: keywordLimit.toString() });
+      if (competitor) params.append('competitor', competitor);
+      const response = await authenticatedFetch(
+        `${API_BASE_URL}/reports/competitor?${params}`,
+      );
+      if (!response.ok) {
+        throw new ApiRequestError(
+          'Failed to fetch competitor rollup',
+          response.status,
+        );
+      }
+      const json: unknown = await response.json();
+      if (isBackendErrorResponse(json)) {
+        throw new ApiRequestError(json.error);
+      }
+      if (!isCompetitorReportResponse(json)) {
+        throw new ApiRequestError('Invalid response format');
+      }
+      setData(json);
+      return json;
+    } catch (err) {
+      const message = getErrorMessage(err, 'visibility');
+      setError(message);
+      console.error('[competitorRollup] Error:', err);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    data,
+    loading,
+    error,
+    fetchCompetitorRollup,
+  };
+}


### PR DESCRIPTION
Re-merge of PR #46 with conflict resolution against current main.

The branch was rooted on main from before the lambda audit chain
(#31-#35). Carries Matias's intent forward:

- New /reports/competitor endpoint
- get-reports-competitor.py handler (per-competitor rollup)
- Frontend useCompetitorRollup hook + types
- 43 unit tests

Conflict resolution and fixes:
- lib/citation-analysis-stack.ts: combined file lists for the
  stats-insights handler (#43 overview + this PR's competitor) and
  unified the apiResource.addResource('reports') registration.
- lambda/api/stats-insights.py: combined route table.
- web/src/api/reports.ts: kept main's overview types, appended
  competitor types and fetcher.
- get-reports-competitor.py: replaced removed @require_config with
  inline get_brand_config() (matching #43's recovery pattern).
- test_get_reports_competitor.py: switched from
  patch('shared.utils.get_brand_config', ...) to
  patch.object(mod, 'get_brand_config', ...) so the patch hits the
  handler's local import binding rather than the unrelated
  shared.utils attribute.

Tests:
- 414/414 lambda pytest pass
- 867/867 web vitest pass
- CDK build clean.
