### PR TITLE
build: convert manualChunks to function form for vite 8 (rolldown)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,34 @@
 /// <reference types="vitest" />
-import { defineConfig, loadEnv } from 'vite';
+import {
+  defineConfig, loadEnv
+} from 'vite';
 import react from '@vitejs/plugin-react';
+
+/**
+ * Vendor chunk assignment for Rollup/Rolldown `manualChunks`.
+ *
+ * Function form instead of object form because vite 8 bundles with rolldown,
+ * which only supports the function signature (the object form fails with
+ * "TypeError: manualChunks is not a function"). The function form is also
+ * first-class Rollup API, so it behaves identically on vite 6.
+ *
+ * `scheduler` is grouped with react/react-dom explicitly: the old object
+ * form pulled it into vendor-react implicitly as a react-dom dependency.
+ * The `[\\/]` boundary after each package name keeps lookalike packages
+ * (react-chartjs-2, react-router, react-markdown) out of vendor-react.
+ */
+function vendorChunk(id: string): string | undefined {
+  if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+    return 'vendor-react';
+  }
+  if (/[\\/]node_modules[\\/](chart\.js|react-chartjs-2)[\\/]/.test(id)) {
+    return 'vendor-charts';
+  }
+  if (/[\\/]node_modules[\\/]xlsx-js-style[\\/]/.test(id)) {
+    return 'vendor-xlsx';
+  }
+  return undefined;
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -18,14 +46,14 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     server: enableDevProxy
       ? {
-          proxy: {
-            '/api': {
-              target: proxyTarget,
-              changeOrigin: true,
-              secure: true,
-            },
+        proxy: {
+          '/api': {
+            target: proxyTarget,
+            changeOrigin: true,
+            secure: true,
           },
-        }
+        },
+      }
       : undefined,
     test: {
       globals: true,
@@ -37,15 +65,7 @@ export default defineConfig(({ mode }) => {
       sourcemap: false,
       minify: 'terser',
       chunkSizeWarningLimit: 1000,
-      rollupOptions: {
-        output: {
-          manualChunks: {
-            'vendor-react': ['react', 'react-dom'],
-            'vendor-charts': ['chart.js', 'react-chartjs-2'],
-            'vendor-xlsx': ['xlsx-js-style'],
-          },
-        },
-      },
+      rollupOptions: {output: {manualChunks: vendorChunk,},},
     },
   };
 });


### PR DESCRIPTION
## Description

Prerequisite for the vite 8 upgrade (#76). vite 8 bundles with rolldown, which does not support the object form of `rollupOptions.output.manualChunks` (build fails with `TypeError: manualChunks is not a function`). This converts the chunking config in `web/vite.config.ts` to the function form, which is first-class Rollup API and works identically on the current vite 6 and on vite 8.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified locally on vite 6 (current main):
- `npm run build` passes; chunk listing diffed against the previous config: vendor-react / vendor-charts / vendor-xlsx all preserved. Two understood deltas: `scheduler` (a react-dom dependency) moves from vendor-charts into vendor-react where it belongs, and the 505 B `xlsx.min` facade chunk folds into vendor-xlsx.
- Full web test suite: 915/915 pass.
- eslint clean (`--fix` also settled pre-existing @stylistic debt in this file).

Also verified the same config builds under vite 8.1.4 (see #76 verification).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings