### PR TITLE
fix(web): Personas header text overflowing under action button

### DIFF
--- a/web/src/components/Settings/QueryPromptsManager.tsx
+++ b/web/src/components/Settings/QueryPromptsManager.tsx
@@ -269,8 +269,10 @@ export function QueryPromptsManager() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
+      {/* items-start + gap keep the description in its own column; without
+          min-w-0 / shrink-0 the text ran underneath the button. */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
           <h3 className="text-lg font-semibold text-gray-900">Personas</h3>
           <p className="text-sm text-gray-500">
             Define user personas to see how AI providers change their responses based on who is asking.
@@ -281,6 +283,7 @@ export function QueryPromptsManager() {
           <Button
             onClick={() => setShowCreate(true)}
             leadingIcon={<PlusIcon className="w-4 h-4" />}
+            className="shrink-0 whitespace-nowrap"
           >
             New Persona
           </Button>


### PR DESCRIPTION
## Description

Fixes the Settings → Personas header layout where the description text overflowed underneath the "New Persona" button and the button wrapped onto two lines.

Root cause: the header row was `flex items-center justify-between` with no `gap`, no `min-w-0` on the text column, and no `shrink-0` on the button, so both children fought for the same space. The fix constrains each column:

- `items-start justify-between gap-4` on the row
- `flex-1 min-w-0` on the title/description column (text wraps in its own column)
- `shrink-0 whitespace-nowrap` on the button (keeps intrinsic size, no wrap)

One-file CSS-class-only change; no behavior affected.

Fixes #99

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- eslint + `tsc --noEmit` clean
- Visually verified in a deployed environment at desktop and narrow viewport widths (layout is not assertable in jsdom)

**Test Configuration**:
* Node.js Version: local dev (vite 8)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
