### PR TITLE
feat(web): show app version on Settings page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citation-analysis-system",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "citation-analysis-system",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT-0",
       "dependencies": {
         "aws-cdk-lib": "^2.260.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citation-analysis-system",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Serverless citation analysis system using AWS CDK",
   "main": "index.js",
   "scripts": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citation-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "citation-dashboard",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.15.2",
         "aws-amplify": "^6.16.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citation-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/Settings/SettingsView.spec.tsx
+++ b/web/src/components/Settings/SettingsView.spec.tsx
@@ -100,6 +100,14 @@ describe('SettingsView', () => {
     });
   });
 
+  describe('app version', () => {
+    it('displays the deployed application version', () => {
+      render(<SettingsView {...buildProps()} />);
+
+      expect(screen.getByText(/^Version \d+\.\d+\.\d+$/)).toBeInTheDocument();
+    });
+  });
+
   describe('providers tab', () => {
     it('switches to providers tab when clicked', async () => {
       mockUseProviderConfig.mockReturnValue({

--- a/web/src/components/Settings/SettingsView.tsx
+++ b/web/src/components/Settings/SettingsView.tsx
@@ -171,6 +171,10 @@ export const SettingsView = ({
           )}
         </div>
       </div>
+
+      <p className="text-xs text-gray-400 dark:text-gray-500 text-center">
+        Version {import.meta.env.VITE_APP_VERSION ?? 'dev'}
+      </p>
     </div>
   );
 };

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_IDENTITY_POOL_ID: string
+  /** Injected at build time from package.json via vite `define`. */
+  readonly VITE_APP_VERSION: string
 }
 
 interface ImportMeta {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,15 @@
 /// <reference types="vitest" />
+import { readFileSync } from 'node:fs';
 import {
   defineConfig, loadEnv
 } from 'vite';
 import react from '@vitejs/plugin-react';
+
+// Single source of truth for the app version shown in the UI (Settings page).
+// Bump `version` in package.json when deploying or merging feature sets.
+const packageJson: { version: string } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
+);
 
 /**
  * Vendor chunk assignment for Rollup/Rolldown `manualChunks`.
@@ -44,6 +51,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    define: {'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),},
     server: enableDevProxy
       ? {
         proxy: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,9 +7,15 @@ import react from '@vitejs/plugin-react';
 
 // Single source of truth for the app version shown in the UI (Settings page).
 // Bump `version` in package.json when deploying or merging feature sets.
-const packageJson: { version: string } = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
-);
+function readAppVersion(): string {
+  const parsed: unknown = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'));
+  if (typeof parsed === 'object' && parsed !== null && 'version' in parsed && typeof parsed.version === 'string') {
+    return parsed.version;
+  }
+  return '0.0.0';
+}
+
+const appVersion = readAppVersion();
 
 /**
  * Vendor chunk assignment for Rollup/Rolldown `manualChunks`.
@@ -51,7 +57,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
-    define: {'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),},
+    define: {'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),},
     server: enableDevProxy
       ? {
         proxy: {


### PR DESCRIPTION
## Description

Shows the deployed app version on the Settings page so anyone can confirm which build they are looking at after a deployment (useful behind CloudFront caching).

- `web/package.json` `version` is the source of truth; convention is to bump it when merging feature sets or deploying
- Injected at build time via vite `define` as `VITE_APP_VERSION` (typed in `vite-env.d.ts`)
- Rendered as "Version x.y.z" at the bottom of the Settings page
- Versions bumped `1.0.0` → `1.1.0` for the current feature set (onboarding checklist #89, keyword-linked schedules #92)

Fixes #95

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- New SettingsView spec asserting the semver version renders
- `npx vitest run SettingsView.spec.tsx` → 7 tests passing
- `tsc --noEmit` and eslint on touched files → clean
- Verified in a deployed environment (version visible on Settings)

**Test Configuration**:
* Node.js Version: local dev (vitest 4 / vite 8)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
