### PR TITLE
feat: keyword-linked schedules + fix broken scheduled runs

### DIFF
--- a/lambda/api/manage-schedule.py
+++ b/lambda/api/manage-schedule.py
@@ -27,6 +27,59 @@ STATE_MACHINE_ARN = os.environ['STATE_MACHINE_ARN']
 SCHEDULE_ROLE_ARN = os.environ['SCHEDULE_ROLE_ARN']
 SCHEDULE_GROUP = 'citation-analysis-schedules'
 
+# Match the limits enforced by parse-keywords / trigger-keyword-analysis.
+MAX_SCHEDULE_KEYWORDS = 100
+MAX_KEYWORD_LENGTH = 500
+
+
+def _normalize_schedule_keywords(keywords: list) -> tuple[list[str], str | None]:
+    """
+    Normalize the optional keyword subset of a schedule.
+
+    Returns (keywords, error). An empty list means "all active keywords",
+    which keeps the schedule input resolved at execution time.
+    """
+    normalized = []
+    for keyword in keywords:
+        if not isinstance(keyword, str):
+            return [], 'keywords must be an array of strings'
+        stripped = keyword.strip()
+        if not stripped:
+            continue
+        if len(stripped) > MAX_KEYWORD_LENGTH:
+            return [], f'Each keyword must be at most {MAX_KEYWORD_LENGTH} characters'
+        normalized.append(stripped)
+
+    if len(normalized) > MAX_SCHEDULE_KEYWORDS:
+        return [], f'Too many keywords (max {MAX_SCHEDULE_KEYWORDS})'
+
+    return normalized, None
+
+
+def _build_schedule_input(schedule_keywords: list[str]) -> str:
+    """
+    Build the Step Functions input baked into the schedule target.
+
+    Schedules without a keyword subset keep {'source': 'dynamodb'} so the
+    keyword list (and query prompts) are resolved fresh at execution time.
+    """
+    if schedule_keywords:
+        return json.dumps({'keywords': schedule_keywords})
+    return json.dumps({'source': 'dynamodb'})
+
+
+def _extract_schedule_keywords(target: dict[str, Any]) -> list[str]:
+    """Read the keyword subset back out of a schedule target input."""
+    try:
+        target_input = json.loads(target.get('Input') or '{}')
+    except (TypeError, ValueError):
+        return []
+
+    keywords = target_input.get('keywords')
+    if not isinstance(keywords, list):
+        return []
+    return [kw for kw in keywords if isinstance(kw, str)]
+
 
 @api_handler
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
@@ -76,7 +129,9 @@ def list_schedules(event: dict[str, Any]) -> dict[str, Any]:
                 'schedule': detail['ScheduleExpression'],
                 'state': detail['State'],
                 'timezone': detail.get('ScheduleExpressionTimezone', 'UTC'),
-                'description': detail.get('Description', '')
+                'description': detail.get('Description', ''),
+                # Empty list = schedule runs all active keywords
+                'keywords': _extract_schedule_keywords(detail.get('Target') or {})
             })
 
         return success_response({'schedules': schedules}, event)
@@ -98,7 +153,16 @@ def list_schedules(event: dict[str, Any]) -> dict[str, Any]:
 def _create_schedule_handler(event: dict[str, Any], context: Any, body: dict[str, Any],
                               name: str, frequency: str, time: str, timezone: str,
                               enabled: bool, day_of_week: str, day_of_month: str) -> dict[str, Any]:
-    """Create a new schedule."""
+    """Create a new schedule, optionally linked to a subset of keywords."""
+    # Validated from the raw body: @validate's list coercion would silently
+    # turn a string into a list of characters.
+    raw_keywords = body.get('keywords', [])
+    if not isinstance(raw_keywords, list):
+        return validation_error('keywords must be an array of strings', event, 'keywords')
+
+    schedule_keywords, keywords_error = _normalize_schedule_keywords(raw_keywords)
+    if keywords_error:
+        return validation_error(keywords_error, event, 'keywords')
     # Validate time format (HH:MM)
     if not time or len(time) != 5 or ':' not in time:
         return validation_error('Invalid time format. Use HH:MM', event, 'time')
@@ -134,6 +198,7 @@ def _create_schedule_handler(event: dict[str, Any], context: Any, body: dict[str
         scheduler.create_schedule_group(Name=SCHEDULE_GROUP)
 
     # Create schedule
+    scope = f"{len(schedule_keywords)} keyword(s)" if schedule_keywords else 'all keywords'
     try:
         scheduler.create_schedule(
             Name=name,
@@ -141,12 +206,12 @@ def _create_schedule_handler(event: dict[str, Any], context: Any, body: dict[str
             ScheduleExpression=cron_expr,
             ScheduleExpressionTimezone=timezone,
             State='ENABLED' if enabled else 'DISABLED',
-            Description=f"Automated {frequency} citation analysis",
+            Description=f"Automated {frequency} citation analysis ({scope})",
             FlexibleTimeWindow={'Mode': 'OFF'},
             Target={
                 'Arn': STATE_MACHINE_ARN,
                 'RoleArn': SCHEDULE_ROLE_ARN,
-                'Input': json.dumps({'source': 'dynamodb'})
+                'Input': _build_schedule_input(schedule_keywords)
             }
         )
 
@@ -154,7 +219,8 @@ def _create_schedule_handler(event: dict[str, Any], context: Any, body: dict[str
             'message': 'Schedule created successfully',
             'name': name,
             'schedule': cron_expr,
-            'timezone': timezone
+            'timezone': timezone,
+            'keywords': schedule_keywords
         }, event, 201)
     except scheduler.exceptions.ConflictException:
         return api_response(409, {'error': 'Schedule with this name already exists'}, event)

--- a/lambda/api/test_manage_schedule.py
+++ b/lambda/api/test_manage_schedule.py
@@ -1,0 +1,286 @@
+"""
+Tests for manage-schedule.py Lambda.
+
+Covers:
+- Schedule creation (cron building, target input, keyword linking)
+- Keyword subset validation (type, count, length)
+- Listing schedules with their keyword scope
+- Deletion and conflict handling
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make `from shared.xxx import` resolve (layer puts shared/ at /opt/python/shared/)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # lambda/
+
+
+class SchedulerResourceNotFound(Exception):
+    """Stands in for scheduler.exceptions.ResourceNotFoundException."""
+
+
+class SchedulerConflict(Exception):
+    """Stands in for scheduler.exceptions.ConflictException."""
+
+
+# Mock the EventBridge Scheduler client at module level
+mock_scheduler = MagicMock()
+mock_scheduler.exceptions.ResourceNotFoundException = SchedulerResourceNotFound
+mock_scheduler.exceptions.ConflictException = SchedulerConflict
+
+
+def _mock_boto3_client(*args, **kwargs):
+    return mock_scheduler
+
+
+# Import the handler module (has hyphens in filename)
+_handler_spec = importlib.util.spec_from_file_location(
+    'manage_schedule',
+    os.path.join(os.path.dirname(__file__), 'manage-schedule.py')
+)
+_handler_mod = importlib.util.module_from_spec(_handler_spec)
+
+_test_env = {
+    'STATE_MACHINE_ARN': 'arn:aws:states:us-east-1:123456789012:stateMachine:test',
+    'SCHEDULE_ROLE_ARN': 'arn:aws:iam::123456789012:role/test-scheduler-role',
+    'CORS_ORIGIN_PARAM': '',
+}
+
+with patch('boto3.client', side_effect=_mock_boto3_client):
+    with patch.dict(os.environ, _test_env):
+        _handler_spec.loader.exec_module(_handler_mod)
+
+_handler_mod.scheduler = mock_scheduler
+
+
+def make_event(method, body=None, path_params=None):
+    """Build a minimal API Gateway event."""
+    return {
+        'httpMethod': method,
+        'pathParameters': path_params,
+        'headers': {'origin': 'http://localhost:3000'},
+        'body': json.dumps(body) if body else None,
+    }
+
+
+def parse_response(result):
+    """Extract status code and parsed body from Lambda response."""
+    status = result.get('statusCode', 200)
+    body = json.loads(result['body']) if isinstance(result.get('body'), str) else result.get('body', {})
+    return status, body
+
+
+def created_target_input():
+    """Return the parsed Target.Input of the last create_schedule call."""
+    kwargs = mock_scheduler.create_schedule.call_args.kwargs
+    return json.loads(kwargs['Target']['Input'])
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset scheduler mocks before each test."""
+    mock_scheduler.reset_mock()
+    mock_scheduler.exceptions.ResourceNotFoundException = SchedulerResourceNotFound
+    mock_scheduler.exceptions.ConflictException = SchedulerConflict
+    mock_scheduler.get_schedule_group.return_value = {'Name': 'citation-analysis-schedules'}
+    mock_scheduler.create_schedule.return_value = {}
+    mock_scheduler.list_schedules.return_value = {'Schedules': []}
+    mock_scheduler.delete_schedule.return_value = {}
+
+
+@pytest.fixture()
+def handler_module():
+    """Provide the handler module with the mocked scheduler client."""
+    _handler_mod.scheduler = mock_scheduler
+    yield _handler_mod
+
+
+class TestCreateSchedule:
+    """Tests for POST /api/schedules."""
+
+    def test_create_without_keywords_targets_all_keywords(self, handler_module):
+        """Schedules without a keyword subset keep the dynamodb source input."""
+        event = make_event('POST', body={'name': 'biweekly', 'frequency': 'daily', 'time': '09:00'})
+        result = handler_module.handler(event, {})
+        status, body = parse_response(result)
+        assert status == 201
+        assert created_target_input() == {'source': 'dynamodb'}
+        assert body['keywords'] == []
+
+    def test_create_daily_schedule_builds_daily_cron(self, handler_module):
+        """Daily frequency at 09:30 produces the matching cron expression."""
+        event = make_event('POST', body={'name': 'daily-am', 'frequency': 'daily', 'time': '09:30'})
+        result = handler_module.handler(event, {})
+        _, body = parse_response(result)
+        assert body['schedule'] == 'cron(30 09 * * ? *)'
+
+    def test_create_with_keywords_bakes_keyword_subset_into_target(self, handler_module):
+        """A keyword subset is stored as direct keywords input for the workflow."""
+        event = make_event('POST', body={
+            'name': 'priority-daily',
+            'frequency': 'daily',
+            'time': '07:00',
+            'keywords': ['best hotels malaga', 'boutique hotels madrid'],
+        })
+        result = handler_module.handler(event, {})
+        status, body = parse_response(result)
+        assert status == 201
+        assert created_target_input() == {'keywords': ['best hotels malaga', 'boutique hotels madrid']}
+        assert body['keywords'] == ['best hotels malaga', 'boutique hotels madrid']
+
+    def test_create_with_keywords_notes_scope_in_description(self, handler_module):
+        """The schedule description reflects the keyword scope."""
+        event = make_event('POST', body={
+            'name': 'priority-daily',
+            'keywords': ['best hotels malaga'],
+        })
+        handler_module.handler(event, {})
+        kwargs = mock_scheduler.create_schedule.call_args.kwargs
+        assert '1 keyword(s)' in kwargs['Description']
+
+    def test_create_strips_whitespace_and_drops_empty_keywords(self, handler_module):
+        """Blank keyword entries are dropped and whitespace is trimmed."""
+        event = make_event('POST', body={
+            'name': 'trimmed',
+            'keywords': ['  best hotels  ', '', '   '],
+        })
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 201
+        assert created_target_input() == {'keywords': ['best hotels']}
+
+    def test_create_rejects_non_string_keywords(self, handler_module):
+        """Keyword entries that are not strings return a validation error."""
+        event = make_event('POST', body={'name': 'bad', 'keywords': ['ok', 42]})
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 400
+
+    def test_create_rejects_more_than_100_keywords(self, handler_module):
+        """Keyword subsets above the pipeline cap of 100 are rejected."""
+        event = make_event('POST', body={'name': 'too-many', 'keywords': [f'kw-{i}' for i in range(101)]})
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 400
+
+    def test_create_rejects_keyword_longer_than_500_chars(self, handler_module):
+        """Keywords beyond 500 characters are rejected like the trigger API."""
+        event = make_event('POST', body={'name': 'long', 'keywords': ['x' * 501]})
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 400
+
+    def test_create_rejects_non_list_keywords(self, handler_module):
+        """A keywords value that is not an array returns a validation error."""
+        event = make_event('POST', body={'name': 'bad-type', 'keywords': 'hotels'})
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 400
+
+    def test_create_weekly_schedule_uses_day_of_week(self, handler_module):
+        """Weekly frequency builds a cron bound to the selected weekday."""
+        event = make_event('POST', body={
+            'name': 'weekly',
+            'frequency': 'weekly',
+            'time': '10:00',
+            'day_of_week': 'FRI',
+        })
+        result = handler_module.handler(event, {})
+        _, body = parse_response(result)
+        assert body['schedule'] == 'cron(00 10 ? * FRI *)'
+
+    def test_create_monthly_rejects_day_of_month_over_28(self, handler_module):
+        """day_of_month beyond 28 is rejected to keep schedules valid every month."""
+        event = make_event('POST', body={
+            'name': 'monthly',
+            'frequency': 'monthly',
+            'day_of_month': '29',
+        })
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 400
+
+    def test_create_rejects_invalid_time_format(self, handler_module):
+        """A time value that is not HH:MM returns a validation error."""
+        event = make_event('POST', body={'name': 'bad-time', 'time': '9am'})
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 400
+
+    def test_create_returns_409_when_name_exists(self, handler_module):
+        """A duplicate schedule name maps to a 409 conflict."""
+        mock_scheduler.create_schedule.side_effect = SchedulerConflict()
+        event = make_event('POST', body={'name': 'daily-analysis'})
+        result = handler_module.handler(event, {})
+        status, body = parse_response(result)
+        assert status == 409
+        assert body['error'] == 'Schedule with this name already exists'
+
+
+class TestListSchedules:
+    """Tests for GET /api/schedules."""
+
+    def test_list_exposes_keyword_subset_from_target_input(self, handler_module):
+        """Keyword-linked schedules report their keywords."""
+        mock_scheduler.list_schedules.return_value = {'Schedules': [{'Name': 'priority-daily'}]}
+        mock_scheduler.get_schedule.return_value = {
+            'Name': 'priority-daily',
+            'ScheduleExpression': 'cron(0 7 * * ? *)',
+            'State': 'ENABLED',
+            'Target': {'Input': json.dumps({'keywords': ['best hotels malaga']})},
+        }
+        result = handler_module.handler(make_event('GET'), {})
+        _, body = parse_response(result)
+        assert body['schedules'][0]['keywords'] == ['best hotels malaga']
+
+    def test_list_reports_empty_keywords_for_all_keyword_schedules(self, handler_module):
+        """Schedules with the dynamodb source input report an empty subset."""
+        mock_scheduler.list_schedules.return_value = {'Schedules': [{'Name': 'daily-analysis'}]}
+        mock_scheduler.get_schedule.return_value = {
+            'Name': 'daily-analysis',
+            'ScheduleExpression': 'cron(0 9 * * ? *)',
+            'State': 'ENABLED',
+            'Target': {'Input': json.dumps({'source': 'dynamodb'})},
+        }
+        result = handler_module.handler(make_event('GET'), {})
+        _, body = parse_response(result)
+        assert body['schedules'][0]['keywords'] == []
+
+    def test_list_reports_empty_keywords_when_target_input_is_invalid(self, handler_module):
+        """Malformed target input degrades to an empty keyword subset."""
+        mock_scheduler.list_schedules.return_value = {'Schedules': [{'Name': 'legacy'}]}
+        mock_scheduler.get_schedule.return_value = {
+            'Name': 'legacy',
+            'ScheduleExpression': 'cron(0 9 * * ? *)',
+            'State': 'ENABLED',
+            'Target': {'Input': 'not-json'},
+        }
+        result = handler_module.handler(make_event('GET'), {})
+        status, body = parse_response(result)
+        assert status == 200
+        assert body['schedules'][0]['keywords'] == []
+
+
+class TestDeleteSchedule:
+    """Tests for DELETE /api/schedules/{name}."""
+
+    def test_delete_existing_schedule_succeeds(self, handler_module):
+        """Deleting an existing schedule returns a success message."""
+        event = make_event('DELETE', path_params={'name': 'daily-analysis'})
+        result = handler_module.handler(event, {})
+        status, body = parse_response(result)
+        assert status == 200
+        assert body['message'] == 'Schedule deleted successfully'
+
+    def test_delete_missing_schedule_returns_404(self, handler_module):
+        """Deleting an unknown schedule name returns 404."""
+        mock_scheduler.delete_schedule.side_effect = SchedulerResourceNotFound()
+        event = make_event('DELETE', path_params={'name': 'ghost'})
+        result = handler_module.handler(event, {})
+        status, _ = parse_response(result)
+        assert status == 404

--- a/lambda/parse-keywords/handler.py
+++ b/lambda/parse-keywords/handler.py
@@ -33,6 +33,50 @@ KEYWORDS_TABLE = (
     or 'CitationAnalysis-Keywords'
 )
 
+QUERY_PROMPTS_TABLE = (
+    os.environ.get('DYNAMODB_TABLE_QUERY_PROMPTS')
+    or os.environ.get('QUERY_PROMPTS_TABLE')
+    or 'CitationAnalysis-QueryPrompts'
+)
+
+
+def read_enabled_query_prompts() -> list[dict[str, str]]:
+    """
+    Read enabled query prompts from DynamoDB.
+
+    Used for executions whose input does not carry query prompts (e.g.
+    EventBridge schedules, which bake their input at creation time). Resolving
+    prompts here keeps scheduled runs in sync with the current configuration.
+    """
+    try:
+        table = dynamodb.Table(QUERY_PROMPTS_TABLE)
+        response = table.query(
+            IndexName='EnabledIndex',
+            KeyConditionExpression=Key('enabled').eq('true'),
+            Limit=10
+        )
+        prompts = [
+            {
+                'id': item['id'],
+                'name': item.get('name', ''),
+                'template': item.get('template', ''),
+            }
+            for item in response.get('Items', [])
+        ]
+        logger.info(f"Read {len(prompts)} enabled query prompts from DynamoDB")
+        return prompts
+    except Exception as e:
+        logger.warning(f"Could not fetch query prompts, proceeding without them: {e}")
+        return []
+
+
+def resolve_query_prompts(event: dict[str, Any]) -> list:
+    """Pass through query prompts from the execution input, or load enabled ones."""
+    prompts = event.get('query_prompts')
+    if isinstance(prompts, list):
+        return prompts
+    return read_enabled_query_prompts()
+
 
 def read_keywords_from_dynamodb() -> list[str]:
     """Read active keywords from DynamoDB Keywords table."""
@@ -107,11 +151,18 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     2. Direct array: {"keywords": ["keyword1", "keyword2"]}
     3. Direct string: {"keywords": "keyword1\nkeyword2"}
 
+    An optional "query_prompts" list in the input is passed through to the
+    output. When absent (scheduled runs), enabled prompts are loaded from
+    DynamoDB instead.
+
     Output:
     {
         "keywords": [
             {"keyword": "best hotels in malaga", "timestamp": "2025-01-15T10:30:00Z"},
             {"keyword": "top restaurants paris", "timestamp": "2025-01-15T10:30:00Z"}
+        ],
+        "query_prompts": [
+            {"id": "prompt-1", "name": "Family Traveler", "template": "As a family traveler, find {keyword}"}
         ]
     }
     """
@@ -160,7 +211,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             logger.warning(f"{len(valid_keywords)} keywords provided, limiting to 100")
             valid_keywords = valid_keywords[:100]
 
-        # Format output with timestamps
+        # Format output with timestamps. query_prompts is always emitted so the
+        # ProcessKeywords Map state can select it from this state's output,
+        # regardless of whether the execution input carried prompts (API
+        # triggers do, EventBridge schedules do not).
         result = {
             "keywords": [
                 {
@@ -168,7 +222,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                     "timestamp": timestamp
                 }
                 for keyword in valid_keywords
-            ]
+            ],
+            "query_prompts": resolve_query_prompts(event)
         }
 
         logger.info(f"Successfully parsed {len(valid_keywords)} keywords")

--- a/lambda/parse-keywords/test_handler.py
+++ b/lambda/parse-keywords/test_handler.py
@@ -1,0 +1,144 @@
+"""
+Tests for the ParseKeywords Lambda handler.
+
+Covers:
+- Keyword parsing from direct input and DynamoDB
+- query_prompts pass-through from the execution input
+- query_prompts resolution from DynamoDB for scheduled runs
+"""
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make `from shared.xxx import` resolve (layer puts shared/ at /opt/python/shared/)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # lambda/
+
+# Mock DynamoDB tables at module level
+mock_keywords_table = MagicMock()
+mock_prompts_table = MagicMock()
+mock_dynamodb = MagicMock()
+
+
+def _table_for_name(name):
+    if name == 'test-prompts-table':
+        return mock_prompts_table
+    return mock_keywords_table
+
+
+mock_dynamodb.Table.side_effect = _table_for_name
+
+
+def _mock_boto3_resource(*args, **kwargs):
+    return mock_dynamodb
+
+
+def _mock_boto3_client(*args, **kwargs):
+    return MagicMock()
+
+
+# Import the handler module
+_handler_spec = importlib.util.spec_from_file_location(
+    'parse_keywords_handler',
+    os.path.join(os.path.dirname(__file__), 'handler.py')
+)
+_handler_mod = importlib.util.module_from_spec(_handler_spec)
+
+_test_env = {
+    'KEYWORDS_TABLE': 'test-keywords-table',
+    'QUERY_PROMPTS_TABLE': 'test-prompts-table',
+}
+
+with patch('boto3.resource', side_effect=_mock_boto3_resource):
+    with patch('boto3.client', side_effect=_mock_boto3_client):
+        with patch.dict(os.environ, _test_env):
+            _handler_spec.loader.exec_module(_handler_mod)
+
+_handler_mod.dynamodb = mock_dynamodb
+
+
+SAMPLE_PROMPT_ITEMS = [
+    {'id': 'prompt-1', 'name': 'Family Traveler', 'template': 'As a family, find {keyword}'},
+]
+
+EXPECTED_PROMPTS = [
+    {'id': 'prompt-1', 'name': 'Family Traveler', 'template': 'As a family, find {keyword}'},
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset table mocks before each test."""
+    mock_keywords_table.reset_mock()
+    mock_prompts_table.reset_mock()
+    mock_prompts_table.query.side_effect = None
+    mock_keywords_table.query.return_value = {'Items': []}
+    mock_prompts_table.query.return_value = {'Items': SAMPLE_PROMPT_ITEMS}
+
+
+@pytest.fixture()
+def handler_module():
+    """Provide the handler module with mocked DynamoDB."""
+    _handler_mod.dynamodb = mock_dynamodb
+    yield _handler_mod
+
+
+class TestKeywordParsing:
+    """Keyword extraction from the different input shapes."""
+
+    def test_parses_direct_keyword_array(self, handler_module):
+        """A direct keywords array is normalized into keyword/timestamp pairs."""
+        result = handler_module.handler({'keywords': ['best hotels', 'top resorts'], 'query_prompts': []}, {})
+        parsed = [item['keyword'] for item in result['keywords']]
+        assert parsed == ['best hotels', 'top resorts']
+
+    def test_reads_active_keywords_from_dynamodb_for_scheduled_runs(self, handler_module):
+        """source=dynamodb loads the active keywords from the Keywords table."""
+        mock_keywords_table.query.return_value = {
+            'Items': [{'keyword': 'best hotels malaga'}, {'keyword': 'boutique madrid'}]
+        }
+        result = handler_module.handler({'source': 'dynamodb'}, {})
+        parsed = [item['keyword'] for item in result['keywords']]
+        assert parsed == ['best hotels malaga', 'boutique madrid']
+
+    def test_raises_when_no_valid_keywords_found(self, handler_module):
+        """Empty keyword input raises instead of starting an empty run."""
+        with pytest.raises(ValueError, match='No valid keywords'):
+            handler_module.handler({'keywords': ['', '   ']}, {})
+
+
+class TestQueryPromptResolution:
+    """query_prompts output for the ProcessKeywords Map state."""
+
+    def test_passes_through_query_prompts_from_execution_input(self, handler_module):
+        """Prompts provided by trigger APIs are forwarded unchanged."""
+        prompts = [{'id': 'p1', 'name': 'Custom', 'template': 'Find {keyword}'}]
+        result = handler_module.handler({'keywords': ['best hotels'], 'query_prompts': prompts}, {})
+        assert result['query_prompts'] == prompts
+        mock_prompts_table.query.assert_not_called()
+
+    def test_passes_through_empty_prompt_list_without_loading(self, handler_module):
+        """An explicit empty prompt list is respected, not replaced."""
+        result = handler_module.handler({'keywords': ['best hotels'], 'query_prompts': []}, {})
+        assert result['query_prompts'] == []
+        mock_prompts_table.query.assert_not_called()
+
+    def test_loads_enabled_prompts_when_input_has_none(self, handler_module):
+        """Scheduled runs (no prompts in input) resolve enabled prompts from DynamoDB."""
+        mock_keywords_table.query.return_value = {'Items': [{'keyword': 'best hotels'}]}
+        result = handler_module.handler({'source': 'dynamodb'}, {})
+        assert result['query_prompts'] == EXPECTED_PROMPTS
+
+    def test_loads_enabled_prompts_for_keyword_subset_schedules(self, handler_module):
+        """Keyword-linked schedules ({"keywords": [...]}) also resolve prompts."""
+        result = handler_module.handler({'keywords': ['best hotels malaga']}, {})
+        assert result['query_prompts'] == EXPECTED_PROMPTS
+
+    def test_returns_empty_prompts_when_prompt_table_query_fails(self, handler_module):
+        """A prompt lookup failure degrades to an empty list instead of failing the run."""
+        mock_prompts_table.query.side_effect = RuntimeError('table unavailable')
+        result = handler_module.handler({'keywords': ['best hotels']}, {})
+        assert result['query_prompts'] == []

--- a/lib/citation-analysis-stack.spec.ts
+++ b/lib/citation-analysis-stack.spec.ts
@@ -1,59 +1,101 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  describe, it, expect, beforeAll 
+} from 'vitest';
 import { CitationAnalysisStack } from './citation-analysis-stack';
 
-let template: Template;
-let definitionRaw: string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let crawlerEnvVars: Record<string, any>;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Walk a nested unknown structure without unsafe member access. */
+function resolvePath(root: unknown, keys: string[]): unknown {
+  return keys.reduce<unknown>(
+    (current, key) => (isRecord(current) ? current[key] : undefined),
+    root
+  );
+}
+
+/**
+ * Extract the Step Functions definition JSON from the synthesized template.
+ * Fn::Join produces ["", [...parts]]; string parts are concatenated and
+ * object refs replaced with a placeholder.
+ */
+function extractStateMachineDefinition(template: Template): string {
+  const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
+  const logicalId = Object.keys(stateMachines)[0];
+  const joinArgs = resolvePath(stateMachines[logicalId], ['Properties', 'DefinitionString', 'Fn::Join']);
+  const parts = Array.isArray(joinArgs) && Array.isArray(joinArgs[1]) ? joinArgs[1] : [];
+  return parts
+    .map((part) => (typeof part === 'string' ? part : '"__REF__"'))
+    .join('');
+}
+
+function extractLambdaEnvVars(template: Template, functionName: string): Record<string, unknown> {
+  const lambdas = template.findResources('AWS::Lambda::Function', {
+    Properties: { FunctionName: functionName },
+  });
+  const logicalId = Object.keys(lambdas)[0];
+  const envVars = resolvePath(lambdas[logicalId], ['Properties', 'Environment', 'Variables']);
+  return isRecord(envVars) ? envVars : {};
+}
+
+const synthesized: {
+  definitionRaw: string;
+  crawlerEnvVars: Record<string, unknown>;
+  parseKeywordsEnvVars: Record<string, unknown>;
+} = {
+  definitionRaw: '',
+  crawlerEnvVars: {},
+  parseKeywordsEnvVars: {},
+};
 
 beforeAll(() => {
   const app = new cdk.App();
   const stack = new CitationAnalysisStack(app, 'TestStack');
-  template = Template.fromStack(stack);
+  const template = Template.fromStack(stack);
 
-  // Extract the Step Functions definition from the Fn::Join
-  const stateMachines = template.findResources('AWS::StepFunctions::StateMachine');
-  const logicalId = Object.keys(stateMachines)[0];
-  const defString = stateMachines[logicalId].Properties.DefinitionString;
-
-  // Fn::Join produces ["", [...parts]]
-  // Concatenate string parts, replace object refs with a placeholder
-  const parts = defString['Fn::Join'][1] as unknown[];
-  definitionRaw = parts
-    .map((p) => (typeof p === 'string' ? p : '"__REF__"'))
-    .join('');
-
-  // Extract Crawler Lambda env vars
-  const lambdas = template.findResources('AWS::Lambda::Function', {
-    Properties: { FunctionName: 'CitationAnalysis-Crawler' },
-  });
-  const crawlerLogicalId = Object.keys(lambdas)[0];
-  crawlerEnvVars = lambdas[crawlerLogicalId].Properties.Environment.Variables;
+  synthesized.definitionRaw = extractStateMachineDefinition(template);
+  synthesized.crawlerEnvVars = extractLambdaEnvVars(template, 'CitationAnalysis-Crawler');
+  synthesized.parseKeywordsEnvVars = extractLambdaEnvVars(template, 'CitationAnalysis-ParseKeywords');
 }, 60_000);
 
 describe('Step Functions workflow', () => {
   it('passes keyword to CrawlCitations Map itemSelector', () => {
     // Verify the CrawlCitations state includes keyword.$ in its ItemSelector
-    expect(definitionRaw).toContain('"keyword.$":"$.keyword"');
+    expect(synthesized.definitionRaw).toContain('"keyword.$":"$.keyword"');
   });
 
-  it('passes query_prompts to ProcessKeywords Map itemSelector', () => {
-    expect(definitionRaw).toContain('"query_prompts.$":"$$.Execution.Input.query_prompts"');
+  it('selects query_prompts from the ParseKeywords output in ProcessKeywords Map', () => {
+    expect(synthesized.definitionRaw).toContain('"query_prompts.$":"$.query_prompts"');
+  });
+
+  it('does not reference query_prompts from the raw execution input', () => {
+    // Scheduled executions ({"source":"dynamodb"} or {"keywords":[...]}) carry
+    // no query_prompts key in their input; a $$.Execution.Input.query_prompts
+    // reference would raise States.Runtime for every scheduled run.
+    expect(synthesized.definitionRaw).not.toContain('$$.Execution.Input.query_prompts');
+  });
+});
+
+describe('ParseKeywords Lambda environment', () => {
+  it('includes the query prompts table for execution-time prompt resolution', () => {
+    expect(synthesized.parseKeywordsEnvVars).toHaveProperty('DYNAMODB_TABLE_QUERY_PROMPTS');
+    expect(synthesized.parseKeywordsEnvVars).toHaveProperty('QUERY_PROMPTS_TABLE');
   });
 });
 
 describe('Crawler Lambda environment', () => {
   it('does not include unused BROWSER_TIMEOUT_MS env var', () => {
-    expect(crawlerEnvVars).not.toHaveProperty('BROWSER_TIMEOUT_MS');
+    expect(synthesized.crawlerEnvVars).not.toHaveProperty('BROWSER_TIMEOUT_MS');
   });
 
   it('does not include unused PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD env var', () => {
-    expect(crawlerEnvVars).not.toHaveProperty('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD');
+    expect(synthesized.crawlerEnvVars).not.toHaveProperty('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD');
   });
 
   it('does not include unused NOVA_ACT_SECRET_NAME env var', () => {
-    expect(crawlerEnvVars).not.toHaveProperty('NOVA_ACT_SECRET_NAME');
+    expect(synthesized.crawlerEnvVars).not.toHaveProperty('NOVA_ACT_SECRET_NAME');
   });
 });

--- a/lib/citation-analysis-stack.ts
+++ b/lib/citation-analysis-stack.ts
@@ -38,6 +38,18 @@ const bedrockTierEnv = {
 } as const;
 
 /**
+ * Thrown at synth time when a Lambda layer's local build output is missing.
+ * Layers must be built (scripts/deploy.sh or the per-layer build-layer.sh)
+ * before `cdk synth`/`cdk deploy`.
+ */
+class LayerNotBuiltError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LayerNotBuiltError';
+  }
+}
+
+/**
  * Creates optimized Lambda code bundle containing only the specific handler file
  * plus shared utilities (decimal_utils.py). This reduces deployment package size
  * and improves cold start times compared to bundling all API handlers together.
@@ -707,7 +719,7 @@ export class CitationAnalysisStack extends cdk.Stack {
     const sharedLayerPath = path.join(__dirname, '../lambda/layer');
     const sharedLayerPythonPath = path.join(sharedLayerPath, 'python');
     if (!fs.existsSync(sharedLayerPythonPath) || fs.readdirSync(sharedLayerPythonPath).length === 0) {
-      throw new Error(
+      throw new LayerNotBuiltError(
         'Shared layer not built. Run: bash lambda/layer/build-layer.sh\n' +
         'Or use scripts/deploy.sh which builds all layers automatically.'
       );
@@ -745,12 +757,17 @@ export class CitationAnalysisStack extends cdk.Stack {
         // Audit #12 canonical name + legacy for in-flight rollouts.
         DYNAMODB_TABLE_KEYWORDS: keywordsTable.tableName,
         KEYWORDS_TABLE: keywordsTable.tableName,
+        // Enabled query prompts are resolved here for executions whose input
+        // does not carry them (EventBridge schedules).
+        DYNAMODB_TABLE_QUERY_PROMPTS: queryPromptsTable.tableName,
+        QUERY_PROMPTS_TABLE: queryPromptsTable.tableName,
       },
     });
 
-    // Grant ParseKeywords Lambda read access to keywords bucket and table
+    // Grant ParseKeywords Lambda read access to keywords bucket and tables
     keywordsBucket.grantRead(parseKeywordsFunction);
     keywordsTable.grantReadData(parseKeywordsFunction);
+    queryPromptsTable.grantReadData(parseKeywordsFunction);
 
     // Search Lambda Function
     const searchLogGroup = new logs.LogGroup(this, 'SearchLogGroup', {
@@ -818,7 +835,7 @@ export class CitationAnalysisStack extends cdk.Stack {
     const crawlerLayerPath = path.join(__dirname, '../lambda/crawler-layer');
     const crawlerLayerPythonPath = path.join(crawlerLayerPath, 'python');
     if (!fs.existsSync(crawlerLayerPythonPath) || fs.readdirSync(crawlerLayerPythonPath).length === 0) {
-      throw new Error(
+      throw new LayerNotBuiltError(
         'Crawler layer not built. Run: bash lambda/crawler-layer/build-layer.sh\n' +
         'Or use scripts/deploy.sh which builds all layers automatically.'
       );
@@ -1005,7 +1022,12 @@ export class CitationAnalysisStack extends cdk.Stack {
       itemSelector: {
         'keyword.$': '$$.Map.Item.Value.keyword',
         'timestamp.$': '$$.Map.Item.Value.timestamp',
-        'query_prompts.$': '$$.Execution.Input.query_prompts',
+        // query_prompts comes from the ParseKeywords output (this state's
+        // input), NOT the raw execution input: scheduled runs don't carry
+        // prompts in their input, so ParseKeywords resolves them and always
+        // emits the key. Referencing $$.Execution.Input.query_prompts here
+        // would raise States.Runtime for scheduled executions.
+        'query_prompts.$': '$.query_prompts',
       },
     }).itemProcessor(processKeywordChain);
 
@@ -2371,12 +2393,6 @@ def delete_waf(waf, arn):
     // for consolidated functions. The wildcard permission above covers all methods.
     // We use Aspects to remove them after synthesis since they're created on the
     // API Gateway method constructs, not on the Lambda.
-    const consolidatedLogicalPrefixes: string[] = [];
-    for (const fn of consolidatedFunctions) {
-      const cfnFn = fn.node.defaultChild as cdk.CfnResource;
-      consolidatedLogicalPrefixes.push(cfnFn.logicalId);
-    }
-
     class RemoveDuplicatePermissions implements cdk.IAspect {
       private readonly fnArns: Set<string>;
       private readonly fnArnStrings: string[];

--- a/web/src/api/executions.spec.ts
+++ b/web/src/api/executions.spec.ts
@@ -132,27 +132,28 @@ describe('executions API', () => {
   });
 
   describe('createSchedule', () => {
-    it('creates schedule with options', async () => {
+    it('posts the schedule form including the keyword subset', async () => {
       const mockSchedule = {
-        name: 'daily',
+        name: 'priority-daily',
         state: 'ENABLED' 
       };
       mockApiPost.mockResolvedValue(mockSchedule);
 
-      const result = await createSchedule({
-        name: 'daily',
-        schedule: 'rate(1 day)',
+      const formData = {
+        name: 'priority-daily',
+        frequency: 'daily',
+        time: '07:00',
         timezone: 'UTC',
+        day_of_week: 'MON',
+        day_of_month: '1',
         enabled: true,
-      });
+        keywords: ['best hotels malaga'],
+      } satisfies Parameters<typeof createSchedule>[0];
+
+      const result = await createSchedule(formData);
 
       expect(result).toStrictEqual(mockSchedule);
-      expect(mockApiPost).toHaveBeenCalledWith('/schedules', {
-        name: 'daily',
-        schedule: 'rate(1 day)',
-        timezone: 'UTC',
-        enabled: true,
-      });
+      expect(mockApiPost).toHaveBeenCalledWith('/schedules', formData);
     });
   });
 });

--- a/web/src/api/executions.ts
+++ b/web/src/api/executions.ts
@@ -7,7 +7,12 @@ import {
 import {
   apiGet, apiPost, ApiRequestError 
 } from './client';
-import type { Execution } from '../types';
+import type {
+  Execution, Schedule, ScheduleFormData 
+} from '../types';
+
+// Re-exported for existing consumers of this module's schedule API.
+export type { Schedule };
 
 /**
  * Fetches execution status by ARN.
@@ -64,13 +69,6 @@ export async function triggerAnalysis(
   return data as TriggerResponse;
 }
 
-export interface Schedule {
-  name: string;
-  state: 'ENABLED' | 'DISABLED';
-  schedule: string;
-  timezone: string;
-}
-
 interface SchedulesResponse {schedules: Schedule[];}
 
 /**
@@ -81,16 +79,10 @@ export async function fetchSchedules(signal?: AbortSignal): Promise<Schedule[]> 
   return response.schedules ?? [];
 }
 
-interface CreateScheduleOptions {
-  name: string;
-  schedule: string;
-  timezone: string;
-  enabled: boolean;
-}
-
 /**
- * Creates a new schedule.
+ * Creates a new schedule. `keywords` links the schedule to a keyword subset;
+ * an empty array runs all active keywords at execution time.
  */
-export function createSchedule(options: CreateScheduleOptions): Promise<Schedule> {
+export function createSchedule(options: ScheduleFormData): Promise<Schedule> {
   return apiPost<Schedule>('/schedules', options);
 }

--- a/web/src/components/Layout/TabContent.tsx
+++ b/web/src/components/Layout/TabContent.tsx
@@ -182,7 +182,7 @@ export function TabContent(props: TabContentProps) {
     recommendations: <Recommendations />,
     'content-studio': <ContentStudioView />,
     execution: <ExecutionMonitor execution={execution} triggerAnalysis={triggerAnalysis} keywordsCount={keywords.length} keywords={keywords} />,
-    schedule: <ScheduleManager schedules={schedules} setSchedules={setSchedules} />,
+    schedule: <ScheduleManager schedules={schedules} setSchedules={setSchedules} keywords={keywords} />,
     settings: <SettingsView keywords={keywords} setKeywords={setKeywords} />,
     searches: (
       <SearchesView

--- a/web/src/components/Schedule/ScheduleManager.spec.tsx
+++ b/web/src/components/Schedule/ScheduleManager.spec.tsx
@@ -2,16 +2,28 @@ import {
   describe, it, expect, vi, beforeEach 
 } from 'vitest';
 import {
-  render, screen 
+  render, screen, waitFor 
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ScheduleManager } from './ScheduleManager';
 
-import type { Schedule } from '../../types';
+import type {
+  Keyword, Schedule 
+} from '../../types';
 
 vi.mock('../../infrastructure', () => ({
   API_BASE_URL: 'https://api.test.com',
   authenticatedFetch: vi.fn(),
+  isAbortError: vi.fn(() => false),
 }));
+
+vi.mock('../../api/executions', () => ({fetchSchedules: vi.fn(),}));
+
+import { authenticatedFetch } from '../../infrastructure';
+import { fetchSchedules } from '../../api/executions';
+
+const mockAuthFetch = authenticatedFetch as ReturnType<typeof vi.fn>;
+const mockFetchSchedules = fetchSchedules as ReturnType<typeof vi.fn>;
 
 const mockSchedules: Schedule[] = [
   {
@@ -22,23 +34,169 @@ const mockSchedules: Schedule[] = [
   },
 ];
 
+const mockKeywords: Keyword[] = [
+  {
+    id: 'kw-1',
+    keyword: 'best hotels malaga',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'kw-2',
+    keyword: 'boutique hotels madrid',
+    created_at: '2024-01-02T00:00:00Z',
+  },
+];
+
+function buildProps(overrides = {}) {
+  return {
+    schedules: [] satisfies Schedule[],
+    setSchedules: vi.fn(),
+    keywords: mockKeywords,
+    ...overrides,
+  };
+}
+
+async function openScheduleForm() {
+  await userEvent.click(screen.getByRole('button', { name: /New Schedule/i }));
+}
+
+function firstCreateRequestBody(): unknown {
+  const [, requestInit] = mockAuthFetch.mock.calls[0] as [string, RequestInit];
+  return JSON.parse(String(requestInit.body)) as unknown;
+}
+
 describe('ScheduleManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchSchedules.mockResolvedValue([]);
   });
 
-  it('renders without crashing', () => {
-    render(<ScheduleManager schedules={[]} setSchedules={vi.fn()} />);
-    expect(document.body).toBeTruthy();
+  describe('schedule list', () => {
+    it('renders schedule name when schedules exist', () => {
+      render(<ScheduleManager {...buildProps({ schedules: mockSchedules })} />);
+      expect(screen.getByText('daily-analysis')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no schedules', () => {
+      render(<ScheduleManager {...buildProps()} />);
+      expect(screen.getByText(/No schedules/i)).toBeInTheDocument();
+    });
+
+    it('shows all-keywords scope for schedules without linked keywords', () => {
+      render(<ScheduleManager {...buildProps({ schedules: mockSchedules })} />);
+      expect(screen.getByText('Runs all active keywords')).toBeInTheDocument();
+    });
+
+    it('shows linked keywords for keyword-scoped schedules', () => {
+      const keywordSchedule: Schedule[] = [
+        {
+          name: 'priority-daily',
+          state: 'ENABLED',
+          schedule: 'cron(0 7 * * ? *)',
+          timezone: 'UTC',
+          keywords: ['best hotels malaga', 'boutique hotels madrid'],
+        },
+      ];
+      render(<ScheduleManager {...buildProps({ schedules: keywordSchedule })} />);
+      expect(
+        screen.getByText('Runs 2 keyword(s): best hotels malaga, boutique hotels madrid')
+      ).toBeInTheDocument();
+    });
   });
 
-  it('renders schedule name when schedules exist', () => {
-    render(<ScheduleManager schedules={mockSchedules} setSchedules={vi.fn()} />);
-    expect(screen.getByText('daily-analysis')).toBeInTheDocument();
+  describe('initial load', () => {
+    it('loads schedules from the API on mount', async () => {
+      const props = buildProps();
+      mockFetchSchedules.mockResolvedValue(mockSchedules);
+
+      render(<ScheduleManager {...props} />);
+
+      await waitFor(() => expect(props.setSchedules).toHaveBeenCalledWith(mockSchedules));
+    });
   });
 
-  it('shows empty state when no schedules', () => {
-    render(<ScheduleManager schedules={[]} setSchedules={vi.fn()} />);
-    expect(screen.getByText(/No schedules/i)).toBeInTheDocument();
+  describe('keyword scope selection', () => {
+    it('defaults to running all keywords', async () => {
+      render(<ScheduleManager {...buildProps()} />);
+      await openScheduleForm();
+
+      expect(screen.getByRole('radio', { name: /All keywords/i })).toBeChecked();
+    });
+
+    it('lists available keywords when specific scope is selected', async () => {
+      render(<ScheduleManager {...buildProps()} />);
+      await openScheduleForm();
+
+      await userEvent.click(screen.getByRole('radio', { name: /Specific keywords/i }));
+
+      expect(screen.getByRole('checkbox', { name: 'best hotels malaga' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'boutique hotels madrid' })).toBeInTheDocument();
+    });
+
+    it('prompts to add keywords when none exist for specific scope', async () => {
+      render(<ScheduleManager {...buildProps({ keywords: [] })} />);
+      await openScheduleForm();
+
+      await userEvent.click(screen.getByRole('radio', { name: /Specific keywords/i }));
+
+      expect(screen.getByText(/No keywords available yet/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('schedule creation', () => {
+    it('submits an empty keyword subset when all keywords is selected', async () => {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ message: 'created' }),
+      });
+      render(<ScheduleManager {...buildProps()} />);
+      await openScheduleForm();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Schedule' }));
+
+      expect(firstCreateRequestBody()).toMatchObject({ keywords: [] });
+    });
+
+    it('submits the selected keywords when specific scope is chosen', async () => {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ message: 'created' }),
+      });
+      render(<ScheduleManager {...buildProps()} />);
+      await openScheduleForm();
+      await userEvent.click(screen.getByRole('radio', { name: /Specific keywords/i }));
+      await userEvent.click(screen.getByRole('checkbox', { name: 'best hotels malaga' }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Schedule' }));
+
+      expect(firstCreateRequestBody()).toMatchObject({ keywords: ['best hotels malaga'] });
+    });
+
+    it('blocks submission when specific scope has no keywords selected', async () => {
+      render(<ScheduleManager {...buildProps()} />);
+      await openScheduleForm();
+      await userEvent.click(screen.getByRole('radio', { name: /Specific keywords/i }));
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Schedule' }));
+
+      expect(screen.getByText('Select at least one keyword for this schedule')).toBeInTheDocument();
+      expect(mockAuthFetch).not.toHaveBeenCalled();
+    });
+
+    it('refreshes the schedule list after a successful creation', async () => {
+      const props = buildProps();
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ message: 'created' }),
+      });
+      mockFetchSchedules.mockResolvedValue(mockSchedules);
+      render(<ScheduleManager {...props} />);
+      await openScheduleForm();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Schedule' }));
+
+      await waitFor(() => expect(props.setSchedules).toHaveBeenCalledWith(mockSchedules));
+      expect(mockFetchSchedules).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/web/src/components/Schedule/ScheduleManager.tsx
+++ b/web/src/components/Schedule/ScheduleManager.tsx
@@ -1,17 +1,24 @@
-import { useState } from 'react';
 import {
-  API_BASE_URL, authenticatedFetch 
+  useState, useEffect 
+} from 'react';
+import {
+  API_BASE_URL, authenticatedFetch, isAbortError 
 } from '../../infrastructure';
+import { fetchSchedules } from '../../api/executions';
 import type {
-  Schedule, ScheduleFormData 
+  Keyword, Schedule, ScheduleFormData 
 } from '../../types';
 import {
   ConfirmModal, AlertModal 
 } from '../ui/Modal';
+import {
+  ScheduleHeader, ScheduleForm, ScheduleList, type KeywordScope 
+} from './ScheduleManagerComponents';
 
 interface ScheduleManagerProps {
   schedules: Schedule[];
   setSchedules: (schedules: Schedule[]) => void;
+  keywords: Keyword[];
 }
 
 interface ScheduleResponse {
@@ -31,9 +38,10 @@ interface AlertState {
 }
 
 export const ScheduleManager = ({
-  schedules, setSchedules 
+  schedules, setSchedules, keywords 
 }: ScheduleManagerProps) => {
   const [showForm, setShowForm] = useState(false);
+  const [keywordScope, setKeywordScope] = useState<KeywordScope>('all');
   const [formData, setFormData] = useState<ScheduleFormData>({
     name: 'daily-analysis',
     frequency: 'daily',
@@ -42,7 +50,22 @@ export const ScheduleManager = ({
     day_of_week: 'MON',
     day_of_month: '1',
     enabled: true,
+    keywords: [],
   });
+
+  // Load existing schedules on mount; previously the list was only refreshed
+  // after creating a schedule, so it appeared empty on every fresh visit.
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchSchedules(controller.signal)
+      .then(setSchedules)
+      .catch((err: unknown) => {
+        if (!isAbortError(err)) {
+          console.error('Error loading schedules:', err);
+        }
+      });
+    return () => controller.abort();
+  }, [setSchedules]);
 
   const [deleteModal, setDeleteModal] = useState<{
     isOpen: boolean;
@@ -68,11 +91,20 @@ export const ScheduleManager = ({
   };
 
   const createSchedule = async () => {
+    const selectedKeywords = keywordScope === 'selected' ? formData.keywords : [];
+    if (keywordScope === 'selected' && selectedKeywords.length === 0) {
+      showAlert('Error', 'Select at least one keyword for this schedule', 'error');
+      return;
+    }
+
     try {
       const response = await authenticatedFetch(`${API_BASE_URL}/schedules`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({
+          ...formData,
+          keywords: selectedKeywords,
+        }),
       });
 
       const json: unknown = await response.json();
@@ -81,10 +113,12 @@ export const ScheduleManager = ({
       if (response.ok) {
         showAlert('Success', 'Schedule created successfully', 'success');
         setShowForm(false);
-        const refreshResponse = await authenticatedFetch(`${API_BASE_URL}/schedules`);
-        const refreshJson: unknown = await refreshResponse.json();
-        const refreshData: ScheduleResponse = isScheduleResponse(refreshJson) ? refreshJson : {};
-        setSchedules(refreshData.schedules ?? []);
+        setKeywordScope('all');
+        setFormData((prev) => ({
+          ...prev,
+          keywords: [],
+        }));
+        setSchedules(await fetchSchedules());
       } else {
         showAlert('Error', data.error ?? 'Failed to create schedule', 'error');
       }
@@ -116,6 +150,13 @@ export const ScheduleManager = ({
     });
   };
 
+  const toggleKeyword = (keyword: string) => {
+    const nextKeywords = formData.keywords.includes(keyword)
+      ? formData.keywords.filter((selected) => selected !== keyword)
+      : [...formData.keywords, keyword];
+    updateFormField('keywords', nextKeywords);
+  };
+
   return (
     <div className="bg-white rounded-lg border border-gray-200">
       <ScheduleHeader showForm={showForm} setShowForm={setShowForm} />
@@ -125,6 +166,10 @@ export const ScheduleManager = ({
           formData={formData}
           updateFormField={updateFormField}
           onSubmit={createSchedule}
+          availableKeywords={keywords}
+          keywordScope={keywordScope}
+          onScopeChange={setKeywordScope}
+          onToggleKeyword={toggleKeyword}
         />
       )}
 
@@ -162,219 +207,3 @@ export const ScheduleManager = ({
     </div>
   );
 };
-
-interface ScheduleHeaderProps {
-  showForm: boolean;
-  setShowForm: (value: boolean) => void;
-}
-
-const ScheduleHeader = ({
-  showForm, setShowForm 
-}: ScheduleHeaderProps) => (
-  <div className="p-4 sm:p-6 border-b border-gray-200">
-    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
-      <h2 className="text-lg font-semibold text-gray-900">Automated Schedules</h2>
-      <button
-        onClick={() => setShowForm(!showForm)}
-        className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors flex items-center justify-center gap-2 ${
-          showForm
-            ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-            : 'bg-gray-900 text-white hover:bg-gray-800'
-        }`}
-      >
-        {showForm ? 'Cancel' : <><PlusIcon /><span className="hidden sm:inline">New Schedule</span><span className="sm:hidden">New</span></>}
-      </button>
-    </div>
-  </div>
-);
-
-const PlusIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
-  </svg>
-);
-
-interface ScheduleFormProps {
-  formData: ScheduleFormData;
-  updateFormField: <K extends keyof ScheduleFormData>(field: K, value: ScheduleFormData[K]) => void;
-  onSubmit: () => void;
-}
-
-const ScheduleForm = ({
-  formData, updateFormField, onSubmit 
-}: ScheduleFormProps) => (
-  <div className="p-4 sm:p-6 border-b border-gray-200 bg-gray-50">
-    <h3 className="font-medium text-gray-900 mb-4">Create New Schedule</h3>
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      <FormField label="Schedule Name">
-        <input
-          type="text"
-          value={formData.name}
-          onChange={(e) => updateFormField('name', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-        />
-      </FormField>
-      <FormField label="Frequency">
-        <select
-          value={formData.frequency}
-          onChange={(e) => {
-            const value = e.target.value;
-            if (value === 'daily' || value === 'weekly' || value === 'monthly') {
-              updateFormField('frequency', value);
-            }
-          }}
-          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-        >
-          <option value="daily">Daily</option>
-          <option value="weekly">Weekly</option>
-          <option value="monthly">Monthly</option>
-        </select>
-      </FormField>
-      <FormField label="Time">
-        <input
-          type="time"
-          value={formData.time}
-          onChange={(e) => updateFormField('time', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-        />
-      </FormField>
-      <FormField label="Timezone">
-        <select
-          value={formData.timezone}
-          onChange={(e) => updateFormField('timezone', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-        >
-          <option value="UTC">UTC</option>
-          <option value="America/New_York">Eastern Time</option>
-          <option value="America/Chicago">Central Time</option>
-          <option value="America/Denver">Mountain Time</option>
-          <option value="America/Los_Angeles">Pacific Time</option>
-          <option value="Europe/London">London</option>
-          <option value="Europe/Paris">Paris</option>
-        </select>
-      </FormField>
-      {formData.frequency === 'weekly' && (
-        <FormField label="Day of Week">
-          <select
-            value={formData.day_of_week}
-            onChange={(e) => updateFormField('day_of_week', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-          >
-            <option value="MON">Monday</option>
-            <option value="TUE">Tuesday</option>
-            <option value="WED">Wednesday</option>
-            <option value="THU">Thursday</option>
-            <option value="FRI">Friday</option>
-            <option value="SAT">Saturday</option>
-            <option value="SUN">Sunday</option>
-          </select>
-        </FormField>
-      )}
-      {formData.frequency === 'monthly' && (
-        <FormField label="Day of Month">
-          <input
-            type="number"
-            min="1"
-            max="31"
-            value={formData.day_of_month}
-            onChange={(e) => updateFormField('day_of_month', e.target.value)}
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-          />
-        </FormField>
-      )}
-    </div>
-    <button
-      onClick={onSubmit}
-      className="mt-4 px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
-    >
-      Create Schedule
-    </button>
-  </div>
-);
-
-const FormField = ({
-  label, children 
-}: {
-  label: string;
-  children: React.ReactNode 
-}) => (
-  <div>
-    <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
-    {children}
-  </div>
-);
-
-interface ScheduleListProps {
-  schedules: Schedule[];
-  onDelete: (name: string) => void;
-}
-
-const ScheduleList = ({
-  schedules, onDelete 
-}: ScheduleListProps) => (
-  <div className="p-4 sm:p-6">
-    {schedules.length === 0 ? (
-      <EmptyState />
-    ) : (
-      <div className="space-y-3">
-        {schedules.map((schedule) => (
-          <ScheduleItem key={schedule.name} schedule={schedule} onDelete={onDelete} />
-        ))}
-      </div>
-    )}
-  </div>
-);
-
-const EmptyState = () => (
-  <div className="text-center py-12 text-gray-400">
-    <ClockIcon />
-    <p className="text-sm">No schedules configured</p>
-    <p className="text-xs mt-1">Create a schedule to run analysis automatically</p>
-  </div>
-);
-
-const ClockIcon = () => (
-  <svg className="w-12 h-12 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-  </svg>
-);
-
-interface ScheduleItemProps {
-  schedule: Schedule;
-  onDelete: (name: string) => void;
-}
-
-const ScheduleItem = ({
-  schedule, onDelete 
-}: ScheduleItemProps) => (
-  <div className="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
-    <div className="flex-1">
-      <div className="flex items-center gap-3">
-        <h3 className="font-medium text-gray-900 text-sm">{schedule.name}</h3>
-        <span
-          className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-            schedule.state === 'ENABLED'
-              ? 'bg-emerald-100 text-emerald-700'
-              : 'bg-gray-100 text-gray-600'
-          }`}
-        >
-          {schedule.state}
-        </span>
-      </div>
-      <p className="text-sm text-gray-500 mt-1">{schedule.schedule}</p>
-      <p className="text-xs text-gray-400 mt-0.5">{schedule.timezone}</p>
-    </div>
-    <button
-      onClick={() => onDelete(schedule.name)}
-      className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-    >
-      <TrashIcon />
-    </button>
-  </div>
-);
-
-const TrashIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-  </svg>
-);

--- a/web/src/components/Schedule/ScheduleManagerComponents.tsx
+++ b/web/src/components/Schedule/ScheduleManagerComponents.tsx
@@ -1,0 +1,324 @@
+import type {
+  Keyword, Schedule, ScheduleFormData 
+} from '../../types';
+
+export type KeywordScope = 'all' | 'selected';
+
+interface ScheduleHeaderProps {
+  showForm: boolean;
+  setShowForm: (value: boolean) => void;
+}
+
+export const ScheduleHeader = ({
+  showForm, setShowForm 
+}: ScheduleHeaderProps) => (
+  <div className="p-4 sm:p-6 border-b border-gray-200">
+    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
+      <h2 className="text-lg font-semibold text-gray-900">Automated Schedules</h2>
+      <button
+        onClick={() => setShowForm(!showForm)}
+        className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors flex items-center justify-center gap-2 ${
+          showForm
+            ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            : 'bg-gray-900 text-white hover:bg-gray-800'
+        }`}
+      >
+        {showForm ? 'Cancel' : <><PlusIcon /><span className="hidden sm:inline">New Schedule</span><span className="sm:hidden">New</span></>}
+      </button>
+    </div>
+  </div>
+);
+
+const PlusIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
+  </svg>
+);
+
+interface KeywordScopeFieldProps {
+  availableKeywords: Keyword[];
+  keywordScope: KeywordScope;
+  selectedKeywords: string[];
+  onScopeChange: (scope: KeywordScope) => void;
+  onToggleKeyword: (keyword: string) => void;
+}
+
+const KeywordScopeField = ({
+  availableKeywords, keywordScope, selectedKeywords, onScopeChange, onToggleKeyword 
+}: KeywordScopeFieldProps) => (
+  <div className="sm:col-span-2">
+    <FormField label="Keywords">
+      <div className="flex flex-col gap-2">
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="radio"
+            name="keyword-scope"
+            checked={keywordScope === 'all'}
+            onChange={() => onScopeChange('all')}
+          />
+          All keywords (uses the active keyword list at run time)
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="radio"
+            name="keyword-scope"
+            checked={keywordScope === 'selected'}
+            onChange={() => onScopeChange('selected')}
+          />
+          Specific keywords
+        </label>
+      </div>
+    </FormField>
+    {keywordScope === 'selected' && (
+      <KeywordPicker
+        availableKeywords={availableKeywords}
+        selectedKeywords={selectedKeywords}
+        onToggleKeyword={onToggleKeyword}
+      />
+    )}
+  </div>
+);
+
+interface KeywordPickerProps {
+  availableKeywords: Keyword[];
+  selectedKeywords: string[];
+  onToggleKeyword: (keyword: string) => void;
+}
+
+const KeywordPicker = ({
+  availableKeywords, selectedKeywords, onToggleKeyword 
+}: KeywordPickerProps) => {
+  if (availableKeywords.length === 0) {
+    return (
+      <p className="mt-2 text-xs text-amber-600">
+        No keywords available yet. Add keywords in Settings first.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="max-h-40 overflow-y-auto border border-gray-200 rounded-lg bg-white p-3 grid grid-cols-1 sm:grid-cols-2 gap-1">
+        {availableKeywords.map((keyword) => (
+          <label key={keyword.id} className="flex items-center gap-2 text-sm text-gray-700 py-0.5">
+            <input
+              type="checkbox"
+              checked={selectedKeywords.includes(keyword.keyword)}
+              onChange={() => onToggleKeyword(keyword.keyword)}
+            />
+            <span className="truncate">{keyword.keyword}</span>
+          </label>
+        ))}
+      </div>
+      <p className="mt-1 text-xs text-gray-500">{selectedKeywords.length} keyword(s) selected</p>
+    </div>
+  );
+};
+
+interface ScheduleFormProps {
+  formData: ScheduleFormData;
+  updateFormField: <K extends keyof ScheduleFormData>(field: K, value: ScheduleFormData[K]) => void;
+  onSubmit: () => void;
+  availableKeywords: Keyword[];
+  keywordScope: KeywordScope;
+  onScopeChange: (scope: KeywordScope) => void;
+  onToggleKeyword: (keyword: string) => void;
+}
+
+export const ScheduleForm = ({
+  formData, updateFormField, onSubmit, availableKeywords, keywordScope, onScopeChange, onToggleKeyword 
+}: ScheduleFormProps) => (
+  <div className="p-4 sm:p-6 border-b border-gray-200 bg-gray-50">
+    <h3 className="font-medium text-gray-900 mb-4">Create New Schedule</h3>
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <FormField label="Schedule Name">
+        <input
+          type="text"
+          value={formData.name}
+          onChange={(e) => updateFormField('name', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        />
+      </FormField>
+      <FormField label="Frequency">
+        <select
+          value={formData.frequency}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === 'daily' || value === 'weekly' || value === 'monthly') {
+              updateFormField('frequency', value);
+            }
+          }}
+          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        >
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+      </FormField>
+      <FormField label="Time">
+        <input
+          type="time"
+          value={formData.time}
+          onChange={(e) => updateFormField('time', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        />
+      </FormField>
+      <FormField label="Timezone">
+        <select
+          value={formData.timezone}
+          onChange={(e) => updateFormField('timezone', e.target.value)}
+          className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        >
+          <option value="UTC">UTC</option>
+          <option value="America/New_York">Eastern Time</option>
+          <option value="America/Chicago">Central Time</option>
+          <option value="America/Denver">Mountain Time</option>
+          <option value="America/Los_Angeles">Pacific Time</option>
+          <option value="Europe/London">London</option>
+          <option value="Europe/Paris">Paris</option>
+        </select>
+      </FormField>
+      {formData.frequency === 'weekly' && (
+        <FormField label="Day of Week">
+          <select
+            value={formData.day_of_week}
+            onChange={(e) => updateFormField('day_of_week', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+          >
+            <option value="MON">Monday</option>
+            <option value="TUE">Tuesday</option>
+            <option value="WED">Wednesday</option>
+            <option value="THU">Thursday</option>
+            <option value="FRI">Friday</option>
+            <option value="SAT">Saturday</option>
+            <option value="SUN">Sunday</option>
+          </select>
+        </FormField>
+      )}
+      {formData.frequency === 'monthly' && (
+        <FormField label="Day of Month">
+          <input
+            type="number"
+            min="1"
+            max="31"
+            value={formData.day_of_month}
+            onChange={(e) => updateFormField('day_of_month', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+          />
+        </FormField>
+      )}
+      <KeywordScopeField
+        availableKeywords={availableKeywords}
+        keywordScope={keywordScope}
+        selectedKeywords={formData.keywords}
+        onScopeChange={onScopeChange}
+        onToggleKeyword={onToggleKeyword}
+      />
+    </div>
+    <button
+      onClick={onSubmit}
+      className="mt-4 px-4 py-2 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
+    >
+      Create Schedule
+    </button>
+  </div>
+);
+
+const FormField = ({
+  label, children 
+}: {
+  label: string;
+  children: React.ReactNode 
+}) => (
+  <div>
+    <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+    {children}
+  </div>
+);
+
+interface ScheduleListProps {
+  schedules: Schedule[];
+  onDelete: (name: string) => void;
+}
+
+export const ScheduleList = ({
+  schedules, onDelete 
+}: ScheduleListProps) => (
+  <div className="p-4 sm:p-6">
+    {schedules.length === 0 ? (
+      <EmptyState />
+    ) : (
+      <div className="space-y-3">
+        {schedules.map((schedule) => (
+          <ScheduleItem key={schedule.name} schedule={schedule} onDelete={onDelete} />
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+const EmptyState = () => (
+  <div className="text-center py-12 text-gray-400">
+    <ClockIcon />
+    <p className="text-sm">No schedules configured</p>
+    <p className="text-xs mt-1">Create a schedule to run analysis automatically</p>
+  </div>
+);
+
+const ClockIcon = () => (
+  <svg className="w-12 h-12 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
+
+interface ScheduleItemProps {
+  schedule: Schedule;
+  onDelete: (name: string) => void;
+}
+
+const ScheduleScope = ({ keywords }: { keywords?: string[] }) => {
+  if (!keywords || keywords.length === 0) {
+    return <p className="text-xs text-gray-500 mt-1">Runs all active keywords</p>;
+  }
+  return (
+    <p className="text-xs text-gray-500 mt-1 truncate" title={keywords.join(', ')}>
+      Runs {keywords.length} keyword(s): {keywords.join(', ')}
+    </p>
+  );
+};
+
+const ScheduleItem = ({
+  schedule, onDelete 
+}: ScheduleItemProps) => (
+  <div className="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center gap-3">
+        <h3 className="font-medium text-gray-900 text-sm">{schedule.name}</h3>
+        <span
+          className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+            schedule.state === 'ENABLED'
+              ? 'bg-emerald-100 text-emerald-700'
+              : 'bg-gray-100 text-gray-600'
+          }`}
+        >
+          {schedule.state}
+        </span>
+      </div>
+      <p className="text-sm text-gray-500 mt-1">{schedule.schedule}</p>
+      <ScheduleScope keywords={schedule.keywords} />
+      <p className="text-xs text-gray-400 mt-0.5">{schedule.timezone}</p>
+    </div>
+    <button
+      onClick={() => onDelete(schedule.name)}
+      className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+    >
+      <TrashIcon />
+    </button>
+  </div>
+);
+
+const TrashIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+  </svg>
+);

--- a/web/src/types/domain/baseTypes.ts
+++ b/web/src/types/domain/baseTypes.ts
@@ -83,6 +83,8 @@ export interface Schedule {
   state: ScheduleState;
   schedule: string;
   timezone: string;
+  /** Keyword subset this schedule runs. Empty/absent = all active keywords. */
+  keywords?: string[];
 }
 
 export type ScheduleFrequency = 'daily' | 'weekly' | 'monthly';
@@ -95,4 +97,6 @@ export interface ScheduleFormData {
   day_of_week: string;
   day_of_month: string;
   enabled: boolean;
+  /** Keyword subset to run. Empty = all active keywords at execution time. */
+  keywords: string[];
 }


### PR DESCRIPTION
## Description

Adds keyword-linked schedules and fixes the scheduled-run prompt-input bug that blocks them.

### Keyword-linked schedules (#91)

Users can now create as many schedules as they want, each scoped to a keyword subset — e.g. all keywords every 2 weeks plus 3 priority keywords daily.

- `POST /api/schedules` accepts an optional `keywords: string[]`. Validation mirrors the pipeline caps enforced by the trigger APIs (max 100 keywords, 500 chars each, strings only; whitespace trimmed, empties dropped). Validated from the raw body because the `@validate` decorator's `list` coercion would silently turn a string into a list of characters.
- Keyword subsets are baked into the EventBridge target input as `{"keywords": [...]}` — `parse-keywords` already accepts direct keyword arrays, so the pipeline needs no changes for subsets. Without keywords, the input stays `{"source": "dynamodb"}` (all active keywords, resolved at run time so new keywords are picked up).
- `GET /api/schedules` now parses each schedule's target input and returns its `keywords` scope; the schedule description reflects the scope.
- Schedule UI: "Keywords" scope picker in the create form (All keywords / Specific keywords with checkbox list), per-schedule scope display in the list, and the schedule list now loads on mount (previously it was only populated after creating a schedule, so it always appeared empty on a fresh visit).
- `Schedule`/`ScheduleFormData` types extended; the duplicate `Schedule` interface in `web/src/api/executions.ts` was unified with the domain type, and `createSchedule` now matches the actual POST contract.
- `ScheduleManager` presentational components were split into `ScheduleManagerComponents.tsx` (mirrors the existing `KeywordsManagerComponents.tsx` pattern) to stay under the 400-line lint limit.

### Bug fix: scheduled runs fail at ProcessKeywords (#90)

The `ProcessKeywords` Map state selected `'query_prompts.$': '$$.Execution.Input.query_prompts'`. Scheduled inputs (`{"source":"dynamodb"}` — and the new `{"keywords":[...]}`) never contain that key, so every scheduled execution raised `States.Runtime`. Fixed at the root:

- `parse-keywords` now always emits `query_prompts`: passed through from the execution input when present (trigger APIs are byte-identical to before), otherwise loaded from the QueryPrompts table (`EnabledIndex`, limit 10, same query as `trigger-analysis`). Failures degrade to `[]` with a warning instead of failing the run.
- The state machine selects `'query_prompts.$': '$.query_prompts'` from the ParseKeywords output.
- ParseKeywords Lambda receives `DYNAMODB_TABLE_QUERY_PROMPTS`/`QUERY_PROMPTS_TABLE` env vars and `grantReadData` on the table.

This also means prompts for scheduled runs resolve at execution time instead of being frozen into the schedule at creation.

### Code ownership cleanups (files already touched)

- `lib/citation-analysis-stack.ts`: replaced two generic `Error` throws with a `LayerNotBuiltError` class; removed the unused `consolidatedLogicalPrefixes` collection (its contents were never read).
- `lib/citation-analysis-stack.spec.ts`: removed `let` mutations, an eslint-disable directive, and unsafe `any` member access via a typed `resolvePath` helper; assertions updated for the new itemSelector plus a regression test that the definition no longer references `$$.Execution.Input.query_prompts`.

Fixes #90
Fixes #91

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- New `lambda/api/test_manage_schedule.py` (16 tests: target input building, keyword validation caps/types/trimming, cron building incl. day-of-month bounds, list keyword scope incl. malformed input, delete/conflict paths)
- New `lambda/parse-keywords/test_handler.py` (10 tests: keyword input shapes, prompt pass-through vs DynamoDB resolution, failure degradation)
- pytest (`lambda/api lambda/shared lambda/parse-keywords lambda/search lambda/deduplication`): 449 passed (was 423 on `main`)
- Root vitest (CDK stack assertions incl. new itemSelector + env var tests): 7 passed
- `web`: `npm test` → 924 tests passing (was 915), including new ScheduleManager scope-picker/fetch-on-mount specs
- `tsc` (root + web), `vite build`, `eslint` on all touched files, `ruff check` on touched Lambda files → all clean

Note: the test for `@validate`'s list coercion caught a real edge — a string `keywords` value would have been coerced to a character list; the handler now validates from the raw body.

Not verified: not deployed to an AWS account. The `States.Runtime` failure of scheduled runs is a code-level analysis (scheduled input demonstrably lacks the referenced key); reviewer validation of a live scheduled execution is welcome.

**Test Configuration**:
* Node.js Version: local dev (vitest 4 / vite 8 / CDK lib 2.260)
* Python Version: 3.12 target (pytest 8)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
