### PR TITLE
feat(web): About modal Version tab + content freshness (stacked on #96)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citation-analysis-system",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "citation-analysis-system",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT-0",
       "dependencies": {
         "aws-cdk-lib": "^2.260.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citation-analysis-system",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Serverless citation analysis system using AWS CDK",
   "main": "index.js",
   "scripts": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citation-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "citation-dashboard",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.15.2",
         "aws-amplify": "^6.16.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citation-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/About/AboutModal.spec.tsx
+++ b/web/src/components/About/AboutModal.spec.tsx
@@ -12,6 +12,8 @@ vi.mock('./ArchitectureTab', () => ({ArchitectureTab: () => <div>Architecture Co
 
 vi.mock('./LicensesTab', () => ({LicensesTab: () => <div>Licenses Content</div>}));
 
+vi.mock('./VersionTab', () => ({VersionTab: () => <div>Version Content</div>}));
+
 describe('AboutModal', () => {
   const mockOnClose = vi.fn();
 
@@ -53,5 +55,11 @@ describe('AboutModal', () => {
     render(<AboutModal isOpen={true} onClose={mockOnClose} />);
     fireEvent.click(screen.getByText('Open Source'));
     expect(screen.getByText('Licenses Content')).toBeInTheDocument();
+  });
+
+  it('shows Version tab content when Version tab clicked', () => {
+    render(<AboutModal isOpen={true} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByText('Version'));
+    expect(screen.getByText('Version Content')).toBeInTheDocument();
   });
 });

--- a/web/src/components/About/AboutModal.tsx
+++ b/web/src/components/About/AboutModal.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react';
 import { AboutTab } from './AboutTab';
 import { ArchitectureTab } from './ArchitectureTab';
 import { LicensesTab } from './LicensesTab';
+import { VersionTab } from './VersionTab';
 
 interface AboutModalProps {
   readonly isOpen: boolean;
   readonly onClose: () => void;
 }
 
-type TabType = 'about' | 'architecture' | 'licenses';
+type TabType = 'about' | 'architecture' | 'licenses' | 'version';
 
 interface TabConfig {
   readonly id: TabType;
@@ -27,6 +28,10 @@ const TABS: readonly TabConfig[] = [
   {
     id: 'licenses',
     label: 'Open Source' 
+  },
+  {
+    id: 'version',
+    label: 'Version' 
   },
 ];
 
@@ -75,6 +80,7 @@ export const AboutModal = ({
           {activeTab === 'about' && <AboutTab />}
           {activeTab === 'architecture' && <ArchitectureTab />}
           {activeTab === 'licenses' && <LicensesTab />}
+          {activeTab === 'version' && <VersionTab />}
         </div>
       </div>
     </div>

--- a/web/src/components/About/ArchitectureTab.tsx
+++ b/web/src/components/About/ArchitectureTab.tsx
@@ -21,6 +21,8 @@ const AI_PROVIDERS = [
   },
 ];
 
+const SEARCH_PROVIDERS = ['Brave Search', 'Tavily', 'Exa', 'SerpAPI', 'Firecrawl'];
+
 const CAPABILITIES = [
   {
     icon: '🔍',
@@ -51,6 +53,21 @@ const CAPABILITIES = [
     icon: '💡',
     title: 'Recommendations',
     desc: 'Actionable insights to improve ranking' 
+  },
+  {
+    icon: '👥',
+    title: 'Personas',
+    desc: 'See how responses change based on who is asking' 
+  },
+  {
+    icon: '⏰',
+    title: 'Scheduled Runs',
+    desc: 'EventBridge schedules, optionally scoped to keyword subsets' 
+  },
+  {
+    icon: '📄',
+    title: 'Reports',
+    desc: 'Executive summaries and competitor gap reports' 
   },
 ];
 
@@ -96,6 +113,12 @@ export function ArchitectureTab() {
                 <div className="text-xs text-gray-500">Workflow Orchestration</div>
               </div>
             </div>
+            <div className="bg-white border border-gray-300 rounded-lg px-4 py-3 text-sm shadow-sm">
+              <div className="text-center">
+                <div className="font-semibold text-gray-700">EventBridge Scheduler</div>
+                <div className="text-xs text-gray-500">Automated Runs</div>
+              </div>
+            </div>
           </div>
           <div className="flex items-center gap-2 mb-2">
             <div className="w-16 h-px bg-gray-300"></div>
@@ -104,7 +127,7 @@ export function ArchitectureTab() {
           </div>
 
           <div className="flex flex-wrap justify-center gap-3 mb-4">
-            {['Search', 'Crawl', 'Dedupe', 'Extract'].map((fn) => (
+            {['Parse', 'Search', 'Dedupe', 'Crawl', 'Summarize'].map((fn) => (
               <div key={fn} className="bg-amber-50 border border-amber-200 rounded px-3 py-2 text-xs font-medium text-amber-800">
                 λ {fn}
               </div>
@@ -120,6 +143,10 @@ export function ArchitectureTab() {
             <div className="bg-purple-50 border border-purple-200 rounded-lg px-4 py-2 text-sm">
               <div className="font-semibold text-purple-800">Bedrock</div>
               <div className="text-xs text-purple-600">Brand Extraction</div>
+            </div>
+            <div className="bg-purple-50 border border-purple-200 rounded-lg px-4 py-2 text-sm">
+              <div className="font-semibold text-purple-800">Bedrock AgentCore</div>
+              <div className="text-xs text-purple-600">Browser Crawling</div>
             </div>
             <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-2 text-sm">
               <div className="font-semibold text-green-800">S3</div>
@@ -139,6 +166,16 @@ export function ArchitectureTab() {
             </div>
           ))}
         </div>
+        <div className="flex flex-wrap gap-2 mt-3">
+          {SEARCH_PROVIDERS.map((provider) => (
+            <span key={provider} className="text-xs bg-gray-50 text-gray-700 border border-gray-200 px-2 py-1 rounded">
+              {provider}
+            </span>
+          ))}
+        </div>
+        <p className="text-xs text-gray-500 mt-2">
+          Optional web search providers complement the LLM providers during analysis runs.
+        </p>
       </div>
 
       <div>

--- a/web/src/components/About/LicensesTab.tsx
+++ b/web/src/components/About/LicensesTab.tsx
@@ -13,9 +13,27 @@ const FRONTEND_DEPS = [
   },
   {
     name: 'Vite',
-    version: '5.x',
+    version: '8.x',
     license: 'MIT',
     desc: 'Build tool' 
+  },
+  {
+    name: 'React Router',
+    version: '7.x',
+    license: 'MIT',
+    desc: 'Routing' 
+  },
+  {
+    name: 'react-markdown',
+    version: '10.x',
+    license: 'MIT',
+    desc: 'Markdown rendering' 
+  },
+  {
+    name: 'docx',
+    version: '9.x',
+    license: 'MIT',
+    desc: 'Word export' 
   },
   {
     name: 'Tailwind CSS',
@@ -84,7 +102,7 @@ const BACKEND_DEPS = [
 
 const AWS_SERVICES = [
   'Lambda', 'DynamoDB', 'Step Functions', 'API Gateway', 'S3', 
-  'CloudFront', 'Cognito', 'Bedrock', 'Secrets Manager', 'EventBridge', 'WAF'
+  'CloudFront', 'Cognito', 'Bedrock', 'Bedrock AgentCore', 'Secrets Manager', 'EventBridge Scheduler', 'WAF'
 ];
 
 const USE_CASES = [

--- a/web/src/components/About/VersionTab.tsx
+++ b/web/src/components/About/VersionTab.tsx
@@ -1,0 +1,57 @@
+const GITHUB_REPO_URL = 'https://github.com/aws-samples/sample-llm-search-citation-analysis-with-amazon-bedrock';
+
+const GitHubIcon = () => (
+  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+  </svg>
+);
+
+export function VersionTab() {
+  const appVersion = import.meta.env.VITE_APP_VERSION ?? 'dev';
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-semibold text-gray-900 mb-3">Application Version</h3>
+        <div className="bg-gray-50 rounded-lg p-4 border border-gray-200 flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-600">Currently deployed build</p>
+            <p className="text-2xl font-semibold text-gray-900 mt-1">v{appVersion}</p>
+          </div>
+        </div>
+        <p className="text-xs text-gray-500 mt-2">
+          The version follows the <code className="bg-gray-100 px-1 rounded">web/package.json</code> version
+          and is bumped whenever a feature set is merged or deployed.
+        </p>
+      </div>
+
+      <div className="border-t border-gray-200 pt-6">
+        <h3 className="text-base font-semibold text-gray-900 mb-3">Source Code</h3>
+        <p className="text-sm text-gray-600 mb-3">
+          This project is open source and maintained in the AWS Samples organization on GitHub.
+          Releases, issues, and pull requests all live there.
+        </p>
+        <div className="flex flex-col gap-2">
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            <GitHubIcon />
+            GitHub repository
+          </a>
+          <a
+            href={`${GITHUB_REPO_URL}/issues`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            <GitHubIcon />
+            Report an issue or request a feature
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Settings/SettingsView.spec.tsx
+++ b/web/src/components/Settings/SettingsView.spec.tsx
@@ -100,6 +100,14 @@ describe('SettingsView', () => {
     });
   });
 
+  describe('app version', () => {
+    it('displays the deployed application version', () => {
+      render(<SettingsView {...buildProps()} />);
+
+      expect(screen.getByText(/^Version \d+\.\d+\.\d+$/)).toBeInTheDocument();
+    });
+  });
+
   describe('providers tab', () => {
     it('switches to providers tab when clicked', async () => {
       mockUseProviderConfig.mockReturnValue({

--- a/web/src/components/Settings/SettingsView.tsx
+++ b/web/src/components/Settings/SettingsView.tsx
@@ -171,6 +171,10 @@ export const SettingsView = ({
           )}
         </div>
       </div>
+
+      <p className="text-xs text-gray-400 dark:text-gray-500 text-center">
+        Version {import.meta.env.VITE_APP_VERSION ?? 'dev'}
+      </p>
     </div>
   );
 };

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_IDENTITY_POOL_ID: string
+  /** Injected at build time from package.json via vite `define`. */
+  readonly VITE_APP_VERSION: string
 }
 
 interface ImportMeta {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,15 @@
 /// <reference types="vitest" />
+import { readFileSync } from 'node:fs';
 import {
   defineConfig, loadEnv
 } from 'vite';
 import react from '@vitejs/plugin-react';
+
+// Single source of truth for the app version shown in the UI (Settings page).
+// Bump `version` in package.json when deploying or merging feature sets.
+const packageJson: { version: string } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
+);
 
 /**
  * Vendor chunk assignment for Rollup/Rolldown `manualChunks`.
@@ -44,6 +51,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    define: {'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),},
     server: enableDevProxy
       ? {
         proxy: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,9 +7,15 @@ import react from '@vitejs/plugin-react';
 
 // Single source of truth for the app version shown in the UI (Settings page).
 // Bump `version` in package.json when deploying or merging feature sets.
-const packageJson: { version: string } = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
-);
+function readAppVersion(): string {
+  const parsed: unknown = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'));
+  if (typeof parsed === 'object' && parsed !== null && 'version' in parsed && typeof parsed.version === 'string') {
+    return parsed.version;
+  }
+  return '0.0.0';
+}
+
+const appVersion = readAppVersion();
 
 /**
  * Vendor chunk assignment for Rollup/Rolldown `manualChunks`.
@@ -51,7 +57,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
-    define: {'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),},
+    define: {'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),},
     server: enableDevProxy
       ? {
         proxy: {


### PR DESCRIPTION
## Description

Adds a **Version** tab to the About modal and brings the Architecture / Open Source tabs back in line with the actual system.

- **Version tab**: deployed app version (from `VITE_APP_VERSION`, injected in #96) plus links to the GitHub repository and issue tracker — the running build is now identifiable from the "i" button.
- **Architecture tab**: EventBridge Scheduler added next to Step Functions (scheduled runs), Bedrock AgentCore (browser crawling) added to the service row, Lambda boxes now match the real pipeline (Parse / Search / Dedupe / Crawl / Summarize), the five optional web search providers (Brave Search, Tavily, Exa, SerpAPI, Firecrawl) are listed alongside the four LLM providers, and Personas / Scheduled Runs / Reports were added to the capabilities grid.
- **Open Source tab**: Vite corrected 5.x → 8.x; React Router 7.x, react-markdown 10.x, and docx 9.x added; AWS services list now includes Bedrock AgentCore and names EventBridge Scheduler explicitly.

**Stacked on #96** (`feat/settings-app-version`) because the `VITE_APP_VERSION` build injection and its type declaration live there — merge #96 first; this PR's base is set accordingly.

Fixes #101

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- AboutModal spec extended with the Version tab (7 tests passing)
- eslint + `tsc --noEmit` clean
- Verified in a deployed environment (Version tab shows the deployed build and working GitHub links)

**Test Configuration**:
* Node.js Version: local dev (vitest 4 / vite 8)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
